### PR TITLE
change cmdline passed to sudoers-check to use a Path + arguments

### DIFF
--- a/lib/sudo-common/src/context.rs
+++ b/lib/sudo-common/src/context.rs
@@ -11,16 +11,6 @@ pub struct CommandAndArguments<'a> {
     pub arguments: Vec<&'a str>,
 }
 
-impl<'a> ToString for CommandAndArguments<'a> {
-    fn to_string(&self) -> String {
-        format!(
-            "{} {}",
-            self.command.to_string_lossy(),
-            self.arguments.join(" ")
-        )
-    }
-}
-
 impl<'a> TryFrom<&'a [String]> for CommandAndArguments<'a> {
     type Error = Error;
 

--- a/lib/sudoers/src/compute_hash.rs
+++ b/lib/sudoers/src/compute_hash.rs
@@ -1,9 +1,9 @@
-pub fn sha2(bits: u16, path: &str) -> Box<[u8]> {
+pub fn sha2(bits: u16, path: &std::path::Path) -> Box<[u8]> {
     use digest::{Digest, DynDigest};
 
     fn compute_hash(
         mut hasher: Box<dyn DynDigest>,
-        path: &str,
+        path: &std::path::Path,
     ) -> Result<Box<[u8]>, std::io::Error> {
         use std::fs::File;
         use std::io::{BufRead, BufReader};
@@ -38,7 +38,7 @@ pub fn sha2(bits: u16, path: &str) -> Box<[u8]> {
 mod test {
     #[test]
     fn check_hash() {
-        let file_to_check = "/bin/more";
+        let file_to_check = std::path::Path::new("/bin/more");
         use crate::basic_parser::parse_eval;
         use crate::tokens::Sha2;
         use std::process::Command;

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -141,10 +141,6 @@ impl Token for Upper {
 /// limited to 1024 characters.
 pub type Command = (glob::Pattern, glob::Pattern);
 
-pub fn split_args(text: &str) -> Vec<&str> {
-    text.split_whitespace().collect::<Vec<_>>()
-}
-
 impl Token for Command {
     const MAX_LEN: usize = 1024;
 
@@ -152,7 +148,7 @@ impl Token for Command {
         let cvt_err = |pat: Result<_, glob::PatternError>| {
             pat.map_err(|err| format!("wildcard pattern error {err}"))
         };
-        let mut cmdvec = split_args(&s);
+        let mut cmdvec = s.split_whitespace().collect::<Vec<_>>();
         if cmdvec.len() == 1 {
             // if no arguments are mentioned, anything is allowed
             cmdvec.push("*");

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -23,12 +23,13 @@ fn check_sudoers(sudoers: &Sudoers, context: &Context) -> Result<Option<Vec<Tag>
     Ok(sudoers::check_permission(
         sudoers,
         &context.current_user,
+        &context.hostname,
         sudoers::Request {
             user: &context.target_user,
             group: &context.target_group,
+            command: &context.command.command,
+            arguments: &context.command.arguments.join(" "),
         },
-        &context.hostname,
-        context.command.to_string().as_str(),
     ))
 }
 

--- a/test-binaries/checkpermit.rs
+++ b/test-binaries/checkpermit.rs
@@ -12,15 +12,20 @@ fn chatty_check_permission(
         "Is '{}' allowed on '{}' to run: '{}' (as {}:{})?",
         am_user, on_host, chosen_poison, user, group
     );
+    let (command, arguments) = {
+        let mut items = chosen_poison.split_whitespace();
+        (items.next().unwrap(), items.collect::<Vec<_>>().join(" "))
+    };
     let result = sudoers::check_permission(
         &sudoers,
         &am_user,
+        on_host,
         sudoers::Request {
             user: &user,
             group: &group,
+            command: command.as_ref(),
+            arguments: &arguments,
         },
-        on_host,
-        chosen_poison,
     );
     println!("OUTCOME: {result:?}");
 }


### PR DESCRIPTION
The sudoers checker internally split the command it was passed into a "binary" and "arguments" part (for wildcard matching); on the caller side this string was made by concatenating the binary and the arguments. This PR fixes that.

This also fixes a bug (discovered by this refactor), where a SHA2 digest would be computed by trying to open the complete argument as a file.

Also there is a small refactor so that the command and arguments are now bundled into the `Request` structure (the idea is now that this structure marks the things that are "under user control", whereas `am_user` and `on_host` are under system control, i.e. the request is the thing being checked)

Closing issue #64 