### PR TITLE
Add parser for integer 'Default' values

### DIFF
--- a/lib/sudo-defaults/src/lib.rs
+++ b/lib/sudo-defaults/src/lib.rs
@@ -31,7 +31,7 @@ defaults! {
     visiblepw                 = false
 
     passwd_tries              = 3
-    umask                     = 0o22 (!= 0o777)    [#8, 0..=0o777]
+    umask                     = 0o22 (!= 0o777)    [0..=0o777; radix: 8]
 
     editor                    = "/usr/bin/editor"
     lecture_file              = ""
@@ -81,8 +81,8 @@ mod test {
         test! { match_group_by_gid => Flag(false) };
         test! { use_pty => Flag(false) };
         test! { visiblepw => Flag(false) };
-        test! { passwd_tries => Integer(OptTuple { default: 3, negated: None }) };
-        test! { umask => Integer(OptTuple { default: 18, negated: Some(511) }) };
+        test! { passwd_tries => Integer(OptTuple { default: 3, negated: None }, _) };
+        test! { umask => Integer(OptTuple { default: 18, negated: Some(511) }, _) };
         test! { editor => Text(OptTuple { default: "/usr/bin/editor", negated: None }) };
         test! { lecture_file => Text(_) };
         test! { secure_path => Text(OptTuple { default: "", negated: Some("") }) };

--- a/lib/sudo-defaults/src/lib.rs
+++ b/lib/sudo-defaults/src/lib.rs
@@ -3,7 +3,7 @@
 // "verifypw" and "logfile"
 pub enum SudoDefault {
     Flag(bool),
-    Integer(OptTuple<i128>, fn(&str)->Option<i128>),
+    Integer(OptTuple<i128>, fn(&str) -> Option<i128>),
     Text(OptTuple<&'static str>),
     List(&'static [&'static str]),
     Enum(OptTuple<StrEnum<'static>>),

--- a/lib/sudo-defaults/src/lib.rs
+++ b/lib/sudo-defaults/src/lib.rs
@@ -1,10 +1,9 @@
 // FUTURE IDEA: use a representation that allows for more Rust-type structure rather than passing
 // strings around; some settings in sudoers file are more naturally represented like that, such as
 // "verifypw" and "logfile"
-#[derive(Debug)]
 pub enum SudoDefault {
     Flag(bool),
-    Integer(OptTuple<i128>),
+    Integer(OptTuple<i128>, fn(&str)->Option<i128>),
     Text(OptTuple<&'static str>),
     List(&'static [&'static str]),
     Enum(OptTuple<StrEnum<'static>>),
@@ -32,7 +31,7 @@ defaults! {
     visiblepw                 = false
 
     passwd_tries              = 3
-    umask                     = 0o22 (!= 0o777)
+    umask                     = 0o22 (!= 0o777)    [#8, 0..=0o777]
 
     editor                    = "/usr/bin/editor"
     lecture_file              = ""

--- a/lib/sudo-defaults/src/settings_dsl.rs
+++ b/lib/sudo-defaults/src/settings_dsl.rs
@@ -61,7 +61,11 @@ macro_rules! defaults {
             $(stringify!($name)),*
         ];
 
+        // because of the nature of radix and ranges, 'let mut result' is not always necessary, and
+        // a radix of 10 can also not always be avoided (and for uniformity, I would also not avoid this
+        // if this was hand-written code.
         #[allow(unused_mut)]
+        #[allow(clippy::from_str_radix_10)]
         pub fn sudo_default(var: &str) -> Option<SudoDefault> {
             add_from!(Flag, bool);
             add_from!(Integer, i128, negatable, |text| i128::from_str_radix(text, 10).ok());

--- a/lib/sudo-defaults/src/settings_dsl.rs
+++ b/lib/sudo-defaults/src/settings_dsl.rs
@@ -56,7 +56,7 @@ macro_rules! optional {
 }
 
 macro_rules! defaults {
-    ($($name:ident = $value:tt $((!= $negate:tt))? $([$($key:ident),*])? $([#$radix:expr, $range:expr])?)*) => {
+    ($($name:ident = $value:tt $((!= $negate:tt))? $([$($key:ident),*])? $([$first:literal ..= $last:literal$(; radix: $radix: expr)?])?)*) => {
         pub const ALL_PARAMS: &'static [&'static str] = &[
             $(stringify!($name)),*
         ];
@@ -84,7 +84,7 @@ macro_rules! defaults {
                           let mut result = tupleify!(datum$(, restrict($negate))?).into();
                           $(
                               if let SudoDefault::Integer(_, ref mut checker) = &mut result {
-                                  *checker = |text| i128::from_str_radix(text, $radix).ok().filter(|val| $range.contains(val));
+                                  *checker = |text| i128::from_str_radix(text, 10$(*0 + $radix)?).ok().filter(|val| ($first ..= $last).contains(val));
                               }
                           )?
                           result

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -586,9 +586,12 @@ fn get_directive(
                 Some(Setting::Enum(OptTuple {
                     negated: Some(val), ..
                 })) => ConfigValue::Enum(val),
-                Some(Setting::Integer(OptTuple {
-                    negated: Some(val), ..
-                }, _checker)) => ConfigValue::Num(val),
+                Some(Setting::Integer(
+                    OptTuple {
+                        negated: Some(val), ..
+                    },
+                    _checker,
+                )) => ConfigValue::Num(val),
                 _ => unrecoverable!(
                     pos = value_pos,
                     stream,
@@ -617,9 +620,13 @@ fn get_directive(
                         if let Some(value) = checker(&denotation) {
                             make(Defaults(name, ConfigValue::Num(value)))
                         } else {
-                            unrecoverable!(pos = value_pos, stream, "`{denotation}' is not a valid value for {name}");
+                            unrecoverable!(
+                                pos = value_pos,
+                                stream,
+                                "`{denotation}' is not a valid value for {name}"
+                            );
                         }
-                    },
+                    }
                     Setting::List(_) => {
                         let items = parse_vars(stream)?;
                         make(Defaults(name, ConfigValue::List(Mode::Set, items)))
@@ -631,7 +638,11 @@ fn get_directive(
                     Setting::Enum(sudo_defaults::OptTuple { default: key, .. }) => {
                         let text = text_item(stream)?;
                         let Some(value) = key.alt(&text) else {
-                            unrecoverable!(pos = value_pos, stream, "`{text}' is not a valid value for {name}");
+                            unrecoverable!(
+                                pos = value_pos,
+                                stream,
+                                "`{text}' is not a valid value for {name}"
+                            );
                         };
                         make(Defaults(name, ConfigValue::Enum(value)))
                     }

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -312,7 +312,10 @@ impl Parse for ProtoCommandSpec {
                 "sha256" => 256,
                 "sha384" => 384,
                 "sha512" => 512,
-                "sudoedit" => todo!(), // note: special behaviour of forward slashes in wildcards, tread carefully
+                "sudoedit" => {
+                    // note: special behaviour of forward slashes in wildcards, tread carefully
+                    unrecoverable!(stream, "sudoedit is not yet supported");
+                }
                 _ => unrecoverable!(
                     pos = start_pos,
                     stream,
@@ -585,7 +588,7 @@ fn get_directive(
                 })) => ConfigValue::Enum(val),
                 Some(Setting::Integer(OptTuple {
                     negated: Some(val), ..
-                })) => ConfigValue::Num(val),
+                }, _checker)) => ConfigValue::Num(val),
                 _ => unrecoverable!(
                     pos = value_pos,
                     stream,
@@ -604,11 +607,19 @@ fn get_directive(
             } else if is_syntax('-', stream)? {
                 list_items(Mode::Del, name, cfg, stream)
             } else if is_syntax('=', stream)? {
+                let value_pos = stream.get_pos();
                 match cfg {
                     Setting::Flag(_) => {
                         unrecoverable!(stream, "can't assign to boolean setting `{name}'")
                     }
-                    Setting::Integer(_) => todo!(),
+                    Setting::Integer(_, checker) => {
+                        let Decimal(denotation) = expect_nonterminal(stream)?;
+                        if let Some(value) = checker(&denotation) {
+                            make(Defaults(name, ConfigValue::Num(value)))
+                        } else {
+                            unrecoverable!(pos = value_pos, stream, "`{denotation}' is not a valid value for {name}");
+                        }
+                    },
                     Setting::List(_) => {
                         let items = parse_vars(stream)?;
                         make(Defaults(name, ConfigValue::List(Mode::Set, items)))
@@ -618,7 +629,6 @@ fn get_directive(
                         make(Defaults(name, ConfigValue::Text(text)))
                     }
                     Setting::Enum(sudo_defaults::OptTuple { default: key, .. }) => {
-                        let value_pos = stream.get_pos();
                         let text = text_item(stream)?;
                         let Some(value) = key.alt(&text) else {
                             unrecoverable!(pos = value_pos, stream, "`{text}' is not a valid value for {name}");

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -616,7 +616,7 @@ fn get_directive(
                         unrecoverable!(stream, "can't assign to boolean setting `{name}'")
                     }
                     Setting::Integer(_, checker) => {
-                        let Decimal(denotation) = expect_nonterminal(stream)?;
+                        let Numeric(denotation) = expect_nonterminal(stream)?;
                         if let Some(value) = checker(&denotation) {
                             make(Defaults(name, ConfigValue::Num(value)))
                         } else {

--- a/lib/sudoers/src/ast_names.rs
+++ b/lib/sudoers/src/ast_names.rs
@@ -15,7 +15,7 @@ mod names {
         const DESCRIPTION: &'static str = "number";
     }
 
-    impl UserFriendly for tokens::Decimal {
+    impl UserFriendly for tokens::Numeric {
         const DESCRIPTION: &'static str = "number";
     }
 

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -311,7 +311,7 @@ impl Default for Settings {
                 SudoDefault::Enum(OptTuple { default, .. }) => {
                     this.enum_value.insert(key.to_string(), default);
                 }
-                SudoDefault::Integer(OptTuple { default, .. }) => {
+                SudoDefault::Integer(OptTuple { default, .. }, _) => {
                     this.int_value.insert(key.to_string(), default);
                 }
                 SudoDefault::List(default) => {

--- a/lib/sudoers/src/test/mod.rs
+++ b/lib/sudoers/src/test/mod.rs
@@ -316,6 +316,12 @@ fn default_set_test() {
     assert_eq!(settings.str_value["secure_path"], "/etc");
     assert_eq!(settings.int_value["umask"], 0o123);
     assert_eq!(settings.int_value["passwd_tries"], 5);
+
+    assert!(parse_string::<Sudo>("Defaults umask = 789").is_err());
+    assert!(parse_string::<Sudo>("Defaults umask = 1234").is_err());
+    assert!(parse_string::<Sudo>("Defaults verifypw = \"sometimes\"").is_err());
+    assert!(parse_string::<Sudo>("Defaults verifypw = sometimes").is_err());
+    assert!(parse_string::<Sudo>("Defaults verifypw = never").is_ok());
 }
 
 #[test]

--- a/lib/sudoers/src/test/mod.rs
+++ b/lib/sudoers/src/test/mod.rs
@@ -296,8 +296,8 @@ fn default_set_test() {
         "Defaults !env_check",
         "Defaults env_check += \"FOO\"",
         "Defaults env_check += \"XYZZY\"",
-        //"Defaults umask = 0123",
-        //"Defaults passwd_tries = 5",
+        "Defaults umask = 0123",
+        "Defaults passwd_tries = 5",
         "Defaults lecture_file = \"/etc/sudoers\"",
         "Defaults secure_path = /etc"
     ]);
@@ -314,8 +314,8 @@ fn default_set_test() {
     );
     assert_eq!(settings.str_value["lecture_file"], "/etc/sudoers");
     assert_eq!(settings.str_value["secure_path"], "/etc");
-    //assert_eq!(settings.int_value["umask"], 0o123);
-    //assert_eq!(settings.int_value["passwd_tries"], 5);
+    assert_eq!(settings.int_value["umask"], 0o123);
+    assert_eq!(settings.int_value["passwd_tries"], 5);
 }
 
 #[test]

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -49,7 +49,7 @@ impl Token for Numeric {
     }
 
     fn accept(c: char) -> bool {
-        c.is_ascii_digit()
+        c.is_ascii_hexdigit()
     }
 }
 

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -39,19 +39,17 @@ impl Token for Digits {
 }
 
 #[derive(Debug)]
-pub struct Decimal(pub i32);
+pub struct Decimal(pub String);
 
 impl Token for Decimal {
+    const MAX_LEN: usize = 38;
+
     fn construct(s: String) -> Result<Self, String> {
-        Ok(Decimal(s.parse().unwrap()))
+        Ok(Decimal(s))
     }
 
     fn accept(c: char) -> bool {
         c.is_ascii_digit()
-    }
-
-    fn accept_1st(c: char) -> bool {
-        c.is_ascii_digit() || "+-".contains(c)
     }
 }
 

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -39,13 +39,13 @@ impl Token for Digits {
 }
 
 #[derive(Debug)]
-pub struct Decimal(pub String);
+pub struct Numeric(pub String);
 
-impl Token for Decimal {
+impl Token for Numeric {
     const MAX_LEN: usize = 38;
 
     fn construct(s: String) -> Result<Self, String> {
-        Ok(Decimal(s))
+        Ok(Numeric(s))
     }
 
     fn accept(c: char) -> bool {

--- a/test-binaries/sudoers
+++ b/test-binaries/sudoers
@@ -2,6 +2,7 @@ Defaults	env_reset
 Defaults	env_keep = "AAP NOOT MIES"
 Defaults	env_keep += "MIES WIM ZUS JET" * AAP
 Defaults	env_keep -= "AAP NOOT ZUS JET"
+Defaults	umask=778
 
 Defaults	mail_badpass
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"


### PR DESCRIPTION
What it says, this allows the parser to accept integer Default values.

This also adds support for restricting the range of accepted inputs for integer values (and their radix); this turns out to be necessary: for example, a umask value is always parsed as octal (i.e. not all integer values are "the same"). The parser itself should not be bothered with all those minutiae.

Still need to check if there are cases of hexadecimal integers in sudoers.