### PR TITLE
compliance tests: password auth & sudoers' user_list

### DIFF
--- a/test-framework/sudo-compliance-tests/src/nopasswd.rs
+++ b/test-framework/sudo-compliance-tests/src/nopasswd.rs
@@ -31,6 +31,32 @@ fn root_can_sudo_without_providing_a_password_if_roots_group_is_in_sudoers_file(
 }
 
 #[test]
+fn root_can_sudo_without_providing_a_password_if_roots_user_id_is_in_sudoers_file() -> Result<()> {
+    let env = EnvBuilder::default()
+        .sudoers("#0 ALL=(ALL:ALL) ALL")
+        .build()?;
+
+    let output = env.exec(&["sudo", "true"], As::Root, None)?;
+    assert!(output.status.success(), "{}", output.stderr);
+
+    Ok(())
+}
+
+#[ignore]
+#[test]
+fn root_can_sudo_without_providing_a_password_if_roots_group_id_is_in_sudoers_file() -> Result<()> {
+    let env = EnvBuilder::default()
+        .sudoers("%#0 ALL=(ALL:ALL) ALL")
+        .build()?;
+
+    let output = env.exec(&["sudo", "true"], As::Root, None)?;
+    assert!(output.status.success(), "{}", output.stderr);
+
+    Ok(())
+}
+
+#[ignore]
+#[test]
 fn user_can_sudo_without_providing_a_password_if_users_group_is_in_sudoers_file_and_nopasswd_is_set(
 ) -> Result<()> {
     let username = "ferris";

--- a/test-framework/sudo-compliance-tests/src/nopasswd.rs
+++ b/test-framework/sudo-compliance-tests/src/nopasswd.rs
@@ -4,82 +4,16 @@ use sudo_test::{As, EnvBuilder};
 
 use crate::{Result, SUDOERS_ROOT_ALL};
 
+// NOTE all these tests assume that the invoking user passes the sudoers file 'User_List' criteria
+
 // man sudoers > User Authentication:
 // "A password is not required if the invoking user is root"
 #[ignore]
 #[test]
-fn root_can_sudo_if_root_user_is_in_sudoers_file() -> Result<()> {
+fn user_is_root() -> Result<()> {
     let env = EnvBuilder::default().sudoers(SUDOERS_ROOT_ALL).build()?;
 
     let output = env.exec(&["sudo", "true"], As::Root, None)?;
-    assert!(output.status.success(), "{}", output.stderr);
-
-    Ok(())
-}
-
-#[ignore]
-#[test]
-fn root_can_sudo_if_roots_group_is_in_sudoers_file() -> Result<()> {
-    let env = EnvBuilder::default()
-        .sudoers("%root    ALL=(ALL:ALL) ALL")
-        .build()?;
-
-    let output = env.exec(&["sudo", "true"], As::Root, None)?;
-    assert!(output.status.success(), "{}", output.stderr);
-
-    Ok(())
-}
-
-#[test]
-fn root_can_sudo_if_roots_user_id_is_in_sudoers_file() -> Result<()> {
-    let env = EnvBuilder::default()
-        .sudoers("#0 ALL=(ALL:ALL) ALL")
-        .build()?;
-
-    let output = env.exec(&["sudo", "true"], As::Root, None)?;
-    assert!(output.status.success(), "{}", output.stderr);
-
-    Ok(())
-}
-
-#[ignore]
-#[test]
-fn root_can_sudo_if_roots_group_id_is_in_sudoers_file() -> Result<()> {
-    let env = EnvBuilder::default()
-        .sudoers("%#0 ALL=(ALL:ALL) ALL")
-        .build()?;
-
-    let output = env.exec(&["sudo", "true"], As::Root, None)?;
-    assert!(output.status.success(), "{}", output.stderr);
-
-    Ok(())
-}
-
-#[ignore]
-#[test]
-fn user_can_sudo_if_users_group_is_in_sudoers_file_and_nopasswd_is_set() -> Result<()> {
-    let username = "ferris";
-    let groupname = "rustaceans";
-    let env = EnvBuilder::default()
-        .sudoers(&format!("%{groupname}    ALL=(ALL:ALL) NOPASSWD: ALL"))
-        .user(username, &[groupname])
-        .build()?;
-
-    let output = env.exec(&["sudo", "true"], As::User { name: username }, None)?;
-    assert!(output.status.success(), "{}", output.stderr);
-
-    Ok(())
-}
-
-#[test]
-fn user_can_sudo_if_user_is_in_sudoers_file_and_nopasswd_is_set() -> Result<()> {
-    let username = "ferris";
-    let env = EnvBuilder::default()
-        .sudoers(&format!("{username}    ALL=(ALL:ALL) NOPASSWD: ALL"))
-        .user(username, &["rustaceans"])
-        .build()?;
-
-    let output = env.exec(&["sudo", "true"], As::User { name: username }, None)?;
     assert!(output.status.success(), "{}", output.stderr);
 
     Ok(())
@@ -89,7 +23,7 @@ fn user_can_sudo_if_user_is_in_sudoers_file_and_nopasswd_is_set() -> Result<()> 
 // "A password is not required if (..) the target user is the same as the invoking user"
 #[ignore]
 #[test]
-fn user_can_sudo_as_themselves() -> Result<()> {
+fn user_as_themselves() -> Result<()> {
     let username = "ferris";
     let env = EnvBuilder::default()
         .user(username, &[])
@@ -102,6 +36,20 @@ fn user_can_sudo_as_themselves() -> Result<()> {
         None,
     )?;
 
+    assert!(output.status.success(), "{}", output.stderr);
+
+    Ok(())
+}
+
+#[test]
+fn nopasswd_tag() -> Result<()> {
+    let username = "ferris";
+    let env = EnvBuilder::default()
+        .sudoers(&format!("{username}    ALL=(ALL:ALL) NOPASSWD: ALL"))
+        .user(username, &[])
+        .build()?;
+
+    let output = env.exec(&["sudo", "true"], As::User { name: username }, None)?;
     assert!(output.status.success(), "{}", output.stderr);
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/nopasswd.rs
+++ b/test-framework/sudo-compliance-tests/src/nopasswd.rs
@@ -8,7 +8,7 @@ use crate::{Result, SUDOERS_ROOT_ALL};
 // "A password is not required if the invoking user is root"
 #[ignore]
 #[test]
-fn root_can_sudo_without_providing_a_password_if_root_user_is_in_sudoers_file() -> Result<()> {
+fn root_can_sudo_if_root_user_is_in_sudoers_file() -> Result<()> {
     let env = EnvBuilder::default().sudoers(SUDOERS_ROOT_ALL).build()?;
 
     let output = env.exec(&["sudo", "true"], As::Root, None)?;
@@ -19,7 +19,7 @@ fn root_can_sudo_without_providing_a_password_if_root_user_is_in_sudoers_file() 
 
 #[ignore]
 #[test]
-fn root_can_sudo_without_providing_a_password_if_roots_group_is_in_sudoers_file() -> Result<()> {
+fn root_can_sudo_if_roots_group_is_in_sudoers_file() -> Result<()> {
     let env = EnvBuilder::default()
         .sudoers("%root    ALL=(ALL:ALL) ALL")
         .build()?;
@@ -31,7 +31,7 @@ fn root_can_sudo_without_providing_a_password_if_roots_group_is_in_sudoers_file(
 }
 
 #[test]
-fn root_can_sudo_without_providing_a_password_if_roots_user_id_is_in_sudoers_file() -> Result<()> {
+fn root_can_sudo_if_roots_user_id_is_in_sudoers_file() -> Result<()> {
     let env = EnvBuilder::default()
         .sudoers("#0 ALL=(ALL:ALL) ALL")
         .build()?;
@@ -44,7 +44,7 @@ fn root_can_sudo_without_providing_a_password_if_roots_user_id_is_in_sudoers_fil
 
 #[ignore]
 #[test]
-fn root_can_sudo_without_providing_a_password_if_roots_group_id_is_in_sudoers_file() -> Result<()> {
+fn root_can_sudo_if_roots_group_id_is_in_sudoers_file() -> Result<()> {
     let env = EnvBuilder::default()
         .sudoers("%#0 ALL=(ALL:ALL) ALL")
         .build()?;
@@ -57,8 +57,7 @@ fn root_can_sudo_without_providing_a_password_if_roots_group_id_is_in_sudoers_fi
 
 #[ignore]
 #[test]
-fn user_can_sudo_without_providing_a_password_if_users_group_is_in_sudoers_file_and_nopasswd_is_set(
-) -> Result<()> {
+fn user_can_sudo_if_users_group_is_in_sudoers_file_and_nopasswd_is_set() -> Result<()> {
     let username = "ferris";
     let groupname = "rustaceans";
     let env = EnvBuilder::default()
@@ -73,8 +72,7 @@ fn user_can_sudo_without_providing_a_password_if_users_group_is_in_sudoers_file_
 }
 
 #[test]
-fn user_can_sudo_without_providing_a_password_if_user_is_in_sudoers_file_and_nopasswd_is_set(
-) -> Result<()> {
+fn user_can_sudo_if_user_is_in_sudoers_file_and_nopasswd_is_set() -> Result<()> {
     let username = "ferris";
     let env = EnvBuilder::default()
         .sudoers(&format!("{username}    ALL=(ALL:ALL) NOPASSWD: ALL"))
@@ -91,7 +89,7 @@ fn user_can_sudo_without_providing_a_password_if_user_is_in_sudoers_file_and_nop
 // "A password is not required if (..) the target user is the same as the invoking user"
 #[ignore]
 #[test]
-fn user_can_become_themselves_without_providing_a_password() -> Result<()> {
+fn user_can_sudo_as_themselves() -> Result<()> {
     let username = "ferris";
     let env = EnvBuilder::default()
         .user(username, &[])

--- a/test-framework/sudo-compliance-tests/src/nopasswd.rs
+++ b/test-framework/sudo-compliance-tests/src/nopasswd.rs
@@ -8,7 +8,7 @@ use crate::{Result, SUDOERS_ROOT_ALL};
 // "A password is not required if the invoking user is root"
 #[ignore]
 #[test]
-fn can_sudo_as_root_without_providing_a_password_if_root_user_is_in_sudoers_file() -> Result<()> {
+fn root_can_sudo_without_providing_a_password_if_root_user_is_in_sudoers_file() -> Result<()> {
     let env = EnvBuilder::default().sudoers(SUDOERS_ROOT_ALL).build()?;
 
     let output = env.exec(&["sudo", "true"], As::Root, None)?;
@@ -19,7 +19,7 @@ fn can_sudo_as_root_without_providing_a_password_if_root_user_is_in_sudoers_file
 
 #[ignore]
 #[test]
-fn can_sudo_as_root_without_providing_a_password_if_roots_group_is_in_sudoers_file() -> Result<()> {
+fn root_can_sudo_without_providing_a_password_if_roots_group_is_in_sudoers_file() -> Result<()> {
     let env = EnvBuilder::default()
         .sudoers("%root    ALL=(ALL:ALL) ALL")
         .build()?;
@@ -31,7 +31,7 @@ fn can_sudo_as_root_without_providing_a_password_if_roots_group_is_in_sudoers_fi
 }
 
 #[test]
-fn can_sudo_as_user_without_providing_a_password_if_users_group_is_in_sudoers_file_and_nopasswd_is_set(
+fn user_can_sudo_without_providing_a_password_if_users_group_is_in_sudoers_file_and_nopasswd_is_set(
 ) -> Result<()> {
     let username = "ferris";
     let groupname = "rustaceans";
@@ -47,7 +47,7 @@ fn can_sudo_as_user_without_providing_a_password_if_users_group_is_in_sudoers_fi
 }
 
 #[test]
-fn can_sudo_as_user_without_providing_a_password_if_user_is_in_sudoers_file_and_nopasswd_is_set(
+fn user_can_sudo_without_providing_a_password_if_user_is_in_sudoers_file_and_nopasswd_is_set(
 ) -> Result<()> {
     let username = "ferris";
     let env = EnvBuilder::default()

--- a/test-framework/sudo-compliance-tests/src/pass_auth.rs
+++ b/test-framework/sudo-compliance-tests/src/pass_auth.rs
@@ -140,18 +140,3 @@ fn user_cannot_sudo_if_user_is_in_sudoers_file_and_password_is_not_provided() ->
 
     Ok(())
 }
-
-#[test]
-fn cannot_sudo_if_sudoers_has_invalid_syntax() -> Result<()> {
-    let env = EnvBuilder::default().sudoers("invalid syntax").build()?;
-
-    let output = env.exec(&["sudo", "true"], As::Root, None)?;
-    assert!(!output.status.success());
-    assert_eq!(Some(1), output.status.code());
-
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr, "syntax error");
-    }
-
-    Ok(())
-}

--- a/test-framework/sudo-compliance-tests/src/pass_auth.rs
+++ b/test-framework/sudo-compliance-tests/src/pass_auth.rs
@@ -8,8 +8,8 @@ use crate::Result;
 
 #[ignore]
 #[test]
-fn can_sudo_as_user_if_users_group_is_in_sudoers_file_and_correct_password_is_provided(
-) -> Result<()> {
+fn user_can_sudo_if_users_group_is_in_sudoers_file_and_correct_password_is_provided() -> Result<()>
+{
     let username = "ferris";
     let groupname = "rustaceans";
     let password = "strong-password";
@@ -30,7 +30,7 @@ fn can_sudo_as_user_if_users_group_is_in_sudoers_file_and_correct_password_is_pr
 }
 
 #[test]
-fn cannot_sudo_as_user_if_users_group_is_in_sudoers_file_and_incorrect_password_is_provided(
+fn user_cannot_sudo_if_users_group_is_in_sudoers_file_and_incorrect_password_is_provided(
 ) -> Result<()> {
     let username = "ferris";
     let groupname = "rustaceans";
@@ -56,8 +56,7 @@ fn cannot_sudo_as_user_if_users_group_is_in_sudoers_file_and_incorrect_password_
 }
 
 #[test]
-fn cannot_sudo_as_user_if_users_group_is_in_sudoers_file_and_password_is_not_provided() -> Result<()>
-{
+fn user_cannot_sudo_if_users_group_is_in_sudoers_file_and_password_is_not_provided() -> Result<()> {
     let username = "ferris";
     let groupname = "rustaceans";
     let password = "strong-password";
@@ -79,7 +78,7 @@ fn cannot_sudo_as_user_if_users_group_is_in_sudoers_file_and_password_is_not_pro
 
 #[ignore]
 #[test]
-fn can_sudo_as_user_if_user_is_in_sudoers_file_and_correct_password_is_provided() -> Result<()> {
+fn user_can_sudo_if_user_is_in_sudoers_file_and_correct_password_is_provided() -> Result<()> {
     let username = "ferris";
     let password = "strong-password";
     let env = EnvBuilder::default()
@@ -99,8 +98,7 @@ fn can_sudo_as_user_if_user_is_in_sudoers_file_and_correct_password_is_provided(
 }
 
 #[test]
-fn cannot_sudo_as_user_if_user_is_in_sudoers_file_and_incorrect_password_is_provided() -> Result<()>
-{
+fn user_cannot_sudo_if_user_is_in_sudoers_file_and_incorrect_password_is_provided() -> Result<()> {
     let username = "ferris";
     let env = EnvBuilder::default()
         .sudoers(&format!("{username}    ALL=(ALL:ALL) ALL"))
@@ -124,7 +122,7 @@ fn cannot_sudo_as_user_if_user_is_in_sudoers_file_and_incorrect_password_is_prov
 }
 
 #[test]
-fn cannot_sudo_as_user_if_user_is_in_sudoers_file_and_password_is_not_provided() -> Result<()> {
+fn user_cannot_sudo_if_user_is_in_sudoers_file_and_password_is_not_provided() -> Result<()> {
     let username = "ferris";
     let password = "strong-password";
     let env = EnvBuilder::default()

--- a/test-framework/sudo-compliance-tests/src/pass_auth.rs
+++ b/test-framework/sudo-compliance-tests/src/pass_auth.rs
@@ -1,5 +1,7 @@
 //! Scenarios where password authentication is needed
 
+// NOTE all these tests assume that the invoking user passes the sudoers file 'User_List' criteria
+
 use pretty_assertions::assert_eq;
 
 use sudo_test::{As, EnvBuilder};
@@ -8,149 +10,12 @@ use crate::Result;
 
 #[ignore]
 #[test]
-fn user_can_sudo_if_users_group_is_in_sudoers_file_and_correct_password_is_provided() -> Result<()>
-{
-    let username = "ferris";
-    let groupname = "rustaceans";
-    let password = "strong-password";
-    let env = EnvBuilder::default()
-        .sudoers(&format!("%{groupname}    ALL=(ALL:ALL) ALL"))
-        .user(username, &[groupname])
-        .user_password(username, password)
-        .build()?;
-
-    let output = env.exec(
-        &["sudo", "-S", "true"],
-        As::User { name: username },
-        Some(password),
-    )?;
-    assert!(output.status.success(), "{}", output.stderr);
-
-    Ok(())
-}
-
-#[test]
-fn user_cannot_sudo_if_users_group_is_in_sudoers_file_and_incorrect_password_is_provided(
-) -> Result<()> {
-    let username = "ferris";
-    let groupname = "rustaceans";
-    let env = EnvBuilder::default()
-        .sudoers(&format!("%{groupname}    ALL=(ALL:ALL) ALL"))
-        .user(username, &[groupname])
-        .user_password(username, "strong-password")
-        .build()?;
-
-    let output = env.exec(
-        &["sudo", "-S", "true"],
-        As::User { name: username },
-        Some("incorrect-password"),
-    )?;
-    assert!(!output.status.success());
-    assert_eq!(Some(1), output.status.code());
-
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr, "incorrect password attempt");
-    }
-
-    Ok(())
-}
-
-#[test]
-fn user_cannot_sudo_if_users_group_is_in_sudoers_file_and_password_is_not_provided() -> Result<()> {
-    let username = "ferris";
-    let groupname = "rustaceans";
-    let password = "strong-password";
-    let env = EnvBuilder::default()
-        .sudoers(&format!("%{groupname}    ALL=(ALL:ALL) ALL"))
-        .user(username, &[groupname])
-        .user_password(username, password)
-        .build()?;
-
-    let output = env.exec(&["sudo", "-S", "true"], As::User { name: username }, None)?;
-    assert_eq!(Some(1), output.status.code());
-
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr, "no password was provided");
-    }
-
-    Ok(())
-}
-
-#[ignore]
-#[test]
-fn user_can_sudo_if_user_is_in_sudoers_file_and_correct_password_is_provided() -> Result<()> {
+fn correct_password() -> Result<()> {
     let username = "ferris";
     let password = "strong-password";
     let env = EnvBuilder::default()
         .sudoers(&format!("{username}    ALL=(ALL:ALL) ALL"))
-        .user(username, &["rustaceans"])
-        .user_password(username, password)
-        .build()?;
-
-    let output = env.exec(
-        &["sudo", "-S", "true"],
-        As::User { name: username },
-        Some(password),
-    )?;
-    assert!(output.status.success(), "{}", output.stderr);
-
-    Ok(())
-}
-
-#[test]
-fn user_cannot_sudo_if_user_is_in_sudoers_file_and_incorrect_password_is_provided() -> Result<()> {
-    let username = "ferris";
-    let env = EnvBuilder::default()
-        .sudoers(&format!("{username}    ALL=(ALL:ALL) ALL"))
-        .user(username, &["rustaceans"])
-        .user_password(username, "strong-password")
-        .build()?;
-
-    let output = env.exec(
-        &["sudo", "-S", "true"],
-        As::User { name: username },
-        Some("incorrect-password"),
-    )?;
-    assert!(!output.status.success());
-    assert_eq!(Some(1), output.status.code());
-
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr, "incorrect password attempt");
-    }
-
-    Ok(())
-}
-
-#[test]
-fn user_cannot_sudo_if_user_is_in_sudoers_file_and_password_is_not_provided() -> Result<()> {
-    let username = "ferris";
-    let password = "strong-password";
-    let env = EnvBuilder::default()
-        .sudoers(&format!("{username}    ALL=(ALL:ALL) ALL"))
-        .user(username, &["rustaceans"])
-        .user_password(username, password)
-        .build()?;
-
-    let output = env.exec(&["sudo", "-S", "true"], As::User { name: username }, None)?;
-    assert_eq!(Some(1), output.status.code());
-
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr, "no password was provided");
-    }
-
-    Ok(())
-}
-
-#[ignore]
-#[test]
-fn user_can_sudo_if_user_id_is_in_sudoers_file_and_correct_password_is_provided() -> Result<()> {
-    let username = "ferris";
-    let user_id = 1023;
-    let password = "strong-password";
-    let env = EnvBuilder::default()
-        .sudoers(&format!("#{user_id}    ALL=(ALL:ALL) ALL"))
         .user(username, &[])
-        .user_id(username, user_id)
         .user_password(username, password)
         .build()?;
 
@@ -164,27 +29,46 @@ fn user_can_sudo_if_user_id_is_in_sudoers_file_and_correct_password_is_provided(
     Ok(())
 }
 
-#[ignore]
 #[test]
-fn user_can_sudo_if_theirs_group_id_is_in_sudoers_file_and_correct_password_is_provided(
-) -> Result<()> {
+fn incorrect_password() -> Result<()> {
     let username = "ferris";
-    let group_id = 1023;
-    let groupname = "rustaceans";
-    let password = "strong-password";
     let env = EnvBuilder::default()
-        .sudoers(&format!("%#{group_id}    ALL=(ALL:ALL) ALL"))
-        .user(username, &[groupname])
-        .group_id(groupname, group_id)
-        .user_password(username, password)
+        .sudoers(&format!("{username}    ALL=(ALL:ALL) ALL"))
+        .user(username, &[])
+        .user_password(username, "strong-password")
         .build()?;
 
     let output = env.exec(
         &["sudo", "-S", "true"],
         As::User { name: username },
-        Some(password),
+        Some("incorrect-password"),
     )?;
-    assert!(output.status.success(), "{}", output.stderr);
+    assert!(!output.status.success());
+    assert_eq!(Some(1), output.status.code());
+
+    if sudo_test::is_original_sudo() {
+        assert_contains!(output.stderr, "incorrect password attempt");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn no_password() -> Result<()> {
+    let username = "ferris";
+    let password = "strong-password";
+    let env = EnvBuilder::default()
+        .sudoers(&format!("{username}    ALL=(ALL:ALL) ALL"))
+        .user(username, &[])
+        .user_password(username, password)
+        .build()?;
+
+    let output = env.exec(&["sudo", "-S", "true"], As::User { name: username }, None)?;
+    assert_eq!(Some(1), output.status.code());
+
+    if sudo_test::is_original_sudo() {
+        assert_contains!(output.stderr, "no password was provided");
+    }
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/pass_auth.rs
+++ b/test-framework/sudo-compliance-tests/src/pass_auth.rs
@@ -140,3 +140,51 @@ fn user_cannot_sudo_if_user_is_in_sudoers_file_and_password_is_not_provided() ->
 
     Ok(())
 }
+
+#[ignore]
+#[test]
+fn user_can_sudo_if_user_id_is_in_sudoers_file_and_correct_password_is_provided() -> Result<()> {
+    let username = "ferris";
+    let user_id = 1023;
+    let password = "strong-password";
+    let env = EnvBuilder::default()
+        .sudoers(&format!("#{user_id}    ALL=(ALL:ALL) ALL"))
+        .user(username, &[])
+        .user_id(username, user_id)
+        .user_password(username, password)
+        .build()?;
+
+    let output = env.exec(
+        &["sudo", "-S", "true"],
+        As::User { name: username },
+        Some(password),
+    )?;
+    assert!(output.status.success(), "{}", output.stderr);
+
+    Ok(())
+}
+
+#[ignore]
+#[test]
+fn user_can_sudo_if_theirs_group_id_is_in_sudoers_file_and_correct_password_is_provided(
+) -> Result<()> {
+    let username = "ferris";
+    let group_id = 1023;
+    let groupname = "rustaceans";
+    let password = "strong-password";
+    let env = EnvBuilder::default()
+        .sudoers(&format!("%#{group_id}    ALL=(ALL:ALL) ALL"))
+        .user(username, &[groupname])
+        .group_id(groupname, group_id)
+        .user_password(username, password)
+        .build()?;
+
+    let output = env.exec(
+        &["sudo", "-S", "true"],
+        As::User { name: username },
+        Some(password),
+    )?;
+    assert!(output.status.success(), "{}", output.stderr);
+
+    Ok(())
+}

--- a/test-framework/sudo-compliance-tests/src/sudoers.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers.rs
@@ -2,34 +2,7 @@ use sudo_test::{As, EnvBuilder};
 
 use crate::Result;
 
-#[test]
-fn cannot_sudo_with_empty_sudoers_file() -> Result<()> {
-    let env = EnvBuilder::default().build()?;
-
-    let output = env.exec(&["sudo", "true"], As::Root, None)?;
-    assert_eq!(Some(1), output.status.code());
-
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr, "root is not in the sudoers file");
-    }
-
-    Ok(())
-}
-
-#[test]
-fn cannot_sudo_if_sudoers_has_invalid_syntax() -> Result<()> {
-    let env = EnvBuilder::default().sudoers("invalid syntax").build()?;
-
-    let output = env.exec(&["sudo", "true"], As::Root, None)?;
-    assert!(!output.status.success());
-    assert_eq!(Some(1), output.status.code());
-
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr, "syntax error");
-    }
-
-    Ok(())
-}
+mod user_list;
 
 #[test]
 fn cannot_sudo_if_sudoers_file_is_world_writable() -> Result<()> {

--- a/test-framework/sudo-compliance-tests/src/sudoers.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers.rs
@@ -17,6 +17,21 @@ fn cannot_sudo_with_empty_sudoers_file() -> Result<()> {
 }
 
 #[test]
+fn cannot_sudo_if_sudoers_has_invalid_syntax() -> Result<()> {
+    let env = EnvBuilder::default().sudoers("invalid syntax").build()?;
+
+    let output = env.exec(&["sudo", "true"], As::Root, None)?;
+    assert!(!output.status.success());
+    assert_eq!(Some(1), output.status.code());
+
+    if sudo_test::is_original_sudo() {
+        assert_contains!(output.stderr, "syntax error");
+    }
+
+    Ok(())
+}
+
+#[test]
 fn cannot_sudo_if_sudoers_file_is_world_writable() -> Result<()> {
     let env = EnvBuilder::default().sudoers_chmod("446").build()?;
 

--- a/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
@@ -60,7 +60,6 @@ fn user_id() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn group_name() -> Result<()> {
     let env = EnvBuilder::default()
         .sudoers("%root ALL=(ALL:ALL) NOPASSWD: ALL")
@@ -73,7 +72,6 @@ fn group_name() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn group_id() -> Result<()> {
     let env = EnvBuilder::default()
         .sudoers("%#0 ALL=(ALL:ALL) NOPASSWD: ALL")

--- a/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
@@ -60,6 +60,7 @@ fn user_id() -> Result<()> {
 }
 
 #[test]
+#[ignore]
 fn group_name() -> Result<()> {
     let env = EnvBuilder::default()
         .sudoers("%root ALL=(ALL:ALL) NOPASSWD: ALL")
@@ -72,6 +73,7 @@ fn group_name() -> Result<()> {
 }
 
 #[test]
+#[ignore]
 fn group_id() -> Result<()> {
     let env = EnvBuilder::default()
         .sudoers("%#0 ALL=(ALL:ALL) NOPASSWD: ALL")

--- a/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
@@ -1,0 +1,84 @@
+//! Test the first component of the user specification: `<user_list> ALL=(ALL:ALL) ALL`
+
+use sudo_test::{As, EnvBuilder};
+
+use crate::Result;
+
+#[test]
+fn no_match() -> Result<()> {
+    let env = EnvBuilder::default().build()?;
+
+    let output = env.exec(&["sudo", "true"], As::Root, None)?;
+    assert_eq!(Some(1), output.status.code());
+
+    if sudo_test::is_original_sudo() {
+        assert_contains!(output.stderr, "root is not in the sudoers file");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn all() -> Result<()> {
+    let username = "ferris";
+    let env = EnvBuilder::default()
+        .sudoers("ALL ALL=(ALL:ALL) NOPASSWD: ALL")
+        .user(username, &[])
+        .build()?;
+
+    let output = env.exec(&["sudo", "true"], As::Root, None)?;
+    assert!(output.status.success(), "{}", output.stderr);
+
+    let output = env.exec(&["sudo", "true"], As::User { name: username }, None)?;
+    assert!(output.status.success(), "{}", output.stderr);
+
+    Ok(())
+}
+
+#[test]
+fn user_name() -> Result<()> {
+    let env = EnvBuilder::default()
+        .sudoers("root ALL=(ALL:ALL) NOPASSWD: ALL")
+        .build()?;
+
+    let output = env.exec(&["sudo", "true"], As::Root, None)?;
+    assert!(output.status.success(), "{}", output.stderr);
+
+    Ok(())
+}
+
+#[test]
+fn user_id() -> Result<()> {
+    let env = EnvBuilder::default()
+        .sudoers("#0 ALL=(ALL:ALL) NOPASSWD: ALL")
+        .build()?;
+
+    let output = env.exec(&["sudo", "true"], As::Root, None)?;
+    assert!(output.status.success(), "{}", output.stderr);
+
+    Ok(())
+}
+
+#[test]
+fn group_name() -> Result<()> {
+    let env = EnvBuilder::default()
+        .sudoers("%root ALL=(ALL:ALL) NOPASSWD: ALL")
+        .build()?;
+
+    let output = env.exec(&["sudo", "true"], As::Root, None)?;
+    assert!(output.status.success(), "{}", output.stderr);
+
+    Ok(())
+}
+
+#[test]
+fn group_id() -> Result<()> {
+    let env = EnvBuilder::default()
+        .sudoers("%#0 ALL=(ALL:ALL) NOPASSWD: ALL")
+        .build()?;
+
+    let output = env.exec(&["sudo", "true"], As::Root, None)?;
+    assert!(output.status.success(), "{}", output.stderr);
+
+    Ok(())
+}

--- a/test-framework/sudo-test/Cargo.toml
+++ b/test-framework/sudo-test/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 doctest = false
 
 [dependencies]
+bimap = "0.6.2"
 tempfile = "3.4.0"


### PR DESCRIPTION
I ended doing a U turn towards the end of the commit history but I think focusing on the orthogonality of the tests is a change for the better.

this is best reviewed commit by commit

cc #96
closes #99