### PR TITLE
Nicer error messages

### DIFF
--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -290,12 +290,12 @@ impl Parse for CommandSpec {
                 "sha384" => 384,
                 "sha512" => 512,
                 "sudoedit" => todo!(), // note: special behaviour of forward slashes in wildcards, tread carefully
-                _ => unrecoverable!("parse error: expected command but found {keyword}"),
+                _ => unrecoverable!(stream, "parse error: expected command but found {keyword}"),
             };
             expect_syntax(':', stream)?;
             let hex = expect_nonterminal::<Sha2>(stream)?;
             if 8 * hex.0.len() != hash_type {
-                unrecoverable!("parse error: digest length incorrect for sha{hash_type}")
+                unrecoverable!(stream, "parse error: digest length incorrect for sha{hash_type}")
             };
 
             hex

--- a/lib/sudoers/src/ast_names.rs
+++ b/lib/sudoers/src/ast_names.rs
@@ -1,0 +1,91 @@
+/// This module contains user-friendly names for the various items in the AST, to report in case they are missing
+
+pub trait UserFriendly {
+    const DESCRIPTION: &'static str;
+}
+
+// this is in a submodule so it can be switched off and replaced by a blanket implementation for test-cases
+#[cfg(not(test))]
+mod names {
+    use super::*;
+    use crate::ast::*;
+    use crate::tokens;
+
+    impl UserFriendly for tokens::Digits {
+        const DESCRIPTION: &'static str = "number";
+    }
+
+    impl UserFriendly for tokens::Decimal {
+        const DESCRIPTION: &'static str = "number";
+    }
+
+    impl UserFriendly for Identifier {
+        const DESCRIPTION: &'static str = "identifier";
+    }
+
+    impl<T: UserFriendly> UserFriendly for Vec<T> {
+        const DESCRIPTION: &'static str = T::DESCRIPTION;
+    }
+
+    impl<T: UserFriendly> UserFriendly for tokens::Meta<T> {
+        const DESCRIPTION: &'static str = T::DESCRIPTION;
+    }
+
+    impl<T: UserFriendly> UserFriendly for Qualified<T> {
+        const DESCRIPTION: &'static str = T::DESCRIPTION;
+    }
+
+    impl UserFriendly for tokens::Command {
+        const DESCRIPTION: &'static str = "path to binary (or sudoedit)";
+    }
+
+    impl UserFriendly for CommandSpec {
+        const DESCRIPTION: &'static str = tokens::Command::DESCRIPTION;
+    }
+
+    impl UserFriendly for (SpecList<tokens::Hostname>, Option<RunAs>, Vec<CommandSpec>) {
+        const DESCRIPTION: &'static str = tokens::Hostname::DESCRIPTION;
+    }
+
+    // this can never happen, as parse<Sudo> always succeeds
+    impl UserFriendly for Sudo {
+        const DESCRIPTION: &'static str = "nothing";
+    }
+
+    impl UserFriendly for UserSpecifier {
+        const DESCRIPTION: &'static str = "user";
+    }
+
+    impl UserFriendly for tokens::Hostname {
+        const DESCRIPTION: &'static str = "host name";
+    }
+
+    impl UserFriendly for tokens::QuotedText {
+        const DESCRIPTION: &'static str = "non-empty string";
+    }
+
+    impl UserFriendly for tokens::StringParameter {
+        const DESCRIPTION: &'static str = tokens::QuotedText::DESCRIPTION;
+    }
+
+    impl UserFriendly for tokens::IncludePath {
+        const DESCRIPTION: &'static str = "path to file";
+    }
+
+    impl UserFriendly for tokens::Upper {
+        const DESCRIPTION: &'static str = "alias name";
+    }
+
+    impl UserFriendly for tokens::EnvVar {
+        const DESCRIPTION: &'static str = "environment variable";
+    }
+
+    impl UserFriendly for tokens::Sha2 {
+        const DESCRIPTION: &'static str = "digest";
+    }
+}
+
+#[cfg(test)]
+impl<T: crate::basic_parser::Parse> UserFriendly for T {
+    const DESCRIPTION: &'static str = "elem";
+}

--- a/lib/sudoers/src/basic_parser.rs
+++ b/lib/sudoers/src/basic_parser.rs
@@ -33,8 +33,8 @@ pub type Position = (usize, usize);
 #[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum Status {
