### PR TITLE
Cli parser

### DIFF
--- a/sudo/Cargo.toml
+++ b/sudo/Cargo.toml
@@ -6,4 +6,8 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 sudo-common = { path = "../lib/sudo-common" }
-clap = { version = "4.0.32", features = ["derive"] }
+clap = { version = "4.0.32", features = ["derive", "cargo"] }
+
+# [dev-dependencies]
+assert_cmd = "2.0.8"
+predicates = "2.1.5"

--- a/sudo/Cargo.toml
+++ b/sudo/Cargo.toml
@@ -6,3 +6,4 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 sudo-common = { path = "../lib/sudo-common" }
+clap = { version = "4.0.32", features = ["derive"] }

--- a/sudo/src/cli_args.rs
+++ b/sudo/src/cli_args.rs
@@ -1,50 +1,79 @@
-use std::{path::PathBuf, error::Error};
+use std::path::PathBuf;
 
 use clap:: {
     Parser,
+    ArgAction
 };
 
-// warning: derive helper attribute is used before it is introduced
-#[command(name = "sudo-rs")]
-#[command(about = "sudo - execute a command as another user", long_about = None)]
-#[command(version)] // Read from `Cargo.toml`
-
+#[clap(
+    name = "sudo-rs",
+    about = "sudo - execute a command as another user",
+    version,
+    // disable_version_flag = true,
+    // disable_help_flag = true,
+    override_usage = "usage: sudo -h | -K | -k | -V
+    usage: sudo -v [-AknS] [-g group] [-h host] [-p prompt] [-u user]
+    usage: sudo -l [-AknS] [-g group] [-h host] [-p prompt] [-U user] [-u user] [command]
+    usage: sudo [-AbEHknPS] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] [-u user] [VAR=value] [-i|-s] [<command>]
+    usage: sudo -e [-AknS] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] [-u user] file ...",
+)]
 #[derive(Debug, Parser)]
