### PR TITLE
check sudoers permissions

### DIFF
--- a/lib/sudo-system/src/audit.rs
+++ b/lib/sudo-system/src/audit.rs
@@ -1,0 +1,43 @@
+use std::fs::File;
+use std::io::{self, Error, ErrorKind};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::Path;
+
+// of course we can also write "file & 0o040 != 0", but this makes the intent explicit
+enum Op {
+    _Read = 4,
+    Write = 2,
+    _Exec = 1,
+}
+enum Category {
+    _Owner = 2,
+    Group = 1,
+    World = 0,
+}
+
+fn mode(who: Category, what: Op) -> u32 {
+    (what as u32) << (3 * who as u32)
+}
+
+pub fn secure_open(path: &Path) -> io::Result<File> {
+    let file = File::open(path)?;
+    let meta = file.metadata()?;
+    let permbits = meta.permissions().mode();
+    let error = |msg| Error::new(ErrorKind::PermissionDenied, msg);
+
+    if meta.uid() != 0 {
+        Err(error(format!("{} must be owned by root", path.display())))
+    } else if meta.gid() != 0 && (permbits & mode(Category::Group, Op::Write) != 0) {
+        Err(error(format!(
+            "{} cannot be group-writable",
+            path.display()
+        )))
+    } else if permbits & mode(Category::World, Op::Write) != 0 {
+        Err(error(format!(
+            "{} cannot be world-writable",
+            path.display()
+        )))
+    } else {
+        Ok(file)
+    }
+}

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -10,6 +10,9 @@ use libc::pid_t;
 pub use libc::PATH_MAX;
 use sudo_cutils::*;
 
+mod audit;
+pub use audit::secure_open;
+
 pub fn hostname() -> String {
     let max_hostname_size = sysconf(libc::_SC_HOST_NAME_MAX).unwrap_or(256);
     let mut buf = vec![0; max_hostname_size as usize];

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -86,9 +86,8 @@ impl Sudoers {
 }
 
 fn read_sudoers(path: &Path) -> Result<Vec<basic_parser::Parsed<Sudo>>, std::io::Error> {
-    use std::fs::File;
     use std::io::Read;
-    let mut source = File::open(path)?;
+    let mut source = sudo_system::secure_open(path)?;
 
     // it's a bit frustrating that BufReader.chars() does not exist
     let mut buffer = String::new();

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -16,7 +16,7 @@ fn parse_sudoers() -> Result<Sudoers, Error> {
     let sudoers_path = "/etc/sudoers.test";
 
     let (sudoers, syntax_errors) = Sudoers::new(sudoers_path)
-        .map_err(|e| Error::Configuration(format!("no sudoers file {e}")))?;
+        .map_err(|e| Error::Configuration(format!("no valid sudoers file: {e}")))?;
 
     for sudoers::Error(_pos, error) in syntax_errors {
         eprintln!("Parse error: {error}");

--- a/test-framework/sudo-compliance-tests/src/sudoers.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers.rs
@@ -1,18 +1,68 @@
 use sudo_test::{Command, Env, TextFile, User};
 
-use crate::{Result, PASSWORD, USERNAME};
+use crate::{Result, PASSWORD, SUDOERS_ROOT_ALL_NOPASSWD, USERNAME};
 
 mod user_list;
 
 #[test]
 fn cannot_sudo_if_sudoers_file_is_world_writable() -> Result<()> {
-    let env = Env(TextFile("").chmod("446")).build()?;
+    let env = Env(TextFile(SUDOERS_ROOT_ALL_NOPASSWD).chmod("446")).build()?;
 
     let output = Command::new("sudo").arg("true").exec(&env)?;
     assert_eq!(Some(1), output.status().code());
 
     if sudo_test::is_original_sudo() {
         assert_contains!(output.stderr(), "/etc/sudoers is world writable");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn cannot_sudo_if_sudoers_file_is_group_writable() -> Result<()> {
+    let env = Env(TextFile(SUDOERS_ROOT_ALL_NOPASSWD)
+        .chmod("464")
+        .chown("root:1234"))
+    .user(User(USERNAME).password(PASSWORD))
+    .build()?;
+
+    let output = Command::new("sudo").arg("true").exec(&env)?;
+    assert_eq!(Some(1), output.status().code());
+
+    if sudo_test::is_original_sudo() {
+        assert_contains!(
+            output.stderr(),
+            "/etc/sudoers is owned by gid 1234, should be 0"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn can_sudo_if_sudoers_file_is_owner_writable() -> Result<()> {
+    let env = Env(TextFile(SUDOERS_ROOT_ALL_NOPASSWD).chmod("644")).build()?;
+
+    let output = Command::new("sudo").arg("true").exec(&env)?;
+    assert_eq!(Some(0), output.status().code());
+
+    Ok(())
+}
+
+#[test]
+fn cannot_sudo_if_sudoers_file_is_not_owned_by_root() -> Result<()> {
+    let env = Env(TextFile(SUDOERS_ROOT_ALL_NOPASSWD).chown("1234:root"))
+        .user(User(USERNAME).password(PASSWORD))
+        .build()?;
+
+    let output = Command::new("sudo").arg("true").exec(&env)?;
+    assert_eq!(Some(1), output.status().code());
+
+    if sudo_test::is_original_sudo() {
+        assert_contains!(
+            output.stderr(),
+            "/etc/sudoers is owned by uid 1234, should be 0"
+        );
     }
 
     Ok(())


### PR DESCRIPTION
Closing #77 

This actually also fixes the test-case so it actually fails (without the addition); in the original test sudo-rs would fail because the sudoers file it read contained no rules.