### PR TITLE
Dont' require authentication if user is root or requested user themselves.

### DIFF
--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -80,7 +80,7 @@ impl Sudoers {
     ) -> Policy {
         // exception: if user is root or does not switch users, NOPASSWD is implied
         let skip_passwd =
-            am_user.is_root() || request.user == am_user && in_group(am_user, request.group);
+            am_user.is_root() || (request.user == am_user && in_group(am_user, request.group));
 
         let mut flags = check_permission(self, am_user, on_host, request);
         if let Some(Tag { passwd, .. }) = flags.as_mut() {

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -78,8 +78,19 @@ impl Sudoers {
         on_host: &str,
         request: Request<User, Group>,
     ) -> Policy {
+        // exception: if user is root or does not switch users, NOPASSWD is implied
+        let skip_passwd =
+            am_user.is_root() || request.user == am_user && in_group(am_user, request.group);
+
+        let mut flags = check_permission(self, am_user, on_host, request);
+        if let Some(Tag { passwd, .. }) = flags.as_mut() {
+            if skip_passwd {
+                *passwd = false
+            }
+        }
+
         Policy {
-            flags: check_permission(self, am_user, on_host, request),
+            flags,
             settings: self.settings.clone(), // this is wasteful, but in the future this will not be a simple clone and it avoids a lifetime
         }
     }

--- a/lib/sudoers/src/test/mod.rs
+++ b/lib/sudoers/src/test/mod.rs
@@ -213,6 +213,8 @@ fn permission_test() {
 
     pass!(["user ALL=(ALL:ALL) /bin/foo"], "user" => root(), "server"; "/bin/foo" => [passwd: true]);
     pass!(["root ALL=(ALL:ALL) /bin/foo"], "root" => root(), "server"; "/bin/foo" => [passwd: false]);
+    pass!(["user ALL=(ALL:ALL) /bin/foo"], "user" => (&Named("user"), &Named("user")), "server"; "/bin/foo" => [passwd: false]);
+    pass!(["user ALL=(ALL:ALL) /bin/foo"], "user" => (&Named("user"), &Named("root")), "server"; "/bin/foo" => [passwd: true]);
 
     SYNTAX!(["User_Alias, marc ALL = ALL"]);
 

--- a/lib/sudoers/src/test/mod.rs
+++ b/lib/sudoers/src/test/mod.rs
@@ -136,7 +136,7 @@ fn permission_test() {
             let (Sudoers { rules,aliases,settings }, _) = analyze(sudoer![$($sudo),*]);
             let cmdvec = $command.split_whitespace().collect::<Vec<_>>();
             let req = Request { user: $req.0, group: $req.1, command: cmdvec[0].as_ref(), arguments: &cmdvec[1..].join(" ") };
-            assert_eq!(check_permission(&Sudoers { rules, aliases, settings }, &Named($user), $server, req), None);
+            assert_eq!(Sudoers { rules, aliases, settings }.check(&Named($user), $server, req).flags, None);
         }
     }
 
@@ -145,7 +145,7 @@ fn permission_test() {
             let (Sudoers { rules,aliases,settings }, _) = analyze(sudoer![$($sudo),*]);
             let cmdvec = $command.split_whitespace().collect::<Vec<_>>();
             let req = Request { user: $req.0, group: $req.1, command: &cmdvec[0].as_ref(), arguments: &cmdvec[1..].join(" ") };
-            let result = check_permission(&Sudoers { rules, aliases, settings }, &Named($user), $server, req);
+            let result = Sudoers { rules, aliases, settings }.check(&Named($user), $server, req).flags;
             assert!(!result.is_none());
             $(
                 let result = result.unwrap();
@@ -210,6 +210,9 @@ fn permission_test() {
     FAIL!(["user ALL=/bin/hel* me"], "user" => root(), "server"; "/bin/help");
     pass!(["user ALL=/bin/hel* me"], "user" => root(), "server"; "/bin/help me");
     FAIL!(["user ALL=/bin/hel* me"], "user" => root(), "server"; "/bin/help me please");
+
+    pass!(["user ALL=(ALL:ALL) /bin/foo"], "user" => root(), "server"; "/bin/foo" => [passwd: true]);
+    pass!(["root ALL=(ALL:ALL) /bin/foo"], "root" => root(), "server"; "/bin/foo" => [passwd: false]);
 
     SYNTAX!(["User_Alias, marc ALL = ALL"]);
 

--- a/test-framework/sudo-compliance-tests/src/nopasswd.rs
+++ b/test-framework/sudo-compliance-tests/src/nopasswd.rs
@@ -8,7 +8,6 @@ use crate::{Result, SUDOERS_ROOT_ALL};
 
 // man sudoers > User Authentication:
 // "A password is not required if the invoking user is root"
-#[ignore]
 #[test]
 fn user_is_root() -> Result<()> {
     let env = EnvBuilder::default().sudoers(SUDOERS_ROOT_ALL).build()?;
@@ -21,7 +20,6 @@ fn user_is_root() -> Result<()> {
 
 // man sudoers > User Authentication:
 // "A password is not required if (..) the target user is the same as the invoking user"
-#[ignore]
 #[test]
 fn user_as_themselves() -> Result<()> {
     let username = "ferris";


### PR DESCRIPTION
Most changes are to test cases and code intended to be readable so this is an easy one to review.

Check this set of changes for sudo compliancy: as far as my probing has revealed (and what seems logical) is that sudo does not require a password if:

- you are already root (since you can do whatever you want anyway)
- with *the combination* of "-u" and "-g" you are not trying to become anything that you are not already

Should be squashed.