### PR TITLE
Safety corrections to libc-cutils

### DIFF
--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -68,3 +68,27 @@ pub fn into_leaky_cstring(s: &str) -> *const libc::c_char {
 
     mem as *mut libc::c_char
 }
+
+#[cfg(test)]
+mod test {
+    use super::{into_leaky_cstring, string_from_ptr};
+
+    #[test]
+    fn test_str_to_ptr() {
+        let strp = |ptr| unsafe { string_from_ptr(ptr) };
+        assert_eq!(strp(std::ptr::null()), "");
+        assert_eq!(strp("\0".as_ptr() as *const libc::c_char), "");
+        assert_eq!(strp("hello\0".as_ptr() as *const libc::c_char), "hello");
+    }
+
+    #[test]
+    fn test_leaky_cstring() {
+        let strp = |ptr| unsafe {
+            let result = string_from_ptr(ptr);
+            libc::free(ptr as *mut libc::c_void);
+            result
+        };
+        assert_eq!(strp(into_leaky_cstring("")), "");
+        assert_eq!(strp(into_leaky_cstring("hello")), "hello");
+    }
+}

--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -249,7 +249,7 @@ pub(crate) extern "C" fn converse<C: Converser>(
             // Unwrap here should be ok because we previously allocated an array of the same size
             let our_resp = &conversation.messages.get(i as usize).unwrap().response;
             if let Some(r) = our_resp {
-                let cstr = sudo_cutils::into_leaky_cstring(r);
+                let cstr = unsafe { sudo_cutils::into_leaky_cstring(r) };
                 response.resp = cstr as *mut _;
             }
         }


### PR DESCRIPTION
`into_leaky_cstring` is an unsafe function and should be marked as such; also added some test cases.