### PR TITLE
Richer error messages

### DIFF
--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -548,7 +548,7 @@ fn get_directive(
     fn parse_default<T: CharStream>(stream: &mut T) -> Parsed<Directive> {
         let id_pos = stream.get_pos();
 
-        let list_items = |mode: Mode, name: String, cfg: Setting, stream: &mut _| {
+        let list_items = |mode: Mode, name: String, cfg: Setting, stream: &mut T| {
             expect_syntax('=', stream)?;
             if !matches!(cfg, Setting::List(_)) {
                 unrecoverable!(pos = id_pos, stream, "{name} is not a list parameter");

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -305,6 +305,7 @@ impl Parse for ProtoCommandSpec {
             }
         }
 
+        let start_pos = stream.get_pos();
         let digest = if let Some(Username(keyword)) = try_nonterminal(stream)? {
             let hash_type = match keyword.as_str() {
                 "sha224" => 224,
@@ -312,7 +313,11 @@ impl Parse for ProtoCommandSpec {
                 "sha384" => 384,
                 "sha512" => 512,
                 "sudoedit" => todo!(), // note: special behaviour of forward slashes in wildcards, tread carefully
-                _ => unrecoverable!(stream, "expected command but found {keyword}"),
+                _ => unrecoverable!(
+                    pos = start_pos,
+                    stream,
+                    "expected command but found {keyword}"
+                ),
             };
             expect_syntax(':', stream)?;
             let hex = expect_nonterminal::<Sha2>(stream)?;
@@ -464,18 +469,24 @@ fn parse_include(stream: &mut impl CharStream) -> Parsed<Sudo> {
             expect_syntax('"', stream)?;
             make(path)
         } else {
+            let value_pos = stream.get_pos();
             let IncludePath(path) = expect_nonterminal(stream)?;
             if stream.peek() != Some('\n') {
-                unrecoverable!(stream, "use quotes around filenames or escape whitespace")
+                unrecoverable!(
+                    pos = value_pos,
+                    stream,
+                    "use quotes around filenames or escape whitespace"
+                )
             }
             make(path)
         }
     }
 
+    let key_pos = stream.get_pos();
     let result = match try_nonterminal(stream)? {
         Some(Username(key)) if key == "include" => Sudo::Include(get_path(stream)?),
         Some(Username(key)) if key == "includedir" => Sudo::IncludeDir(get_path(stream)?),
-        _ => unrecoverable!(stream, "unknown directive"),
+        _ => unrecoverable!(pos = key_pos, stream, "unknown directive"),
     };
 
     make(result)
@@ -561,6 +572,7 @@ fn get_directive(
         use sudo_defaults::OptTuple;
 
         if is_syntax('!', stream)? {
+            let value_pos = stream.get_pos();
             let EnvVar(name) = expect_nonterminal(stream)?;
             let value = match sudo_default(&name) {
                 Some(Setting::Flag(_)) => ConfigValue::Flag(false),
@@ -574,13 +586,17 @@ fn get_directive(
                 Some(Setting::Integer(OptTuple {
                     negated: Some(val), ..
                 })) => ConfigValue::Num(val),
-                _ => unrecoverable!(stream, "`{name}' cannot be used in a boolean context"),
+                _ => unrecoverable!(
+                    pos = value_pos,
+                    stream,
+                    "`{name}' cannot be used in a boolean context"
+                ),
             };
             make(Defaults(name, value))
         } else {
             let EnvVar(name) = try_nonterminal(stream)?;
             let Some(cfg) = sudo_default(&name) else {
-                unrecoverable!(pos=id_pos, stream, "unknown setting: `{name}'");
+                unrecoverable!(pos = id_pos, stream, "unknown setting: `{name}'");
             };
 
             if is_syntax('+', stream)? {

--- a/lib/sudoers/src/basic_parser.rs
+++ b/lib/sudoers/src/basic_parser.rs
@@ -28,7 +28,7 @@
 /// Type holding a parsed object (or error information if parsing failed)
 pub type Parsed<T> = Result<T, Status>;
 
-pub type Position = (usize, usize);
+pub type Position = std::ops::Range<(usize, usize)>;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
@@ -46,15 +46,17 @@ pub fn reject<T>() -> Parsed<T> {
 }
 
 macro_rules! unrecoverable {
-    // TODO: transmit begin-and-end position information to give an accurate "underlining" of the full error
     (pos=$pos:expr, $stream:ident, $($str:expr),*) => {
-        return Err(crate::basic_parser::Status::Fatal($pos,format![$($str),*]))
+        return Err(crate::basic_parser::Status::Fatal($pos .. $stream.get_pos(), format![$($str),*]))
     };
     ($stream:ident, $($str:expr),*) => {
-        return Err(crate::basic_parser::Status::Fatal($stream.get_pos(),format![$($str),*]))
+        {
+            let pos = $stream.get_pos();
+            return Err(crate::basic_parser::Status::Fatal(pos .. pos, format![$($str),*]))
+        }
     };
     ($($str:expr),*) => {
-        return Err(crate::basic_parser::Status::Fatal(None,format![$($str),*]))
+        return Err(crate::basic_parser::Status::Fatal(Default::default(), format![$($str),*]))
     };
 }
 

--- a/lib/sudoers/src/basic_parser.rs
+++ b/lib/sudoers/src/basic_parser.rs
@@ -202,9 +202,10 @@ pub fn try_nonterminal<T: Parse>(stream: &mut impl CharStream) -> Parsed<T> {
 use crate::ast_names::UserFriendly;
 
 pub fn expect_nonterminal<T: Parse + UserFriendly>(stream: &mut impl CharStream) -> Parsed<T> {
+    let begin_pos = stream.get_pos();
     match try_nonterminal(stream) {
         Err(Status::Reject) => {
-            unrecoverable!(stream, "expected {}", T::DESCRIPTION)
+            unrecoverable!(pos = begin_pos, stream, "expected {}", T::DESCRIPTION)
         }
         result => result,
     }

--- a/sudo/src/diagnostic.rs
+++ b/sudo/src/diagnostic.rs
@@ -1,0 +1,38 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+// TODO: in the future, we will have range information (i.e. error starts here and ends here)
+
+pub(crate) fn cited_error(message: &str, line: usize, col: usize, path: impl AsRef<Path>) {
+    let path_str = path.as_ref().display();
+    eprintln!("{path_str}:{line}:{col}: {message}");
+
+    let citation = || {
+        let inp = BufReader::new(File::open(path).ok()?);
+        let line = inp.lines().nth(line - 1)?.ok()?;
+        let padding = line
+            .chars()
+            .take(col - 1)
+            .map(|c| if c.is_whitespace() { c } else { ' ' })
+            .collect::<String>();
+        eprintln!("{line}");
+        eprintln!("{padding}^");
+        Some(())
+    };
+
+    // we ignore any errors in displaying an error
+    let _ = citation();
+}
+
+macro_rules! diagnostic {
+    ($str:expr, $path:tt @ $pos:ident) => {
+        if let Some((line, col)) = $pos {
+            $crate::diagnostic::cited_error(&format!($str), line, col, $path);
+        } else {
+            eprintln!($str);
+        }
+    };
+}
+
+pub(crate) use diagnostic;

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -9,6 +9,7 @@ use sudo_common::{
 use sudo_env::environment;
 use sudoers::{Authorization, Sudoers};
 
+mod diagnostic;
 mod pam;
 
 fn parse_sudoers() -> Result<Sudoers, Error> {
@@ -18,8 +19,8 @@ fn parse_sudoers() -> Result<Sudoers, Error> {
     let (sudoers, syntax_errors) = Sudoers::new(sudoers_path)
         .map_err(|e| Error::Configuration(format!("no sudoers file {e}")))?;
 
-    for sudoers::Error(_pos, error) in syntax_errors {
-        eprintln!("Parse error: {error}");
+    for sudoers::Error(pos, error) in syntax_errors {
+        diagnostic::diagnostic!("{error}", sudoers_path @ pos);
     }
 
     Ok(sudoers)

--- a/test-binaries/checkpermit.rs
+++ b/test-binaries/checkpermit.rs
@@ -128,7 +128,7 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     if let Ok((cfg, warn)) = Sudoers::new("./sudoers") {
         for sudoers::Error(pos, msg) in warn {
-            if let Some((x, y)) = pos {
+            if let Some(std::ops::Range { start: (x, y), .. }) = pos {
                 fancy_error(x, y, "./sudoers");
             }
             eprintln!("{msg}");


### PR DESCRIPTION
*sales pitch voice*:

Before:
```
$ target/debug/sudo ls
Parse error: can't assign to boolean setting `env_reset'
Parse error: use quotes around filenames or escape whitespace
```
After:
```
$ target/debug/sudo ls
/etc/sudoers.test:1:22: can't assign to boolean setting `env_reset'
Defaults env_reset = "FOO BAR BAZ"
                     ^
/etc/sudoers.test:2:10: use quotes around filenames or escape whitespace
@include hello world
         ^~~~~~
```
Much nicer, no?

Note that the squigglies are not based on some kind of "skip until the next bit of whitespace" heuristic but the end of them actually indicates the position where the parser rejected the input. The caret generally indicates where the offending element started (but what is considered a "element" depends on context).

And all of this can be yours today! Just click on the *merge* button and GitHub should do the rest! 