### PR TITLE
Better signal handling

### DIFF
--- a/lib/sudo-common/src/context.rs
+++ b/lib/sudo-common/src/context.rs
@@ -68,6 +68,7 @@ pub struct Context<'a> {
     // system
     pub hostname: String,
     pub current_user: User,
+    pub pid: i32,
 }
 
 pub trait Configuration {
@@ -142,6 +143,7 @@ impl<'a> Context<'a> {
             login: sudo_options.login,
             shell: sudo_options.shell,
             chdir: sudo_options.directory.clone(),
+            pid: std::process::id() as i32,
         })
     }
 }

--- a/lib/sudo-common/src/context.rs
+++ b/lib/sudo-common/src/context.rs
@@ -143,7 +143,7 @@ impl<'a> Context<'a> {
             login: sudo_options.login,
             shell: sudo_options.shell,
             chdir: sudo_options.directory.clone(),
-            pid: std::process::id() as i32,
+            pid: sudo_system::Process::process_id(),
         })
     }
 }

--- a/lib/sudo-env/tests/env_tests.rs
+++ b/lib/sudo-env/tests/env_tests.rs
@@ -132,6 +132,7 @@ fn create_test_context<'a>(sudo_options: &'a SudoOptions) -> Context<'a> {
         login: sudo_options.login,
         shell: sudo_options.shell,
         chdir: sudo_options.directory.clone(),
+        pid: std::process::id() as i32,
     }
 }
 

--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -96,8 +96,12 @@ fn is_self_terminating(process: Option<Process>, cmd_pid: i32, sudo_pid: i32) ->
             }
             let grp_leader = getpgid(process.pid);
 
-            if grp_leader != -1 && (grp_leader == cmd_pid || grp_leader == sudo_pid) {
-                return true;
+            if grp_leader != -1 {
+                if grp_leader == cmd_pid || grp_leader == sudo_pid {
+                    return true;
+                }
+            } else {
+                eprintln!("Could not fetch process group ID");
             }
         }
     }

--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -47,7 +47,8 @@ pub fn run_command(ctx: Context<'_>, env: Environment) -> io::Result<ExitStatus>
             match signal {
                 SIGCHLD => {
                     // FIXME: check `handle_sigchld_nopty`
-                    cmd.kill()?;
+                    // We just wait until all the children are done.
+                    continue;
                 }
                 SIGWINCH | SIGINT | SIGQUIT | SIGTSTP => {
                     if cause != Cause::Sent(Sent::User) || handle_process(process, cmd_pid, ctx.pid)

--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 use signal_hook::{
     consts::*,
     iterator::{exfiltrator::WithOrigin, SignalsInfo},
-    low_level::siginfo::{Cause, Origin, Process, Sent},
+    low_level::siginfo::{Cause, Process, Sent},
 };
 use sudo_common::context::{Context, Environment};
 use sudo_system::{getpgid, kill};
@@ -96,7 +96,7 @@ fn is_self_terminating(process: Option<Process>, cmd_pid: i32, sudo_pid: i32) ->
             }
             let grp_leader = getpgid(process.pid);
 
-            if grp_leader != -1 || grp_leader == cmd_pid || grp_leader == sudo_pid {
+            if grp_leader != -1 && (grp_leader == cmd_pid || grp_leader == sudo_pid) {
                 return true;
             }
         }

--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -15,14 +15,10 @@ use signal_hook::{
 use sudo_common::context::{Context, Environment};
 use sudo_system::{getpgid, kill};
 
-/// We do not handle `SIGKILL`, `SIGSTOP`, `SIGILL`, `SIGFPE` nor `SIGSEGV` because those should
-/// not be intercepted and replaced. according to `POSIX`.
-// FIXME: are we missing any signals? `SIGEMT`, `SIGLOST` and `SIGPWR` are not exposed by
-// `signal-hook`.
+/// We only handle the signals that ogsudo handles.
 const SIGNALS: &[c_int] = &[
-    SIGABRT, SIGALRM, SIGBUS, SIGCHLD, SIGCONT, SIGHUP, SIGINT, SIGPIPE, SIGPROF, SIGQUIT, SIGSYS,
-    SIGTERM, SIGTRAP, SIGTSTP, SIGTTIN, SIGTTOU, SIGURG, SIGUSR1, SIGUSR2, SIGVTALRM, SIGWINCH,
-    SIGXCPU, SIGXFSZ, SIGIO,
+    SIGINT, SIGQUIT, SIGTSTP, SIGTERM, SIGHUP, SIGALRM, SIGPIPE, SIGUSR1, SIGUSR2, SIGCHLD,
+    SIGCONT, SIGWINCH,
 ];
 
 /// Based on `ogsudo`s `exec_nopty` function.


### PR DESCRIPTION
This PR introduces the following changes:

- Handle SIGWINCH as a regular signal as we are not doing any I/O logging.
- Handle SIGALRM by sending SIGHUP, SIGTERM and SIGKILL to the command to match ogsudo's behavior.
- Only overwrite the same signal handlers that ogsudo overwrites.
- If the command was terminated by a signal, send that signal to sudo to terminate itself and generate the correct exit status (aka fix #112)

On a very @japaric fashion, this PR is easier to review commit by commit :P 