### PR TITLE
Feature parser directives

### DIFF
--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -522,13 +522,12 @@ fn get_directive(
                     let items = parse_vars(stream)?;
                     make(Defaults(name, DefaultValue::List(Mode::Set, items)))
                 } else {
-                    //TODO: what are the precise syntactic considerations for 'string options'?
                     let text = if accept_if(|c| c == '"', stream).is_ok() {
                         let QuotedText(text) = expect_nonterminal(stream)?;
                         expect_syntax('"', stream)?;
                         text
                     } else {
-                        let EnvVar(name) = expect_nonterminal(stream)?;
+                        let StringParameter(name) = expect_nonterminal(stream)?;
                         name
                     };
                     make(Defaults(name, DefaultValue::Text(text)))

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -345,6 +345,10 @@ impl Parse for Sudo {
     // but accept:
     //   "user, User_Alias machine = command"; this does the same
     fn parse(stream: &mut Peekable<impl Iterator<Item = char>>) -> Parsed<Self> {
+	if accept_if(|c| c == '@', stream).is_ok() {
+	    return parse_include(stream)
+	}
+
         let ambiguous = stream.peek() == Some(&'#');
 
         match try_nonterminal::<SpecList<_>>(stream) {

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -55,16 +55,32 @@ pub struct Def<T>(pub String, pub SpecList<T>);
 
 /// AST object for directive specifications (aliases, arguments, etc)
 #[derive(Debug)]
-#[allow(clippy::enum_variant_names)] // this is temporary
 pub enum Directive {
     UserAlias(Def<UserSpecifier>),
     HostAlias(Def<Hostname>),
     CmndAlias(Def<Command>),
     RunasAlias(Def<UserSpecifier>),
+    Defaults(String, DefaultValue),
+}
+
+#[derive(Debug)]
+//TODO: integer values and "boolean context strings/lists/integers"
+pub enum DefaultValue {
+    Flag(bool),
+    Text(String),
+
+    // encoding: -1 = subtract, 0 = set, +1 = add
+    List(Mode, Vec<String>),
+}
+
+#[derive(Debug)]
+pub enum Mode {
+    Add,
+    Set,
+    Del,
 }
 
 /// The Sudoers file can contain permissions and directives
-// TODO: Defaults
 #[derive(Debug)]
 pub enum Sudo {
     Spec(PermissionSpec),
@@ -285,6 +301,23 @@ impl Parse for Sudo {
     }
 }
 
+// temporary stubs
+fn is_bool_param(_name: &str) -> bool {
+    true
+}
+#[allow(dead_code)]
+fn is_int_param(_name: &str) -> bool {
+    true
+}
+#[allow(dead_code)]
+fn is_string_param(_name: &str) -> bool {
+    true
+}
+#[allow(dead_code)]
+fn is_list_param(_name: &str) -> bool {
+    _name != "secure_path"
+}
+
 fn get_directive(
     perhaps_keyword: &Spec<UserSpecifier>,
     stream: &mut Peekable<impl Iterator<Item = char>>,
@@ -295,6 +328,7 @@ fn get_directive(
     use crate::ast::UserSpecifier::*;
     let Allow(Only(User(Identifier::Name(keyword)))) = perhaps_keyword else { return reject() };
 
+    /// Parse an alias definition
     fn parse_alias<T>(
         ctor: fn(Def<T>) -> Directive,
         stream: &mut Peekable<impl Iterator<Item = char>>,
@@ -308,11 +342,91 @@ fn get_directive(
         make(ctor(Def(name, expect_nonterminal(stream)?)))
     }
 
+    /// Parse multiple entries enclosed in quotes (for list-like Defaults-settings)
+    fn parse_vars(stream: &mut Peekable<impl Iterator<Item = char>>) -> Parsed<Vec<String>> {
+        if try_syntax('"', stream).is_ok() {
+            let mut result = Vec::new();
+            while let Some(EnvVar(name)) = maybe(try_nonterminal(stream))? {
+                result.push(name);
+                if try_syntax('=', stream).is_ok() {
+                    // TODO
+                    let QuotedText(_) = expect_nonterminal(stream)?;
+                    expect_syntax('"', stream)?;
+                    unrecoverable!("values in environment variables not yet supported")
+                }
+            }
+            expect_syntax('"', stream)?;
+            if result.is_empty() {
+                unrecoverable!("empty string not allowed");
+            }
+
+            make(result)
+        } else {
+            let EnvVar(name) = expect_nonterminal(stream)?;
+
+            make(vec![name])
+        }
+    }
+
+    /// Parse "Defaults" entries
+    fn parse_default(stream: &mut Peekable<impl Iterator<Item = char>>) -> Parsed<Directive> {
+        let bool_setting = |name: String, value: bool| {
+            // TODO: other types in a boolean context
+            if is_bool_param(&name) {
+                make(Defaults(name, DefaultValue::Flag(value)))
+            } else {
+                unrecoverable!("{name} is not a boolean setting");
+            }
+        };
+
+        let list_items = |mode: Mode, name: String, stream: &mut _| {
+            expect_syntax('=', stream)?;
+            if !is_list_param(&name) {
+                unrecoverable!("{name} is not a list parameter");
+            }
+            let items = parse_vars(stream)?;
+
+            make(Defaults(name, DefaultValue::List(mode, items)))
+        };
+
+        if try_syntax('!', stream).is_ok() {
+            let EnvVar(name) = expect_nonterminal(stream)?;
+            bool_setting(name, false)
+        } else {
+            let EnvVar(name) = try_nonterminal(stream)?;
+
+            if try_syntax('+', stream).is_ok() {
+                list_items(Mode::Add, name, stream)
+            } else if try_syntax('-', stream).is_ok() {
+                list_items(Mode::Del, name, stream)
+            } else if try_syntax('=', stream).is_ok() {
+                if is_list_param(&name) {
+                    let items = parse_vars(stream)?;
+                    make(Defaults(name, DefaultValue::List(Mode::Set, items)))
+                } else {
+                    //TODO: what are the precise syntactic considerations for 'string options'?
+                    let text = if try_syntax('"', stream).is_ok() {
+                        let QuotedText(text) = expect_nonterminal(stream)?;
+                        expect_syntax('"', stream)?;
+                        text
+                    } else {
+                        let EnvVar(name) = expect_nonterminal(stream)?;
+                        name
+                    };
+                    make(Defaults(name, DefaultValue::Text(text)))
+                }
+            } else {
+                bool_setting(name, true)
+            }
+        }
+    }
+
     match keyword.as_str() {
         "User_Alias" => parse_alias(UserAlias, stream),
         "Host_Alias" => parse_alias(HostAlias, stream),
         "Cmnd_Alias" | "Cmd_Alias" => parse_alias(CmndAlias, stream),
         "Runas_Alias" => parse_alias(RunasAlias, stream),
+        "Defaults" => parse_default(stream),
         _ => reject(),
     }
 }

--- a/lib/sudoers/src/basic_parser.rs
+++ b/lib/sudoers/src/basic_parser.rs
@@ -13,7 +13,7 @@
 //! impl<T: Parse> Parse for LinkedList<T> {
 //!     fn parse(stream: &mut Peekable<impl Iterator<Item = char>>) -> Parsed<LinkedList<T>> {
 //!         let x = try_nonterminal(stream)?;
-//!         let mut tail = if maybe(try_syntax('+', stream))?.is_some() {
+//!         let mut tail = if is_syntax('+', stream)? {
 //!             expect_nonterminal(stream)?
 //!         } else {
 //!             LinkedList::new()
@@ -188,6 +188,12 @@ pub fn expect_syntax(
         unrecoverable!("parse error: expecting `{syntax}' but found `{str}'")
     }
     make(())
+}
+
+/// Convenience function: usually try_syntax is called as a test criterion; if this returns true, the input was consumed.
+pub fn is_syntax(syntax: char, stream: &mut Peekable<impl Iterator<Item = char>>) -> Parsed<bool> {
+    let result = maybe(try_syntax(syntax, stream))?;
+    make(result.is_some())
 }
 
 /// Interface for working with types that implement the [Parse] trait; this allows parsing to use

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -561,6 +561,10 @@ mod test {
         assert_eq!(x, "foo bar");
         // this is fine
         let Sudo::LineComment = parse_line("#inlcudedir foo") else { panic!() };
+        let Sudo::Include(_) = parse_line("@include foo") else { panic!() };
+        let Sudo::IncludeDir(_) = parse_line("@includedir foo") else { panic!() };
+        let Sudo::Include(x) = parse_line("@include \"foo bar\"") else { panic!() };
+        assert_eq!(x, "foo bar");
     }
 
     #[test]

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -266,6 +266,8 @@ fn analyze(sudoers: impl IntoIterator<Item = Sudo>) -> (Vec<PermissionSpec>, Ali
 
     for item in sudoers {
         match item {
+            Sudo::LineComment => {}
+
             Sudo::Spec(permission) => permits.push(permission),
 
             Sudo::Decl(UserAlias(def)) => alias.user.1.push(def),

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -298,6 +298,9 @@ fn analyze(sudoers: impl IntoIterator<Item = Sudo>) -> (Vec<PermissionSpec>, Ali
                     }
                 }
             }
+
+            Sudo::Include(_path) => todo!(),
+            Sudo::IncludeDir(_path) => todo!(),
         }
     }
 
@@ -552,7 +555,18 @@ mod test {
         let Sudo::Decl(_) = parse_line("User_Alias FOO=#42, %#0, #3") else { panic!() };
         let Sudo::LineComment = parse_line("") else { panic!() };
         let Sudo::LineComment = parse_line("#this is a comment") else { panic!() };
-        let Sudo::LineComment = parse_line("#include foo") else { panic!() };
+        let Sudo::Include(_) = parse_line("#include foo") else { panic!() };
+        let Sudo::IncludeDir(_) = parse_line("#includedir foo") else { panic!() };
+        let Sudo::Include(x) = parse_line("#include \"foo bar\"") else { panic!() };
+        assert_eq!(x, "foo bar");
+        // this is fine
+        let Sudo::LineComment = parse_line("#inlcudedir foo") else { panic!() };
+    }
+
+    #[test]
+    #[should_panic]
+    fn hashsign_error() {
+        let Sudo::Include(_) = parse_line("#include foo bar") else { todo!() };
     }
 
     fn test_topo_sort(n: usize) {

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -573,6 +573,12 @@ mod test {
         let Sudo::Include(_) = parse_line("#include foo bar") else { todo!() };
     }
 
+    #[test]
+    #[should_panic]
+    fn include_regression() {
+        let Sudo::Include(_) = parse_line("#4,#include foo") else { todo!() };
+    }
+
     fn test_topo_sort(n: usize) {
         let alias = |s: &str| Qualified::Allow(Meta::<UserSpecifier>::Alias(s.to_string()));
         let stop = || Qualified::Allow(Meta::<UserSpecifier>::All);

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -299,8 +299,8 @@ fn analyze(sudoers: impl IntoIterator<Item = Sudo>) -> (Vec<PermissionSpec>, Ali
                 }
             }
 
-            Sudo::Include(_path) => todo!(),
-            Sudo::IncludeDir(_path) => todo!(),
+            Sudo::Include(path) => eprintln!("TODO: this would include the file {path}"),
+            Sudo::IncludeDir(path) => eprintln!("TODO: this would include the folder {path}"),
         }
     }
 

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -390,6 +390,11 @@ mod test {
         }
     }
 
+    // alternative to parse_eval, but goes through sudoer! directly
+    fn parse_line(s: &str) -> Sudo {
+        sudoer![s].next().unwrap()
+    }
+
     impl UnixGroup for (u16, &str) {
         fn try_as_name(&self) -> Option<&str> {
             Some(self.1)
@@ -535,6 +540,19 @@ mod test {
             }
             _ => panic!("incorrectly parsed"),
         }
+    }
+
+    #[test]
+    // the overloading of '#' causes a lot of issues
+    fn hashsign_test() {
+        let Sudo::Spec(_) = parse_line("#42 ALL=ALL") else { panic!() };
+        let Sudo::Spec(_) = parse_line("ALL ALL=(#42) ALL") else { panic!() };
+        let Sudo::Spec(_) = parse_line("ALL ALL=(%#42) ALL") else { panic!() };
+        let Sudo::Spec(_) = parse_line("ALL ALL=(:#42) ALL") else { panic!() };
+        let Sudo::Decl(_) = parse_line("User_Alias FOO=#42, %#0, #3") else { panic!() };
+        let Sudo::LineComment = parse_line("") else { panic!() };
+        let Sudo::LineComment = parse_line("#this is a comment") else { panic!() };
+        let Sudo::LineComment = parse_line("#include foo") else { panic!() };
     }
 
     fn test_topo_sort(n: usize) {

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -222,3 +222,23 @@ impl Token for IncludePath {
         "\\\" ".contains(c)
     }
 }
+
+// used for Defaults where
+pub struct StringParameter(pub String);
+
+impl Token for StringParameter {
+    const MAX_LEN: usize = QuotedText::MAX_LEN;
+
+    fn construct(s: String) -> Parsed<Self> {
+        Ok(StringParameter(s))
+    }
+
+    fn accept(c: char) -> bool {
+        !c.is_control() && !Self::escaped(c)
+    }
+
+    const ESCAPE: char = '\\';
+    fn escaped(c: char) -> bool {
+        "\\\" #".contains(c)
+    }
+}

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -186,3 +186,36 @@ impl Token for Command {
 }
 
 impl Many for Command {}
+
+/// An environment variable name pattern consists of alphanumeric characters as well as "_", "%" and wildcard "*"
+/// (Value patterns are not supported yet)
+pub struct EnvVar(pub String);
+
+impl Token for EnvVar {
+    fn construct(text: String) -> Parsed<Self> {
+        Ok(EnvVar(text))
+    }
+
+    fn accept(c: char) -> bool {
+        c.is_ascii_alphanumeric() || "*_%".contains(c)
+    }
+}
+
+pub struct QuotedText(pub String);
+
+impl Token for QuotedText {
+    const MAX_LEN: usize = 1024;
+
+    fn construct(s: String) -> Parsed<Self> {
+        Ok(QuotedText(s))
+    }
+
+    fn accept(c: char) -> bool {
+        !Self::escaped(c)
+    }
+
+    const ESCAPE: char = '\\';
+    fn escaped(c: char) -> bool {
+        "\\\"".contains(c) || c.is_control()
+    }
+}

--- a/test-binaries/checkpermit.rs
+++ b/test-binaries/checkpermit.rs
@@ -22,6 +22,7 @@ fn main() {
         for foobar in warn {
             println!("ERROR: {foobar:?}")
         }
+        println!("SETTINGS: {:?}", cfg.settings);
         println!(
             "{:?}",
             chatty_check_permission(

--- a/test-binaries/sudoers
+++ b/test-binaries/sudoers
@@ -2,12 +2,16 @@ Defaults	env_reset
 Defaults	env_keep = "AAP NOOT MIES"
 Defaults	env_keep += "MIES WIM ZUS JET" * AAP
 Defaults	env_keep -= "AAP NOOT ZUS JET"
+
 Defaults	mail_badpass
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
 Defaults	use_pty
 Defaults        env_delete="BASH_FUNC_foo%%=()*"
+
 piet, jan vm,laptop=(piet,jan:wheel,backup) ALL : ALL=(ALL) TIMEOUT=123 /bin/echo : tg=(:ALL) NOPASSWD: /bin/ls
+
 roost ALL=(ALL:ALL) /bin/user
 %roost ALL=(ALL:ALL) /bin/group
+
 User_Alias WHEEL = ALL,!piet
 WHEEL laptop=(ALL:ALL) NOPASSWD: /bin/sh whelp

--- a/test-binaries/sudoers
+++ b/test-binaries/sudoers
@@ -1,3 +1,11 @@
+Defaults	env_reset
+Defaults	env_keep = "AAP NOOT MIES"
+Defaults	env_keep += "MIES WIM ZUS JET" * AAP
+Defaults	env_keep -= "AAP NOOT ZUS JET"
+Defaults	mail_badpass
+Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+Defaults	use_pty
+Defaults        env_delete="BASH_FUNC_foo%%=()*"
 piet, jan vm,laptop=(piet,jan:wheel,backup) ALL : ALL=(ALL) TIMEOUT=123 /bin/echo : tg=(:ALL) NOPASSWD: /bin/ls
 roost ALL=(ALL:ALL) /bin/user
 %roost ALL=(ALL:ALL) /bin/group


### PR DESCRIPTION
We can now parse small but actual sudoers files.

(This PR mostly adds support for directives Defaults (preliminary support: typing info is needed), #include/@include, and parsing empty lines.