### PR TITLE
Support for user/group info as #ID and name

### DIFF
--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -66,7 +66,7 @@ pub fn hostname() -> String {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct User {
     pub uid: libc::uid_t,
     pub gid: libc::gid_t,

--- a/lib/sudoers/Cargo.toml
+++ b/lib/sudoers/Cargo.toml
@@ -7,3 +7,6 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 derive_more = ">=0.99.17"
 glob = ">= 0.3.1"
+sudo-system = {path="../sudo-system"}
+
+

--- a/lib/sudoers/Cargo.toml
+++ b/lib/sudoers/Cargo.toml
@@ -5,8 +5,9 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-derive_more = ">=0.99.17"
-glob = ">= 0.3.1"
+derive_more = "0.99.17"
+libc = "0.2.139"
+glob = "0.3.1"
 sudo-system = {path="../sudo-system"}
 
 

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -23,6 +23,8 @@ pub enum UserSpecifier {
     NonunixGroup(Identifier),
 }
 
+pub use crate::tokens::Identifier;
+
 /// The RunAs specification consists of a (possibly empty) list of userspecifiers, followed by a (possibly empty) list of groups.
 #[derive(Debug, Default)]
 pub struct RunAs {

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -27,7 +27,7 @@ pub enum UserSpecifier {
 #[derive(Debug, Default)]
 pub struct RunAs {
     pub users: SpecList<UserSpecifier>,
-    pub groups: SpecList<Username>,
+    pub groups: SpecList<Identifier>,
 }
 
 /// Commands in /etc/sudoers can have attributes attached to them, such as NOPASSWD, NOEXEC, ...

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -111,7 +111,7 @@ impl Parse for Meta<UserSpecifier> {
             make(match meta {
                 Meta::All => Meta::All,
                 Meta::Alias(alias) => Meta::Alias(alias),
-                Meta::Only(name) => Meta::Only(User(Identifier::Name(name))),
+                Meta::Only(Username(name)) => Meta::Only(User(Identifier::Name(name))),
             })
         } else {
             let ctor = if maybe(accept_if(|c| c == '%', stream))?.is_some() {

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -28,6 +28,14 @@ pub struct UserInfo<'a> {
     pub group: &'a str,
 }
 
+// TODO to be replaced with a proper 'user identifier' object provided by the system
+fn temp_kludge(user: &tokens::Identifier) -> &str {
+    match user {
+        Identifier::Name(x) => &x.0,
+        _ => panic!("you have reached the limits of this stub"),
+    }
+}
+
 // TODO: combine this with Vec<PermissionSpec> into a single data structure?
 #[derive(Default)]
 pub struct AliasTable {
@@ -129,20 +137,22 @@ where
 
 fn match_user(username: &str) -> (impl Fn(&UserSpecifier) -> bool + '_) {
     move |spec| match spec {
-        UserSpecifier::User(name) => name.0 == username,
-        UserSpecifier::Group(groupname) => in_group(username, groupname.0.as_str()),
+        UserSpecifier::User(name) => temp_kludge(name) == username,
+        UserSpecifier::Group(groupname) => in_group(username, temp_kludge(groupname)),
+        _ => todo!(),
     }
 }
 
 fn match_group_alias(groupname: &str) -> (impl Fn(&UserSpecifier) -> bool + '_) {
     move |spec| match spec {
-        UserSpecifier::User(name) => name.0 == groupname,
+        UserSpecifier::User(name) => temp_kludge(name) == groupname,
         /* the parser rejects this, but can happen due to Runas_Alias,
          * see https://github.com/memorysafety/sudo-rs/issues/13 */
         UserSpecifier::Group(_) => {
             eprintln!("warning: ignoring %group syntax for use sudo -g");
             false
         }
+        _ => todo!(),
     }
 }
 

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -126,7 +126,7 @@ where
 fn match_user(user: &impl Identifiable) -> impl Fn(&UserSpecifier) -> bool + '_ {
     move |spec| match spec {
         UserSpecifier::User(id) => match_identifier(user, id),
-        UserSpecifier::Group(Identifier::Name(Username(name))) => user.in_group_by_name(name),
+        UserSpecifier::Group(Identifier::Name(name)) => user.in_group_by_name(name),
         UserSpecifier::Group(Identifier::ID(num)) => user.in_group_by_gid(*num),
         _ => todo!(),
     }
@@ -134,7 +134,7 @@ fn match_user(user: &impl Identifiable) -> impl Fn(&UserSpecifier) -> bool + '_ 
 
 fn in_group(user: &impl Identifiable, group: &ast::Identifier) -> bool {
     match group {
-        Identifier::Name(Username(groupname)) => user.in_group_by_name(groupname),
+        Identifier::Name(groupname) => user.in_group_by_name(groupname),
         Identifier::ID(num) => user.in_group_by_gid(*num),
     }
 }
@@ -193,7 +193,7 @@ where
 
 fn match_identifier(user: &impl Identifiable, ident: &ast::Identifier) -> bool {
     match ident {
-        Identifier::Name(tokens::Username(name)) => user.has_name(name),
+        Identifier::Name(name) => user.has_name(name),
         Identifier::ID(num) => user.has_id(*num),
     }
 }
@@ -297,7 +297,7 @@ mod test {
 
     impl From<&str> for ast::Identifier {
         fn from(value: &str) -> ast::Identifier {
-            Identifier::Name(Username(value.to_string()))
+            Identifier::Name(value.to_string())
         }
     }
 

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -304,8 +304,8 @@ mod test {
         fn try_as_name(&self) -> Option<&str> {
             Some(self.1)
         }
-        fn as_gid(&self) -> u16 {
-            self.0
+        fn as_gid(&self) -> libc::gid_t {
+            self.0 as libc::gid_t
         }
     }
 

--- a/lib/sudoers/src/sysuser.rs
+++ b/lib/sudoers/src/sysuser.rs
@@ -5,7 +5,7 @@ pub trait Identifiable {
     fn has_name(&self, _name: &str) -> bool {
         false
     }
-    fn has_uid(&self, _uid: u16) -> bool {
+    fn has_uid(&self, _uid: libc::uid_t) -> bool {
         false
     }
 
@@ -15,21 +15,21 @@ pub trait Identifiable {
     fn in_group_by_name(&self, _name: &str) -> bool {
         false
     }
-    fn in_group_by_gid(&self, _name: u16) -> bool {
+    fn in_group_by_gid(&self, _name: libc::gid_t) -> bool {
         false
     }
 }
 
 pub trait UnixGroup {
-    fn as_gid(&self) -> u16;
+    fn as_gid(&self) -> libc::gid_t;
     fn try_as_name(&self) -> Option<&str>;
 }
 
 /// This is the "canonical" info that we need
 #[derive(Debug)]
-pub struct GroupID(pub u16, pub Option<String>);
+pub struct GroupID(pub libc::gid_t, pub Option<String>);
 #[derive(Debug)]
-pub struct UserRecord(pub u16, pub Option<String>, pub Vec<GroupID>);
+pub struct UserRecord(pub libc::gid_t, pub Option<String>, pub Vec<GroupID>);
 
 impl PartialEq<UserRecord> for UserRecord {
     fn eq(&self, other: &Self) -> bool {
@@ -40,7 +40,7 @@ impl PartialEq<UserRecord> for UserRecord {
 impl Eq for UserRecord {}
 
 impl UnixGroup for GroupID {
-    fn as_gid(&self) -> u16 {
+    fn as_gid(&self) -> libc::gid_t {
         self.0
     }
 
@@ -64,7 +64,7 @@ impl Identifiable for &str {
 }
 
 impl Identifiable for GroupID {
-    fn has_uid(&self, uid: u16) -> bool {
+    fn has_uid(&self, uid: libc::gid_t) -> bool {
         self.0 == uid
     }
     fn has_name(&self, name: &str) -> bool {
@@ -81,7 +81,7 @@ impl Identifiable for UserRecord {
         self.2.iter().any(|g| g.has_name(name))
     }
 
-    fn in_group_by_gid(&self, id: u16) -> bool {
+    fn in_group_by_gid(&self, id: libc::gid_t) -> bool {
         self.2.iter().any(|g| g.has_uid(id))
     }
 }
@@ -90,8 +90,8 @@ impl Identifiable for sudo_system::User {
     fn has_name(&self, name: &str) -> bool {
         self.name == name
     }
-    fn has_uid(&self, uid: u16) -> bool {
-        self.uid as u16 == uid
+    fn has_uid(&self, uid: libc::gid_t) -> bool {
+        self.uid == uid
     }
 
     fn is_root(&self) -> bool {
@@ -100,14 +100,14 @@ impl Identifiable for sudo_system::User {
     fn in_group_by_name(&self, _name: &str) -> bool {
         false
     }
-    fn in_group_by_gid(&self, _name: u16) -> bool {
+    fn in_group_by_gid(&self, _name: libc::gid_t) -> bool {
         false
     }
 }
 
 impl UnixGroup for sudo_system::Group {
-    fn as_gid(&self) -> u16 {
-        self.gid as u16
+    fn as_gid(&self) -> libc::gid_t {
+        self.gid
     }
 
     fn try_as_name(&self) -> Option<&str> {

--- a/lib/sudoers/src/sysuser.rs
+++ b/lib/sudoers/src/sysuser.rs
@@ -1,0 +1,55 @@
+/// This trait/module is here to not make this crate dependent (at the present time) in the idiosyncracies of user representation details
+/// (which we may decide over time), as well as to make explicit what functionality a user-representation must have; this
+/// interface is not set in stone and "easy" to change.
+pub trait Identifiable: Eq {
+    fn has_name(&self, _name: &str) -> bool {
+        false
+    }
+    fn has_id(&self, _uid: u16) -> bool {
+        false
+    }
+
+    fn is_root(&self) -> bool {
+        false
+    }
+    fn in_group_by_name(&self, _name: &str) -> bool {
+        false
+    }
+    fn in_group_by_gid(&self, _name: u16) -> bool {
+        false
+    }
+}
+
+impl Identifiable for &str {
+    fn has_name(&self, name: &str) -> bool {
+        *self == name
+    }
+
+    fn in_group_by_name(&self, name: &str) -> bool {
+        self.has_name(name)
+    }
+
+    fn is_root(&self) -> bool {
+        self.has_name("root")
+    }
+}
+
+impl Identifiable for u16 {
+    fn has_id(&self, uid: u16) -> bool {
+        *self == uid
+    }
+
+    fn is_root(&self) -> bool {
+        self.has_id(0)
+    }
+}
+
+impl Identifiable for (&str, u16) {
+    fn has_name(&self, name: &str) -> bool {
+        self.0 == name
+    }
+
+    fn is_root(&self) -> bool {
+        *self == ("root", 0)
+    }
+}

--- a/lib/sudoers/src/sysuser.rs
+++ b/lib/sudoers/src/sysuser.rs
@@ -85,3 +85,32 @@ impl Identifiable for UserRecord {
         self.2.iter().any(|g| g.has_uid(id))
     }
 }
+
+impl Identifiable for sudo_system::User {
+    fn has_name(&self, name: &str) -> bool {
+        self.name == name
+    }
+    fn has_uid(&self, uid: u16) -> bool {
+        self.uid as u16 == uid
+    }
+
+    fn is_root(&self) -> bool {
+        self.has_uid(0)
+    }
+    fn in_group_by_name(&self, _name: &str) -> bool {
+        false
+    }
+    fn in_group_by_gid(&self, _name: u16) -> bool {
+        false
+    }
+}
+
+impl UnixGroup for sudo_system::Group {
+    fn as_gid(&self) -> u16 {
+        self.gid as u16
+    }
+
+    fn try_as_name(&self) -> Option<&str> {
+        Some(&self.name)
+    }
+}

--- a/lib/sudoers/src/sysuser.rs
+++ b/lib/sudoers/src/sysuser.rs
@@ -1,4 +1,4 @@
-/// This trait/module is here to not make this crate dependent (at the present time) in the idiosyncracies of user representation details
+/// This trait/module is here to not make this crate independent (at the present time) in the idiosyncracies of user representation details
 /// (which we may decide over time), as well as to make explicit what functionality a user-representation must have; this
 /// interface is not set in stone and "easy" to change.
 pub trait Identifiable {

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -61,7 +61,7 @@ impl Many for Hostname {}
 #[derive(Debug)]
 #[cfg_attr(test, derive(Clone, PartialEq, Eq))]
 pub enum Identifier {
-    Name(Username),
+    Name(String),
     ID(u16),
 }
 
@@ -74,7 +74,7 @@ impl Token for Identifier {
                 Err(err) => unrecoverable!("invalid user id: {err}"),
             }
         } else {
-            Identifier::Name(Username(text))
+            Identifier::Name(text)
         })
     }
 

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -1,6 +1,6 @@
 //! Various tokens
 
-use crate::basic_parser::{Many, Parsed, Status, Token};
+use crate::basic_parser::{unrecoverable, Many, Parsed, Status, Token};
 use derive_more::Deref;
 
 #[derive(Debug, Deref)]
@@ -60,18 +60,21 @@ impl Many for Hostname {}
 /// A userspecifier is either a username, or a group name (TODO: user ID and group ID)
 #[derive(Debug)]
 #[cfg_attr(test, derive(Clone, PartialEq, Eq))]
-pub enum UserSpecifier {
-    User(Username),
-    Group(Username),
+pub enum Identifier {
+    Name(Username),
+    ID(u16),
 }
 
-impl Token for UserSpecifier {
+impl Token for Identifier {
     fn construct(text: String) -> Parsed<Self> {
         let mut chars = text.chars();
-        Ok(if let Some('%') = chars.next() {
-            UserSpecifier::Group(Username(chars.as_str().to_string()))
+        Ok(if let Some('#') = chars.next() {
+            match chars.as_str().parse() {
+                Ok(guid) => Identifier::ID(guid),
+                Err(err) => unrecoverable!("invalid user id: {err}"),
+            }
         } else {
-            UserSpecifier::User(Username(text))
+            Identifier::Name(Username(text))
         })
     }
 
@@ -79,11 +82,9 @@ impl Token for UserSpecifier {
         Username::accept(c)
     }
     fn accept_1st(c: char) -> bool {
-        Self::accept(c) || c == '%'
+        Self::accept(c) || c == '#'
     }
 }
-
-impl Many for UserSpecifier {}
 
 /// This enum allows items to use the ALL wildcard or be specified with aliases, or directly.
 /// (Maybe this is better defined not as a Token but simply directly as an implementation of [crate::basic_parser::Parse])

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -62,7 +62,7 @@ impl Many for Hostname {}
 #[cfg_attr(test, derive(Clone, PartialEq, Eq))]
 pub enum Identifier {
     Name(String),
-    ID(u16),
+    ID(libc::gid_t),
 }
 
 impl Token for Identifier {

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -86,6 +86,8 @@ impl Token for Identifier {
     }
 }
 
+impl Many for Identifier {}
+
 /// This enum allows items to use the ALL wildcard or be specified with aliases, or directly.
 /// (Maybe this is better defined not as a Token but simply directly as an implementation of [crate::basic_parser::Parse])
 #[derive(Debug)]

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -75,10 +75,10 @@ fn check_sudoers(context: &Context, sudo_options: &SudoOptions) -> Result<Option
     Ok(sudoers::check_permission(
         &input,
         &aliases,
-        &context.current_user.name,
-        &sudoers::UserInfo {
-            user: &context.target_user.name,
-            group: &context.target_group.name,
+        &context.current_user,
+        sudoers::Request {
+            user: &context.target_user,
+            group: &context.target_group,
         },
         &context.hostname,
         &sudo_options.external_args.join(" "),

--- a/test-binaries/checkpermit.rs
+++ b/test-binaries/checkpermit.rs
@@ -12,7 +12,7 @@ fn sudoers_parse(lines: impl Iterator<Item = String>) -> impl Iterator<Item = su
 fn chatty_check_permission(
     sudoers: impl Iterator<Item = String>,
     am_user: &str,
-    request: &sudoers::Request<&str,sudoers::GroupID>,
+    request: sudoers::Request<&str, sudoers::GroupID>,
     on_host: &str,
     chosen_poison: &str,
 ) {
@@ -22,7 +22,7 @@ fn chatty_check_permission(
     );
     let (input, aliases) = sudoers::analyze(sudoers_parse(sudoers));
     let result =
-        sudoers::check_permission(&input, &aliases, am_user, request, on_host, chosen_poison);
+        sudoers::check_permission(&input, &aliases, &am_user, request, on_host, chosen_poison);
     println!("OUTCOME: {result:?}");
 }
 
@@ -40,9 +40,12 @@ fn main() {
             chatty_check_permission(
                 cfg,
                 &args[1],
-                &sudoers::Request {
-                    user: args.get(4).unwrap_or(&"root".to_string()),
-                    group: args.get(5).map(|x|GroupID(2347,Some(x.clone()))).unwrap_or(GroupID(0,Some("root".to_owned())))
+                sudoers::Request::<&str, GroupID> {
+                    user: &args.get(4).unwrap_or(&"root".to_owned()).as_str(),
+                    group: &args
+                        .get(5)
+                        .map(|x| GroupID(2347, Some(x.clone())))
+                        .unwrap_or_else(|| (GroupID(0, Some("root".to_owned()))))
                 },
                 &args[2],
                 &args[3],

--- a/test-binaries/checkpermit.rs
+++ b/test-binaries/checkpermit.rs
@@ -12,12 +12,12 @@ fn sudoers_parse(lines: impl Iterator<Item = String>) -> impl Iterator<Item = su
 fn chatty_check_permission(
     sudoers: impl Iterator<Item = String>,
     am_user: &str,
-    request: &sudoers::UserInfo,
+    request: &sudoers::Request<&str,sudoers::GroupID>,
     on_host: &str,
     chosen_poison: &str,
 ) {
     println!(
-        "Is '{}' allowed on '{}' to run: '{}' (as {}:{})?",
+        "Is '{}' allowed on '{}' to run: '{}' (as {}:{:?})?",
         am_user, on_host, chosen_poison, request.user, request.group
     );
     let (input, aliases) = sudoers::analyze(sudoers_parse(sudoers));
@@ -31,6 +31,7 @@ use std::fs::File;
 use std::io::{self, BufRead};
 
 fn main() {
+    use sudoers::GroupID;
     let args: Vec<String> = env::args().collect();
     if let Ok(file) = File::open("./sudoers") {
         let cfg = io::BufReader::new(file).lines().map(|x| x.unwrap());
@@ -39,9 +40,9 @@ fn main() {
             chatty_check_permission(
                 cfg,
                 &args[1],
-                &sudoers::UserInfo {
+                &sudoers::Request {
                     user: args.get(4).unwrap_or(&"root".to_string()),
-                    group: args.get(5).unwrap_or(&"root".to_string())
+                    group: args.get(5).map(|x|GroupID(2347,Some(x.clone()))).unwrap_or(GroupID(0,Some("root".to_owned())))
                 },
                 &args[2],
                 &args[3],


### PR DESCRIPTION
Closing #16 

Just the parsing bit isn't that much work; code has been worked in such a way that the parser/checking routines is not doing any syscalls itself to resolve ID's to names and vice versa.