### PR TITLE
Add a must-set environment variable in order to run sudo-rs

### DIFF
--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -43,6 +43,24 @@ fn main() -> Result<(), Error> {
     // parse cli options
     let sudo_options = SudoOptions::parse();
 
+    let check_var = std::env::var("SUDO_RS_IS_UNSTABLE").unwrap_or_else(|_| "".to_string());
+
+    if check_var != "I accept that my system may break unexpectedly" {
+        eprintln!("WARNING!");
+        eprintln!("Sudo-rs is in the early stages of development and could potentially break your system.");
+        eprintln!(
+            "We recommend that you do not run this on any production environment. To turn off this"
+        );
+        eprintln!(
+            "warning and start using sudo-rs set the environment variable SUDO_RS_IS_UNSTABLE to"
+        );
+        eprintln!(
+            "the value `I accept that my system may break unexpectedly`. If you are unsure how to"
+        );
+        eprintln!("do this then this software is not suited for you at this time.");
+        std::process::exit(1);
+    }
+
     // parse sudoers file
     let sudoers = parse_sudoers()?;
 

--- a/test-framework/sudo-compliance-tests/src/env_reset.rs
+++ b/test-framework/sudo-compliance-tests/src/env_reset.rs
@@ -23,7 +23,7 @@ fn vars_set_by_sudo_in_env_reset_mode() -> Result<()> {
 
     // run sudo in an empty environment
     let stdout = env.stdout(
-        &["env", "-i", &sudo_abs_path, &env_abs_path],
+        &["env", "-i", "SUDO_RS_IS_UNSTABLE=I accept that my system may break unexpectedly", &sudo_abs_path, &env_abs_path],
         As::Root,
         None,
     )?;

--- a/test-framework/sudo-test/src/ours.Dockerfile
+++ b/test-framework/sudo-test/src/ours.Dockerfile
@@ -12,3 +12,5 @@ RUN install --mode 4755 target/debug/sudo /usr/bin/sudo
 RUN apt-get autoremove -y clang libclang-dev
 # HACK sudo-rs is hard-coded to use /etc/sudoers.test
 RUN ln -s sudoers /etc/sudoers.test
+# Makes sure our sudo implementation actually runs
+ENV SUDO_RS_IS_UNSTABLE="I accept that my system may break unexpectedly"


### PR DESCRIPTION
Fixes #104 

The produced binary will now only continue running if the environment variable `SUDO_RS_IS_UNSTABLE` is set to `I accept that my system may break unexpectedly`. I chose the explicit value here to make sure that people really understand what they are doing, and explicitly chose not to give the syntax for setting an environment variable for this, so that some thought has to go into using it.