### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM rust:1.67-slim-buster
+RUN apt-get update -y && apt-get install -y clang libclang-dev libpam0g-dev


### PR DESCRIPTION
Adds a minimal dockerfile to allow to build inside docker using a linux distribution (debian).
To run and mount, type:
```
$ docker build -t sudo-rs . 
$ docker run -d -it --name sudo-rs -v "$(pwd)":/sudo bash
```
find the container
```
$ docker ps -a 
$ docker exec -it<container_id> bash
```
build inside the shell: 
```
$ cd sudo
$ cargo build
```