-    Fatal(Option<Position>, String), // not recoverable; stream in inconsistent state
-    Reject,                          // parsing failed by no input consumed
+    Fatal(Position, String), // not recoverable; stream in inconsistent state
+    Reject,                  // parsing failed by no input consumed
 }
 
 pub fn make<T>(value: T) -> Parsed<T> {
@@ -47,7 +47,7 @@ pub fn reject<T>() -> Parsed<T> {
 
 macro_rules! unrecoverable {
     ($stream:ident, $($str:expr),*) => {
-        return Err(crate::basic_parser::Status::Fatal(Some($stream.get_pos()),format![$($str),*]))
+        return Err(crate::basic_parser::Status::Fatal($stream.get_pos(),format![$($str),*]))
     };
     ($($str:expr),*) => {
         return Err(crate::basic_parser::Status::Fatal(None,format![$($str),*]))

--- a/lib/sudoers/src/char_stream.rs
+++ b/lib/sudoers/src/char_stream.rs
@@ -41,6 +41,7 @@ impl<Iter: Iterator<Item = char>> CharStream for PeekableWithPos<Iter> {
     }
 }
 
+#[cfg(test)]
 impl<Iter: Iterator<Item = char>> CharStream for std::iter::Peekable<Iter> {
     fn advance(&mut self) {
         self.next();

--- a/lib/sudoers/src/char_stream.rs
+++ b/lib/sudoers/src/char_stream.rs
@@ -1,0 +1,56 @@
+pub trait CharStream {
+    fn advance(&mut self);
+    fn peek(&mut self) -> Option<char>;
+    fn get_pos(&self) -> (usize, usize);
+}
+
+pub struct PeekableWithPos<Iter: Iterator> {
+    iter: std::iter::Peekable<Iter>,
+    line: usize,
+    col: usize,
+}
+
+impl<Iter: Iterator<Item = char>> PeekableWithPos<Iter> {
+    pub fn new(src: Iter) -> Self {
+        PeekableWithPos {
+            iter: src.peekable(),
+            line: 1,
+            col: 1,
+        }
+    }
+}
+
+impl<Iter: Iterator<Item = char>> CharStream for PeekableWithPos<Iter> {
+    fn advance(&mut self) {
+        match self.iter.next() {
+            Some('\n') => {
+                self.line += 1;
+                self.col = 1;
+            }
+            Some(_) => self.col += 1,
+            _ => {}
+        }
+    }
+
+    fn peek(&mut self) -> Option<char> {
+        self.iter.peek().cloned()
+    }
+
+    fn get_pos(&self) -> (usize, usize) {
+        (self.line, self.col)
+    }
+}
+
+impl<Iter: Iterator<Item = char>> CharStream for std::iter::Peekable<Iter> {
+    fn advance(&mut self) {
+        self.next();
+    }
+
+    fn peek(&mut self) -> Option<char> {
+        self.peek().cloned()
+    }
+
+    fn get_pos(&self) -> (usize, usize) {
+        (0, 0)
+    }
+}

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -1,6 +1,7 @@
 //! Code that checks (and in the future: lists) permissions in the sudoers file
 
 mod ast;
+mod ast_names;
 mod basic_parser;
 mod char_stream;
 mod tokens;

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -17,7 +17,7 @@ const INCLUDE_LIMIT: u8 = 128;
 
 /// Export some necessary symbols from modules
 pub use ast::Tag;
-pub type Error = basic_parser::Status;
+pub struct Error(pub Option<basic_parser::Position>, pub String);
 
 #[derive(Default)]
 pub struct Sudoers {
@@ -254,7 +254,7 @@ fn analyze(sudoers: impl IntoIterator<Item = basic_parser::Parsed<Sudo>>) -> (Su
     impl Sudoers {
         fn include(&mut self, path: &Path, diagnostics: &mut Vec<Error>, count: &mut u8) {
             if *count >= INCLUDE_LIMIT {
-                diagnostics.push(Error::Fatal(
+                diagnostics.push(Error(
                     None,
                     format!("include file limit reached opening `{}'", path.display()),
                 ))
@@ -262,7 +262,7 @@ fn analyze(sudoers: impl IntoIterator<Item = basic_parser::Parsed<Sudo>>) -> (Su
                 *count += 1;
                 self.process(subsudoer, diagnostics, count)
             } else {
-                diagnostics.push(Error::Fatal(
+                diagnostics.push(Error(
                     None,
                     format!("cannot open sudoers file `{}'", path.display()),
                 ))
@@ -317,7 +317,7 @@ fn analyze(sudoers: impl IntoIterator<Item = basic_parser::Parsed<Sudo>>) -> (Su
 
                         Sudo::IncludeDir(path) => {
                             let Ok(files) = std::fs::read_dir(&path) else {
-                                diagnostics.push(Error::Fatal(None,format!("cannot open sudoers file {path}")));
+                                diagnostics.push(Error(None, format!("cannot open sudoers file {path}")));
                                 continue;
                             };
                             let mut safe_files = files
@@ -338,7 +338,10 @@ fn analyze(sudoers: impl IntoIterator<Item = basic_parser::Parsed<Sudo>>) -> (Su
                         }
                     },
 
-                    Err(error) => diagnostics.push(error),
+                    Err(basic_parser::Status::Fatal(pos, error)) => {
+                        diagnostics.push(Error(Some(pos), error))
+                    }
+                    Err(_) => panic!("internal parser error"),
                 }
             }
         }
@@ -378,7 +381,7 @@ fn sanitize_alias_table<T>(table: &Vec<Def<T>>, diagnostics: &mut Vec<Error>) ->
 
     impl<T> Visitor<'_, T> {
         fn complain(&mut self, text: String) {
-            self.diagnostics.push(Error::Fatal(None, text))
+            self.diagnostics.push(Error(None, text))
         }
 
         fn visit(&mut self, pos: usize) {

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -143,7 +143,7 @@ impl Token for Command {
 
     fn construct(s: String) -> Parsed<Self> {
         let cvt_err = |pat: Result<_, glob::PatternError>| {
-            pat.map_err(|err| Status::Fatal(format!("wildcard pattern error {}", err.msg)))
+            pat.map_err(|err| Status::Fatal(None, format!("wildcard pattern error {}", err.msg)))
         };
         let mut cmdvec = split_args(&s);
         if cmdvec.len() == 1 {
@@ -260,7 +260,10 @@ impl Token for Sha2 {
             .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
             .collect::<Result<_, _>>()
             .map_err(|_| {
-                Status::Fatal("should not happen: hexadecimal decoding failed".to_string())
+                Status::Fatal(
+                    None,
+                    "should not happen: hexadecimal decoding failed".to_string(),
+                )
             })?;
 
         Ok(Sha2(bytes.into_boxed_slice()))

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -159,6 +159,11 @@ impl Token for Command {
         Ok((cmd, args))
     }
 
+    // all commands start with "/" except "sudoedit"
+    fn accept_1st(c: char) -> bool {
+        c == '/' || c == 's'
+    }
+
     fn accept(c: char) -> bool {
         !Self::escaped(c) && !c.is_control()
     }
@@ -223,7 +228,7 @@ impl Token for IncludePath {
     }
 }
 
-// used for Defaults where
+// used for Defaults where quotes around some items are optional
 pub struct StringParameter(pub String);
 
 impl Token for StringParameter {

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -10,8 +10,8 @@ fn check_sudoers(context: &Context, sudo_options: &SudoOptions) -> Result<Option
     let (sudoers, syntax_errors) = sudoers::compile(sudoers_path)
         .map_err(|e| Error::Configuration(format!("no sudoers file {e}")))?;
 
-    for error in syntax_errors {
-        eprintln!("Parse error: {error:?}");
+    for sudoers::Error(_pos, error) in syntax_errors {
+        eprintln!("Parse error: {error}");
     }
 
     Ok(sudoers::check_permission(

--- a/test-binaries/checkpermit.rs
+++ b/test-binaries/checkpermit.rs
@@ -1,4 +1,3 @@
-use std::env;
 use sudo_common::sysuser::{UnixGroup, UnixUser};
 
 fn chatty_check_permission(
@@ -64,11 +63,34 @@ impl UnixUser for UserRecord {
     }
 }
 
+fn fancy_error(x: usize, y: usize, path: &str) {
+    use std::io::*;
+    let inp = BufReader::new(std::fs::File::open(path).unwrap());
+    let line = inp.lines().nth(x - 1).unwrap().unwrap();
+    eprintln!("{line}");
+    for (i, c) in line.chars().enumerate() {
+        if i == y - 1 {
+            break;
+        }
+        if c.is_whitespace() {
+            eprint!("{c}");
+        } else {
+            eprint!(" ");
+        }
+    }
+    eprintln!("^");
+}
+
+use std::env;
+
 fn main() {
     let args: Vec<String> = env::args().collect();
     if let Ok((cfg, warn)) = sudoers::compile("./sudoers") {
-        for foobar in warn {
-            println!("ERROR: {foobar:?}")
+        for sudoers::Error(pos, msg) in warn {
+            if let Some((x, y)) = pos {
+                fancy_error(x, y, "./sudoers");
+            }
+            eprintln!("{msg}");
         }
         println!("SETTINGS: {:?}", cfg.settings);
         println!(


### PR DESCRIPTION
This adds position info to the parser errors, and gives a custom error type to the caller. Some todo remains: the analyzer doesn't give position info (since it isn't stored in the AST yet) and it is possible (in the `pos=` cases) to give 'begin' and 'end' position information in the error type. But the major changes to the AST (i.e. introduce the CharStream trait) are ready  to be merged already.