### PR TITLE
PAM module shakedown

### DIFF
--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -205,7 +205,7 @@ pub(crate) extern "C" fn converse<C: Converser>(
             messages: Vec::with_capacity(num_msg as usize),
         };
         for i in 0..num_msg as isize {
-            let message: &pam_message = unsafe { &*((*msg).offset(i)) };
+            let message: &pam_message = unsafe { &**msg.offset(i) };
 
             let msg = unsafe { sudo_cutils::string_from_ptr(message.msg) };
             let style = if let Some(style) = PamMessageStyle::from_int(message.msg_style) {

--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -165,6 +165,7 @@ impl SequentialConverser for CLIConverser {
 pub(crate) struct ConverserData<C> {
     pub(crate) converser: C,
     pub(crate) panicked: bool,
+    pub(crate) _marker: std::marker::PhantomPinned,
 }
 
 impl<C: Converser> ConverserData<C> {
@@ -383,11 +384,12 @@ mod test {
 
     #[test]
     fn pam_gpt() {
-        let mut hello = ConverserData {
+        let mut hello = Box::pin(ConverserData {
             converser: "tux".to_string(),
             panicked: false,
-        };
-        let cookie = PamConvBorrow::new(Pin::new(&mut hello));
+            _marker: std::marker::PhantomPinned,
+        });
+        let cookie = PamConvBorrow::new(hello.as_mut());
         let pam_conv = cookie.borrow();
 
         assert_eq!(dummy_pam(&[], pam_conv), vec![]);

--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -314,12 +314,14 @@ mod test {
             .collect::<Vec<_>>();
 
         let mut raw_response = std::ptr::null::<pam_response>() as *mut _;
-        let conv_err = converse::<String>(
-            ptrs.len() as i32,
-            ptrs.as_ptr() as *mut _,
-            &mut raw_response,
-            talkie.appdata_ptr,
-        );
+        let conv_err = unsafe {
+            talkie.conv.expect("non-null fn ptr")(
+                ptrs.len() as i32,
+                ptrs.as_ptr() as *mut _,
+                &mut raw_response,
+                talkie.appdata_ptr,
+            )
+        };
 
         // deallocate the leaky strings
         for rec in pam_msgs {

--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -308,10 +308,12 @@ mod test {
                 msg: unsafe { sudo_cutils::into_leaky_cstring(msg) },
                 msg_style: *style as i32,
             })
+            .rev()
             .collect::<Vec<pam_message>>();
         let mut ptrs = pam_msgs
             .iter()
             .map(|x| x as *const pam_message)
+            .rev()
             .collect::<Vec<*const pam_message>>();
 
         let mut raw_response = std::ptr::null_mut::<pam_response>();

--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -342,7 +342,9 @@ mod test {
                 } else {
                     // "The resp_retcode member of this struct is unused and should be set to zero."
                     assert_eq!((*ptr).resp_retcode, 0);
-                    Some(sudo_cutils::string_from_ptr((*ptr).resp))
+                    let response = sudo_cutils::string_from_ptr((*ptr).resp);
+                    libc::free((*ptr).resp as *mut _);
+                    Some(response)
                 }
             })
             .collect();

--- a/lib/sudo-pam/src/error.rs
+++ b/lib/sudo-pam/src/error.rs
@@ -180,3 +180,17 @@ pub(crate) fn pam_err(err: libc::c_int, handle: *const pam_handle_t) -> Result<(
         Err(PamError::from_pam(err, handle))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::PamErrorType;
+
+    #[test]
+    fn isomorphy() {
+        for i in -100..100 {
+            let pam = PamErrorType::from_int(i);
+            assert_eq!(pam.as_int(), i);
+            assert_eq!(PamErrorType::from_int(pam.as_int()), pam);
+        }
+    }
+}

--- a/lib/sudo-pam/src/lib.rs
+++ b/lib/sudo-pam/src/lib.rs
@@ -69,6 +69,7 @@ impl<C: Converser> PamContextBuilder<C> {
             let data = ConverserData {
                 converser,
                 panicked: false,
+                _marker: std::marker::PhantomPinned,
             };
 
             let mut context = PamContext {


### PR DESCRIPTION
* Very simple (but nice to have) test that the errno-to-int and vice versa conversion function are consistent
* Exercising the PAM conversation function (let's give Miri something to do)

*Update*
* Fixes a flaw in pam_msgs handling
* Removes any aliasing (Rust rules are on flux on this, but we can avoid it altogether)