-pub struct Cli {
-    /// This comment will be printed in help!
-    // when `Option<>` isn't used, the arg is required
-    pattern: Option<String>,
-    /// The path to the file to read
-    #[arg(short, help = "This overrides the comment!")]
-    pub path: Option<PathBuf>,
-    /// A flag
-    // `action` sets ArgAction::SetTrue, means we don't need to set a value when we have a bool.
-    #[arg(long, short, action)] 
-    pub flag: bool,
-    /// change the working directory before running command
-    #[arg(long = "chdir=directory", short = 'D', action, conflicts_with("list"))] // exclusion
-    pub directory: bool,
-    #[arg(long, short, action)] 
+pub struct Cli {   
+    #[arg(long, short = 'A', help = "use a helper program for password prompting", action)]  
+    pub askpass: bool,
+    #[arg(short = 'b', long, help = "run command in the background", action)]
+    pub background: bool,
+    #[arg(short = 'B', long, help = "ring bell when prompting", action)]
+    pub bell: bool,
+    #[arg(short = 'C', long = "close-from=num", help = "close all file descriptors >= num")]
+    pub num: Option<i16>,
+    #[arg(short = 'D', long = "chdir=directory", help = "change the working directory before running command")]
+    pub directory:  Option<PathBuf>,
+    #[arg(short = 'E', long = "preserve-env", help = "preserve user environment when running command", action)]
+    pub preserve_env: bool,
+    #[arg(long = "preserve-env=list", help = "preserve specific environment variables", value_name = "list")]
+    pub preserve_env_list: Option<String>,
+    #[arg(short = 'e', long, help = "edit files instead of running a command", action)]
+    pub edit: bool,
+    #[arg(short = 'g', long = "group=group", help = "run command as the specified group name or ID")]
+    pub group: Option<String>,
+    #[arg(short = 'H', long = "set-home", help = "set HOME variable to target user's home dir", action)]
+    pub set_home: bool,
+    // #[arg(long, help = "display help message and exit!", action = ArgAction::Help)] 
+    // pub help: bool, // TO DO: help as well as host are supposed to have short 'h'???
+    // #[arg(short = 'h', long = "host", help = "run command on host (if supported by plugin)")]
+    // pub host: Option<String>,
+    #[arg(short = 'i', long, help = "run login shell as the target user; a command may also be specified", action, conflicts_with("shell"))]
+    pub login: bool,
+    #[arg(short = 'K', long = "remove-timestamp", help = "remove timestamp file completely", action, conflicts_with("reset_timestamp"), conflicts_with("version"))]
+    pub remove_timestamp: bool,
+    #[arg(short = 'k', long = "reset-timestamp", help = "invalidate timestamp file", action, conflicts_with("remove_timestamp"), conflicts_with("version"))]
+    pub reset_timestamp: bool,
+    #[arg(short, long, help = "list user's privileges or check a specific command; use twice for longer format
+    ", action)]
     pub list: bool,
-    /// Hand-written parser for key-value pairs, e.g. envs. But needs flag.
-    // can we strip hyphens?? -
-    #[arg(long = "[VAR=value]", short = 'x', value_parser = parse_key_val::<String, String>)]
-    defines: Vec<(String, String)>,
-}
-
-// It doesn't matter in which order args are given.
-
-
-/// Parse a key-value pair
-fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
-where
-    T: std::str::FromStr,
-    T::Err: Error + Send + Sync + 'static,
-    U: std::str::FromStr,
-    U::Err: Error + Send + Sync + 'static,
-{
-    let pos = s
-        .find('=')
-        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{}`", s))?;
-    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
+    #[arg(short = 'n', long = "non-interactive", help = "non-interactive mode, no prompts are used", action)]
+    pub non_interactive: bool,
+    #[arg(short = 'P', long = "preserve-groups", help = "preserve group vector instead of setting to target's", action)]
+    pub preserve_groups: bool,
+    #[arg(short = 'p', long = "prompt=prompt", help = "use the specified password prompt")]
+    pub prompt: Option<String>,
+    #[arg(short = 'R', long = "chroot=directory", help = "change the root directory before running command", value_name = "directory")]
+    pub chroot: Option<PathBuf>,
+    #[arg(short = 'S', long, help = "read password from standard input", action)]
+    pub stdin: bool,
+    #[arg(short = 's', long, help = "run shell as the target user; a command may also be specified", action)]
+    pub shell: bool,
+    #[arg(short = 'T', long = "command-timeout=timeout", help = "terminate command after the specified time limit", value_name = "timeout")]
+    pub command_timeout: Option<String>,
+    #[arg(short = 'U', long = "other-user=user", help = "in list mode, display privileges for user", value_name = "user")]
+    pub other_user: Option<String>,
+    #[arg(short = 'u', long = "user=user", help = "run command (or edit file) as specified user name or ID")]
+    pub user: Option<String>,
+    // #[arg(short = 'V', long = "version", help = "display version information and exit!", action = ArgAction::Version, conflicts_with("host"), conflicts_with("remove_timestamp"), conflicts_with("reset_timestamp"))] 
+    // pub version: bool,
+    #[arg(short = 'v', long, help = "update user's timestamp without running a command", action)]
+    pub validate: bool,
+    #[arg(long = " ", help = "stop processing command line arguments", action)] // long arg should be "--", not allowed. How to pass?
+    pub stop_processing_args: bool,
 }

--- a/sudo/src/cli_args.rs
+++ b/sudo/src/cli_args.rs
@@ -25,17 +25,17 @@ pub struct Cli {
     pub background: bool,
     #[arg(short = 'B', long, help = "ring bell when prompting", action)]
     pub bell: bool,
-    #[arg(short = 'C', long = "close-from=num", help = "close all file descriptors >= num")]
+    #[arg(short = 'C', long = "close-from", help = "close all file descriptors >= num")]
     pub num: Option<i16>,
-    #[arg(short = 'D', long = "chdir=directory", help = "change the working directory before running command")]
+    #[arg(short = 'D', long = "chdir", help = "change the working directory before running command")]
     pub directory:  Option<PathBuf>,
-    #[arg(short = 'E', long = "preserve-env", help = "preserve user environment when running command", action)]
+    #[arg(short = 'E', long = "preserve-enve", help = "preserve user environment when running command", action)] // TO DO: sudo offers 2 "preserve-env" with same name
     pub preserve_env: bool,
-    #[arg(long = "preserve-env=list", help = "preserve specific environment variables", value_name = "list")]
+    #[arg(long = "preserve-env", help = "preserve specific environment variables", value_name = "list")]
     pub preserve_env_list: Option<String>,
     #[arg(short = 'e', long, help = "edit files instead of running a command", action)]
     pub edit: bool,
-    #[arg(short = 'g', long = "group=group", help = "run command as the specified group name or ID")]
+    #[arg(short = 'g', long = "group", help = "run command as the specified group name or ID")]
     pub group: Option<String>,
     #[arg(short = 'H', long = "set-home", help = "set HOME variable to target user's home dir", action)]
     pub set_home: bool,
@@ -56,19 +56,19 @@ pub struct Cli {
     pub non_interactive: bool,
     #[arg(short = 'P', long = "preserve-groups", help = "preserve group vector instead of setting to target's", action)]
     pub preserve_groups: bool,
-    #[arg(short = 'p', long = "prompt=prompt", help = "use the specified password prompt")]
+    #[arg(short = 'p', long = "prompt", help = "use the specified password prompt")]
     pub prompt: Option<String>,
-    #[arg(short = 'R', long = "chroot=directory", help = "change the root directory before running command", value_name = "directory")]
+    #[arg(short = 'R', long = "chroot", help = "change the root directory before running command", value_name = "directory")]
     pub chroot: Option<PathBuf>,
     #[arg(short = 'S', long, help = "read password from standard input", action)]
     pub stdin: bool,
     #[arg(short = 's', long, help = "run shell as the target user; a command may also be specified", action)]
     pub shell: bool,
-    #[arg(short = 'T', long = "command-timeout=timeout", help = "terminate command after the specified time limit", value_name = "timeout")]
+    #[arg(short = 'T', long = "command-timeout", help = "terminate command after the specified time limit", value_name = "timeout")]
     pub command_timeout: Option<String>,
-    #[arg(short = 'U', long = "other-user=user", help = "in list mode, display privileges for user", value_name = "user")]
+    #[arg(short = 'U', long = "other-user", help = "in list mode, display privileges for user", value_name = "user")]
     pub other_user: Option<String>,
-    #[arg(short = 'u', long = "user=user", help = "run command (or edit file) as specified user name or ID")]
+    #[arg(short = 'u', long = "user", help = "run command (or edit file) as specified user name or ID")]
     pub user: Option<String>,
     // #[arg(short = 'V', long = "version", help = "display version information and exit!", action = ArgAction::Version, conflicts_with("host"), conflicts_with("remove_timestamp"), conflicts_with("reset_timestamp"))] 
     // pub version: bool,

--- a/sudo/src/cli_args.rs
+++ b/sudo/src/cli_args.rs
@@ -1,0 +1,34 @@
+use std::path::PathBuf;
+
+use clap:: {
+    Parser,
+};
+
+
+// doesn't work when derive and builder patterns are combined.
+#[command(name = "sudo-rs")]
+#[command(about = "sudo - execute a command as another user", long_about = None)]
+#[command(version)] // Read from `Cargo.toml`
+
+#[derive(Debug, Parser)]
+pub struct Cli {
+    /// This comment will be printed in help!
+    // when `Option<>` isn't used, the arg is required
+    pattern: Option<String>,
+    /// The path to the file to read
+    #[arg(short, help = "This overrides the comment!")]
+    pub path: Option<PathBuf>,
+    /// A flag
+    // `action` sets ArgAction::SetTrue, means we don't need to set a value when we have a bool.
+    #[clap(long, short, action)] 
+    pub flag: bool,
+    /// Give me an easy exclusion please
+    #[clap(long, short, action, conflicts_with("flag"))]
+    bla: bool,
+    #[clap(long, short, action)] 
+    pub list: bool,
+    #[clap(long, short, action)] 
+    pub directory: bool,
+}
+
+// It doesn't matter in which order args are given.

--- a/sudo/src/cli_args.rs
+++ b/sudo/src/cli_args.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf};
 use clap::Parser;
 
 #[clap(
@@ -16,75 +16,109 @@ use clap::Parser;
 )]
 #[derive(Debug, Parser, Clone)]
 pub struct Cli {   
-    #[arg(long, short = 'A', help = "use a helper program for password prompting", action)]  
-    pub askpass: bool,
+    #[arg(long, short = 'A', help = "use a helper program for password prompting", action)]     
+    askpass: bool,
     #[arg(short = 'b', long, help = "run command in the background", action)]
-    pub background: bool,
+    background: bool,
     #[arg(short = 'B', long, help = "ring bell when prompting", action)]
-    pub bell: bool,
+    bell: bool,
     #[arg(short = 'C', long = "close-from", help = "close all file descriptors >= num")]
-    pub num: Option<i16>,
+    num: Option<i16>,
     #[arg(short = 'D', long = "chdir", help = "change the working directory before running command")]
-    pub directory:  Option<PathBuf>,
-    #[arg(long, value_delimiter=',', default_value = None, default_missing_value = "", require_equals = true, num_args = 0..)]
-    pub preserve_env: Vec<String>,
-    #[arg(short = 'E')]
-    pub short_preserve_env: bool,
+    directory:  Option<PathBuf>,
+    #[arg(long, help = "preserve specific environment variables", value_name = "list", value_delimiter=',', default_value = None, default_missing_value = "", require_equals = true, num_args = 0..)]
+    preserve_env: Vec<String>,
+    #[arg(short = 'E', help = "preserve user environment when running command")]
+    short_preserve_env: bool,
     #[arg(short = 'e', long, help = "edit files instead of running a command", action)]
-    pub edit: bool,
+    edit: bool,
     #[arg(short = 'g', long = "group", help = "run command as the specified group name or ID")]
-    pub group: Option<String>,
+    group: Option<String>,
     #[arg(short = 'H', long = "set-home", help = "set HOME variable to target user's home dir", action)]
-    pub set_home: bool,
+    set_home: bool,
     // #[arg(long, help = "display help message and exit!", action = ArgAction::Help)] 
-    // pub help: bool, // TO DO: help as well as host are supposed to have short 'h'???
+    // help: bool, // TO DO: help as well as host are supposed to have short 'h'???
     // #[arg(short = 'h', long = "host", help = "run command on host (if supported by plugin)")]
-    // pub host: Option<String>,
+    // host: Option<String>,
     #[arg(short = 'i', long, help = "run login shell as the target user; a command may also be specified", action, conflicts_with("shell"))]
-    pub login: bool,
+    login: bool,
     #[arg(short = 'K', long = "remove-timestamp", help = "remove timestamp file completely", action, conflicts_with("reset_timestamp"), conflicts_with("version"))]
-    pub remove_timestamp: bool,
+    remove_timestamp: bool,
     #[arg(short = 'k', long = "reset-timestamp", help = "invalidate timestamp file", action, conflicts_with("remove_timestamp"), conflicts_with("version"))]
-    pub reset_timestamp: bool,
-    #[arg(short, long, help = "list user's privileges or check a specific command; use twice for longer format
-    ", action)]
-    pub list: bool,
+    reset_timestamp: bool,
+    #[arg(short, long, help = "list user's privileges or check a specific command; use twice for longer format", action)]
+    list: bool,
     #[arg(short = 'n', long = "non-interactive", help = "non-interactive mode, no prompts are used", action)]
-    pub non_interactive: bool,
+    non_interactive: bool,
     #[arg(short = 'P', long = "preserve-groups", help = "preserve group vector instead of setting to target's", action)]
-    pub preserve_groups: bool,
+    preserve_groups: bool,
     #[arg(short = 'p', long = "prompt", help = "use the specified password prompt")]
-    pub prompt: Option<String>,
+    prompt: Option<String>,
     #[arg(short = 'R', long = "chroot", help = "change the root directory before running command", value_name = "directory")]
-    pub chroot: Option<PathBuf>,
+    chroot: Option<PathBuf>,
     #[arg(short = 'S', long, help = "read password from standard input", action)]
-    pub stdin: bool,
+    stdin: bool,
     #[arg(short = 's', long, help = "run shell as the target user; a command may also be specified", action)]
-    pub shell: bool,
+    shell: bool,
     #[arg(short = 'T', long = "command-timeout", help = "terminate command after the specified time limit", value_name = "timeout")]
-    pub command_timeout: Option<String>,
+    command_timeout: Option<String>, // To Do: This is the wrong type. Which one is correct?
     #[arg(short = 'U', long = "other-user", help = "in list mode, display privileges for user", value_name = "user")]
-    pub other_user: Option<String>,
+    other_user: Option<String>,
     #[arg(short = 'u', long = "user", help = "run command (or edit file) as specified user name or ID")]
-    pub user: Option<String>,
+    user: Option<String>,
     // #[arg(short = 'V', long = "version", help = "display version information and exit!", action = ArgAction::Version, conflicts_with("host"), conflicts_with("remove_timestamp"), conflicts_with("reset_timestamp"))] 
-    // pub version: bool,
+    // version: bool,
     #[arg(short = 'v', long, help = "update user's timestamp without running a command", action)]
-    pub validate: bool,
+    validate: bool,
     // this is a hack to make help show up for `--`, which wouldn't be allowed as a flag in clap.
     // Ignore value of `stop_processing_args`.
     #[arg(long = " ", help = "stop processing command line arguments", action)]
-    pub stop_processing_args: bool,
+    stop_processing_args: bool,
     // Arguments passed straight through, either seperated by -- or just trailing.
+    #[arg(hide = true)]
     external_args: Vec<String>,
 }
 
 #[derive(Debug)]
 pub struct SudoOptions {
-    // This is what OGsudo calls `-E, --preserve-env`
-    pub preserve_env: bool,
+    pub askpass: bool,
+    pub background: bool,
+    pub bell: bool,
+    pub num: Option<i16>,
+    pub directory:  Option<PathBuf>,
     // This is what OGsudo calls `--preserve-env=list`
     pub preserve_env_list: Vec<String>,
+    // This is what OGsudo calls `-E, --preserve-env`
+    pub preserve_env: bool,
+    // Only one of the -e, -h, -i, -K, -l, -s, -v or -V options may be specified
+    pub edit: bool,
+    pub group: Option<String>,
+    pub set_home: bool,
+    // #[arg(long, help = "display help message and exit!", action = ArgAction::Help)] 
+    // pub help: bool, // TO DO: help as well as host are supposed to have short 'h'???
+    // #[arg(short = 'h', long = "host", help = "run command on host (if supported by plugin)")]
+    // pub host: Option<String>,
+    // possible to do the same way as preserve_env
+    pub login: bool,
+    pub remove_timestamp: bool,
+    pub reset_timestamp: bool,
+    pub list: bool,
+    pub non_interactive: bool,
+    pub preserve_groups: bool,
+    pub prompt: Option<String>,
+    pub chroot: Option<PathBuf>,
+    pub stdin: bool,
+    pub shell: bool,
+    pub command_timeout: Option<String>,
+    pub other_user: Option<String>,
+    pub user: Option<String>,
+    // pub version: bool,
+    pub validate: bool,
+    // this is a hack to make help show up for `--`, which wouldn't be allowed as a flag in clap.
+    // Ignore value of `stop_processing_args`.
+    // pub stop_processing_args: bool,
+    // Arguments passed straight through, either seperated by -- or just trailing.
+    pub external_args: Vec<String>,
 }
 
 impl From<Cli> for SudoOptions {
@@ -103,6 +137,29 @@ impl From<Cli> for SudoOptions {
                     .filter(|s| !s.is_empty())
                     .collect()
             },
+            askpass: command.askpass,
+            background: command.background,
+            bell: command.bell,
+            num: command.num,
+            directory: command.directory,
+            edit: command.edit,
+            group: command.group,
+            set_home: command.set_home,
+            login: command.login,
+            remove_timestamp: command.remove_timestamp,
+            reset_timestamp: command.reset_timestamp,
+            list: command.list,
+            non_interactive: command.non_interactive,
+            preserve_groups: command.preserve_groups,
+            prompt: command.prompt,
+            chroot: command.chroot,
+            stdin: command.stdin,
+            shell: command.shell,
+            command_timeout: command.command_timeout,
+            other_user: command.other_user,
+            user: command.user,
+            validate: command.validate,
+            external_args: command.external_args,
         }
     }
 }

--- a/sudo/src/cli_args.rs
+++ b/sudo/src/cli_args.rs
@@ -2,13 +2,20 @@ use std::path::PathBuf;
 
 use clap:: {
     Parser,
+    Arg,
+    Command,
+    Args,
+    error::Error,
+    ArgMatches,
+    FromArgMatches,
+    ArgAction
 };
 
 
-// doesn't work when derive and builder patterns are combined.
-#[command(name = "sudo-rs")]
-#[command(about = "sudo - execute a command as another user", long_about = None)]
-#[command(version)] // Read from `Cargo.toml`
+// // doesn't work when derive and builder patterns are combined.
+// #[command(name = "sudo-rs")]
+// #[command(about = "sudo - execute a command as another user", long_about = None)]
+// #[command(version)] // Read from `Cargo.toml`
 
 #[derive(Debug, Parser)]
 pub struct Cli {
@@ -29,6 +36,68 @@ pub struct Cli {
     pub list: bool,
     #[clap(long, short, action)] 
     pub directory: bool,
+    /// builder with derive api
+    #[command(flatten)]
+    more_args: CliArgs,
 }
+
+#[derive(Debug)]
+struct CliArgs {
+    either_this: bool,
+    or_that: bool,
+}
+
+impl FromArgMatches for CliArgs {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let mut matches = matches.clone();
+        Self::from_arg_matches_mut(&mut matches)
+    }
+    fn from_arg_matches_mut(matches: &mut ArgMatches) -> Result<Self, Error> {
+        Ok(Self {
+            either_this: matches.get_flag("either_this"),
+            or_that: matches.get_flag("or_that"),
+        })
+    }
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        let mut matches = matches.clone();
+        self.update_from_arg_matches_mut(&mut matches)
+    }
+
+}
+
+impl Args for CliArgs {
+    fn augment_args(cmd: Command) -> Command {
+        cmd.arg(
+            Arg::new("either_this")
+                .short('e')
+                .long("either_this")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("or_that"), // this is what we need, can conflict with any arg, e.g. "flag"
+        )
+        .arg(
+            Arg::new("or_that")
+                .short('o')
+                .long("or_that")
+                .action(ArgAction::SetTrue),
+        )
+    }
+    // what is this needed for?
+    fn augment_args_for_update(cmd: Command) -> Command {
+        cmd.arg(
+            Arg::new("either_this")
+                .short('e')
+                .long("either_this")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("or_that"), // this is what we need,
+        )
+        .arg(
+            Arg::new("or_that")
+                .short('o')
+                .long("or_that")
+                .action(ArgAction::SetTrue),
+        )
+    }
+}
+
 
 // It doesn't matter in which order args are given.

--- a/sudo/src/cli_args.rs
+++ b/sudo/src/cli_args.rs
@@ -1,15 +1,5 @@
 use std::path::PathBuf;
-
-use clap:: {
-    Parser,
-    Arg,
-    Command,
-    Args,
-    error::Error,
-    ArgMatches,
-    FromArgMatches,
-    ArgAction
-};
+use clap::Parser;
 
 #[clap(
     name = "sudo-rs",
@@ -17,6 +7,7 @@ use clap:: {
     version,
     // disable_version_flag = true,
     // disable_help_flag = true,
+    trailing_var_arg = true,
     override_usage = "usage: sudo -h | -K | -k | -V
     usage: sudo -v [-AknS] [-g group] [-h host] [-p prompt] [-u user]
     usage: sudo -l [-AknS] [-g group] [-h host] [-p prompt] [-U user] [-u user] [command]
@@ -80,12 +71,13 @@ pub struct Cli {
     // pub version: bool,
     #[arg(short = 'v', long, help = "update user's timestamp without running a command", action)]
     pub validate: bool,
-    #[arg(long = " ", help = "stop processing command line arguments", action)] // long arg should be "--", not allowed. How to pass?
+    // this is a hack to make help show up for `--`, which wouldn't be allowed as a flag in clap.
+    // Ignore value of `stop_processing_args`.
+    #[arg(long = " ", help = "stop processing command line arguments", action)]
     pub stop_processing_args: bool,
-    // To Do: in OGSudo there is an option   --    "stop processing command line arguments." hyphens are  not allowed in clap!
-
+    // Arguments passed straight through, either seperated by -- or just trailing.
+    external_args: Vec<String>,
 }
-
 
 #[derive(Debug)]
 pub struct SudoOptions {

--- a/sudo/src/cli_args.rs
+++ b/sudo/src/cli_args.rs
@@ -15,60 +15,155 @@ use std::path::PathBuf;
     usage: sudo -e [-AknS] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] [-u user] file ...",
 )]
 #[derive(Debug, Parser, Clone)]
-pub struct Cli {   
-    #[arg(long, short = 'A', help = "use a helper program for password prompting", action)]     
+pub struct Cli {
+    #[arg(
+        long,
+        short = 'A',
+        help = "use a helper program for password prompting",
+        action
+    )]
     askpass: bool,
     #[arg(short = 'b', long, help = "run command in the background", action)]
     background: bool,
     #[arg(short = 'B', long, help = "ring bell when prompting", action)]
     bell: bool,
-    #[arg(short = 'C', long = "close-from", help = "close all file descriptors >= num")]
+    #[arg(
+        short = 'C',
+        long = "close-from",
+        help = "close all file descriptors >= num"
+    )]
     num: Option<i16>,
-    #[arg(short = 'D', long = "chdir", help = "change the working directory before running command")]
-    directory:  Option<PathBuf>,
+    #[arg(
+        short = 'D',
+        long = "chdir",
+        help = "change the working directory before running command"
+    )]
+    directory: Option<PathBuf>,
     #[arg(long, help = "preserve specific environment variables", value_name = "list", value_delimiter=',', default_value = None, default_missing_value = "", require_equals = true, num_args = 0..)]
     preserve_env: Vec<String>,
     #[arg(short = 'E', help = "preserve user environment when running command")]
     short_preserve_env: bool,
-    #[arg(short = 'e', long, help = "edit files instead of running a command", action)]
+    #[arg(
+        short = 'e',
+        long,
+        help = "edit files instead of running a command",
+        action
+    )]
     edit: bool,
-    #[arg(short = 'g', long = "group", help = "run command as the specified group name or ID")]
+    #[arg(
+        short = 'g',
+        long = "group",
+        help = "run command as the specified group name or ID"
+    )]
     group: Option<String>,
-    #[arg(short = 'H', long = "set-home", help = "set HOME variable to target user's home dir", action)]
+    #[arg(
+        short = 'H',
+        long = "set-home",
+        help = "set HOME variable to target user's home dir",
+        action
+    )]
     set_home: bool,
-    // #[arg(long, help = "display help message and exit!", action = ArgAction::Help)] 
+    // #[arg(long, help = "display help message and exit!", action = ArgAction::Help)]
     // help: bool, // TO DO: help as well as host are supposed to have short 'h'???
     // #[arg(short = 'h', long = "host", help = "run command on host (if supported by plugin)")]
     // host: Option<String>,
-    #[arg(short = 'i', long, help = "run login shell as the target user; a command may also be specified", action, conflicts_with("shell"))]
+    #[arg(
+        short = 'i',
+        long,
+        help = "run login shell as the target user; a command may also be specified",
+        action,
+        conflicts_with("shell")
+    )]
     login: bool,
-    #[arg(short = 'K', long = "remove-timestamp", help = "remove timestamp file completely", action, conflicts_with("reset_timestamp"), conflicts_with("version"))]
+    #[arg(
+        short = 'K',
+        long = "remove-timestamp",
+        help = "remove timestamp file completely",
+        action,
+        conflicts_with("reset_timestamp"),
+        conflicts_with("version")
+    )]
     remove_timestamp: bool,
-    #[arg(short = 'k', long = "reset-timestamp", help = "invalidate timestamp file", action, conflicts_with("remove_timestamp"), conflicts_with("version"))]
+    #[arg(
+        short = 'k',
+        long = "reset-timestamp",
+        help = "invalidate timestamp file",
+        action,
+        conflicts_with("remove_timestamp"),
+        conflicts_with("version")
+    )]
     reset_timestamp: bool,
-    #[arg(short, long, help = "list user's privileges or check a specific command; use twice for longer format", action)]
+    #[arg(
+        short,
+        long,
+        help = "list user's privileges or check a specific command; use twice for longer format",
+        action
+    )]
     list: bool,
-    #[arg(short = 'n', long = "non-interactive", help = "non-interactive mode, no prompts are used", action)]
+    #[arg(
+        short = 'n',
+        long = "non-interactive",
+        help = "non-interactive mode, no prompts are used",
+        action
+    )]
     non_interactive: bool,
-    #[arg(short = 'P', long = "preserve-groups", help = "preserve group vector instead of setting to target's", action)]
+    #[arg(
+        short = 'P',
+        long = "preserve-groups",
+        help = "preserve group vector instead of setting to target's",
+        action
+    )]
     preserve_groups: bool,
-    #[arg(short = 'p', long = "prompt", help = "use the specified password prompt")]
+    #[arg(
+        short = 'p',
+        long = "prompt",
+        help = "use the specified password prompt"
+    )]
     prompt: Option<String>,
-    #[arg(short = 'R', long = "chroot", help = "change the root directory before running command", value_name = "directory")]
+    #[arg(
+        short = 'R',
+        long = "chroot",
+        help = "change the root directory before running command",
+        value_name = "directory"
+    )]
     chroot: Option<PathBuf>,
     #[arg(short = 'S', long, help = "read password from standard input", action)]
     stdin: bool,
-    #[arg(short = 's', long, help = "run shell as the target user; a command may also be specified", action)]
+    #[arg(
+        short = 's',
+        long,
+        help = "run shell as the target user; a command may also be specified",
+        action
+    )]
     shell: bool,
-    #[arg(short = 'T', long = "command-timeout", help = "terminate command after the specified time limit", value_name = "timeout")]
+    #[arg(
+        short = 'T',
+        long = "command-timeout",
+        help = "terminate command after the specified time limit",
+        value_name = "timeout"
+    )]
     command_timeout: Option<String>, // To Do: This is the wrong type. Which one is correct?
-    #[arg(short = 'U', long = "other-user", help = "in list mode, display privileges for user", value_name = "user")]
+    #[arg(
+        short = 'U',
+        long = "other-user",
+        help = "in list mode, display privileges for user",
+        value_name = "user"
+    )]
     other_user: Option<String>,
-    #[arg(short = 'u', long = "user", help = "run command (or edit file) as specified user name or ID")]
+    #[arg(
+        short = 'u',
+        long = "user",
+        help = "run command (or edit file) as specified user name or ID"
+    )]
     user: Option<String>,
-    // #[arg(short = 'V', long = "version", help = "display version information and exit!", action = ArgAction::Version, conflicts_with("host"), conflicts_with("remove_timestamp"), conflicts_with("reset_timestamp"))] 
+    // #[arg(short = 'V', long = "version", help = "display version information and exit!", action = ArgAction::Version, conflicts_with("host"), conflicts_with("remove_timestamp"), conflicts_with("reset_timestamp"))]
     // version: bool,
-    #[arg(short = 'v', long, help = "update user's timestamp without running a command", action)]
+    #[arg(
+        short = 'v',
+        long,
+        help = "update user's timestamp without running a command",
+        action
+    )]
     validate: bool,
     // this is a hack to make help show up for `--`, which wouldn't be allowed as a flag in clap.
     // Ignore value of `stop_processing_args`.
@@ -90,11 +185,11 @@ pub struct SudoOptions {
     pub background: bool,
     pub bell: bool,
     pub num: Option<i16>,
-    pub directory:  Option<PathBuf>,
+    pub directory: Option<PathBuf>,
     pub edit: bool,
     pub group: Option<String>,
     pub set_home: bool,
-    // #[arg(long, help = "display help message and exit!", action = ArgAction::Help)] 
+    // #[arg(long, help = "display help message and exit!", action = ArgAction::Help)]
     // pub help: bool, // TO DO: help as well as host are supposed to have short 'h'???
     // #[arg(short = 'h', long = "host", help = "run command on host (if supported by plugin)")]
     // pub host: Option<String>,

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -9,15 +9,12 @@ use crate::cli_args::SudoOptions;
 struct CustomError(String);
 
 fn main() -> Result<(), CustomError> {
-    let mut args = Cli::parse();
-    let mut bla = SudoOptions::from(args.clone());
-    args.preserve_env.clear();
-    args.preserve_env.append(& mut bla.preserve_env_list);
-    args.short_preserve_env.clone_from(&bla.preserve_env);
-
-    println!("args: {:?}", args);
+    let args = Cli::parse();
+    let captured = SudoOptions::from(args.clone());
+    println!("captured: {:?}", captured);
     Ok(())
 }
+
 
 #[test]
 fn verify_cli() {

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -1,14 +1,6 @@
+mod cli_args;
 use clap::Parser;
-
-/// Search for a pattern in a file and display the lines that contain it.
-#[derive(Parser)]
-struct Cli {
-    /// The pattern to look for
-    pattern: String,
-    /// The path to the file to read
-    path: std::path::PathBuf,
-}
-
+use cli_args::Cli;
 #[derive(Debug)]
 struct CustomError(String);
 
@@ -16,8 +8,21 @@ struct CustomError(String);
 fn main() -> Result<(), CustomError> {
 
     let args = Cli::parse();
-    let content = std::fs::read_to_string(&args.path)
-    .map_err(|err| CustomError(format!("Error reading `{}`: {}", &args.path.display(), err)))?;
-    println!("file content: {}", content);
+    // let content = std::fs::read_to_string(&args.path);
+    // if let Some(content) = args.path.as_deref() {
+    if let Some(cli_path) = args.path.as_deref() {
+        let content = cli_path.display();
+        println!("path: {}", content);
+        println!("Value for content: {:?}", std::fs::read_to_string(content.to_string()));
+    }
+
+    println!("args: {:?}", args);
     Ok(())
 }
+
+// try to exclude flags
+// write tests
+// catch trailing stuff (the commands for which are meant to be executed with root rights)
+
+
+// unsolved: how can we pass yet unknown env variables?

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -2,12 +2,20 @@ mod cli_args;
 use clap::{Parser, CommandFactory};
 use cli_args::Cli;
 
+use crate::cli_args::SudoOptions;
+
 
 #[derive(Debug)]
 struct CustomError(String);
 
 fn main() -> Result<(), CustomError> {
-    let args = Cli::parse();
+    let mut args = Cli::parse();
+    // dbg!(SudoOptions::from(args));
+    let mut bla = SudoOptions::from(args.clone());
+    args.preserve_env.clear();
+    args.preserve_env.append(& mut bla.preserve_env_list);
+    args.short_preserve_env.clone_from(&bla.preserve_env);
+
     println!("args: {:?}", args);
     Ok(())
 }

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -1,1 +1,23 @@
-fn main() {}
+use clap::Parser;
+
+/// Search for a pattern in a file and display the lines that contain it.
+#[derive(Parser)]
+struct Cli {
+    /// The pattern to look for
+    pattern: String,
+    /// The path to the file to read
+    path: std::path::PathBuf,
+}
+
+#[derive(Debug)]
+struct CustomError(String);
+
+// fn main() {
+fn main() -> Result<(), CustomError> {
+
+    let args = Cli::parse();
+    let content = std::fs::read_to_string(&args.path)
+    .map_err(|err| CustomError(format!("Error reading `{}`: {}", &args.path.display(), err)))?;
+    println!("file content: {}", content);
+    Ok(())
+}

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -10,7 +10,6 @@ struct CustomError(String);
 
 fn main() -> Result<(), CustomError> {
     let mut args = Cli::parse();
-    // dbg!(SudoOptions::from(args));
     let mut bla = SudoOptions::from(args.clone());
     args.preserve_env.clear();
     args.preserve_env.append(& mut bla.preserve_env_list);

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -10,7 +10,6 @@ fn main() -> Result<(), CustomError> {
     Ok(())
 }
 
-
 #[test]
 fn verify_cli() {
     use clap::CommandFactory;

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -1,5 +1,5 @@
 mod cli_args;
-use clap::Parser;
+use clap::{Parser, CommandFactory};
 use cli_args::Cli;
 
 
@@ -10,4 +10,9 @@ fn main() -> Result<(), CustomError> {
     let args = Cli::parse();
     println!("args: {:?}", args);
     Ok(())
+}
+
+#[test]
+fn verify_cli() {
+    Cli::command().debug_assert()
 }

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -1,6 +1,7 @@
 mod cli_args;
-use clap::Parser;
+use clap::{Parser, CommandFactory};
 use cli_args::Cli;
+
 #[derive(Debug)]
 struct CustomError(String);
 
@@ -20,9 +21,8 @@ fn main() -> Result<(), CustomError> {
     Ok(())
 }
 
-// try to exclude flags
-// write tests
-// catch trailing stuff (the commands for which are meant to be executed with root rights)
-
-
-// unsolved: how can we pass yet unknown env variables?
+#[test]
+fn verify_cli() {
+    use clap::CommandFactory;
+    Cli::command().debug_assert()
+}

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -1,28 +1,13 @@
 mod cli_args;
-use clap::{Parser, CommandFactory};
+use clap::Parser;
 use cli_args::Cli;
+
 
 #[derive(Debug)]
 struct CustomError(String);
 
-// fn main() {
 fn main() -> Result<(), CustomError> {
-
     let args = Cli::parse();
-    // let content = std::fs::read_to_string(&args.path);
-    // if let Some(content) = args.path.as_deref() {
-    if let Some(cli_path) = args.path.as_deref() {
-        let content = cli_path.display();
-        println!("path: {}", content);
-        println!("Value for content: {:?}", std::fs::read_to_string(content.to_string()));
-    }
-
     println!("args: {:?}", args);
     Ok(())
-}
-
-#[test]
-fn verify_cli() {
-    use clap::CommandFactory;
-    Cli::command().debug_assert()
 }


### PR DESCRIPTION
Parse CLI for arguments using Clap, see https://github.com/memorysafety/sudo-rs/issues/6.
- has (most) options/flags (from Sudo version 1.9.5p2)
- can handle trailing arguments that get passed through sudo
- passing env variables is mostly implemented (missing: handle case when  `--` is not passed)
- can handle `--preserve_env` which in original sudo are two different flags with the same name