### PR TITLE
Higher level interface for sudoers parsing

### DIFF
--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -65,6 +65,7 @@ pub enum Directive {
 
 /// The Sudoers file can contain permissions and directives
 // TODO: Defaults
+#[derive(Debug)]
 pub enum Sudo {
     Spec(PermissionSpec),
     Decl(Directive),

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -176,12 +176,12 @@ impl Token for Command {
     }
 
     fn accept(c: char) -> bool {
-        !Self::escaped(c)
+        !Self::escaped(c) && !c.is_control()
     }
 
     const ESCAPE: char = '\\';
     fn escaped(c: char) -> bool {
-        "\\,:=".contains(c)
+        "\\,:=#".contains(c)
     }
 }
 

--- a/test-binaries/checkpermit.rs
+++ b/test-binaries/checkpermit.rs
@@ -1,16 +1,5 @@
-// TODO: this should give parse error messages etc.
-fn sudoers_parse(lines: impl Iterator<Item = String>) -> impl Iterator<Item = sudoers::Sudo> {
-    lines.filter_map(|text| match sudoers::parse_string(&text) {
-        Ok(x) => Some(x),
-        Err(error) => {
-            eprintln!("PARSE ERROR: {error:?}");
-            None
-        }
-    })
-}
-
 fn chatty_check_permission(
-    sudoers: impl Iterator<Item = String>,
+    sudoers: sudoers::Sudoers,
     am_user: &str,
     request: sudoers::Request<&str, sudoers::GroupID>,
     on_host: &str,
@@ -20,21 +9,19 @@ fn chatty_check_permission(
         "Is '{}' allowed on '{}' to run: '{}' (as {}:{:?})?",
         am_user, on_host, chosen_poison, request.user, request.group
     );
-    let (input, aliases) = sudoers::analyze(sudoers_parse(sudoers));
-    let result =
-        sudoers::check_permission(&input, &aliases, &am_user, request, on_host, chosen_poison);
+    let result = sudoers::check_permission(&sudoers, &am_user, request, on_host, chosen_poison);
     println!("OUTCOME: {result:?}");
 }
 
 use std::env;
-use std::fs::File;
-use std::io::{self, BufRead};
 
 fn main() {
     use sudoers::GroupID;
     let args: Vec<String> = env::args().collect();
-    if let Ok(file) = File::open("./sudoers") {
-        let cfg = io::BufReader::new(file).lines().map(|x| x.unwrap());
+    if let Ok((cfg, warn)) = sudoers::compile("./sudoers") {
+        for foobar in warn {
+            println!("ERROR: {foobar:?}")
+        }
         println!(
             "{:?}",
             chatty_check_permission(


### PR DESCRIPTION
Closing #15 

Right now sudoers::compile() just takes a filename as argument and returns an opaque Sudoers object and a list of syntax errors (the latter maybe can be handled differently later).

Squash and merge only, and merge #34 first.