### PR TITLE
Differentiate between the default user and `-u root`

### DIFF
--- a/lib/sudo-common/src/context.rs
+++ b/lib/sudo-common/src/context.rs
@@ -102,14 +102,19 @@ fn resolve_current_user() -> Result<User, Error> {
 }
 
 fn resolve_target_user(target_name_or_id: &Option<String>) -> Result<User, Error> {
+    let is_default = target_name_or_id.is_none();
     let target_name_or_id = target_name_or_id.as_deref().unwrap_or("root");
 
-    match NameOrId::parse(target_name_or_id) {
+    let mut user = match NameOrId::parse(target_name_or_id) {
         Some(NameOrId::Name(name)) => User::from_name(name)?,
         Some(NameOrId::Id(uid)) => User::from_uid(uid)?,
         _ => None,
     }
-    .ok_or_else(|| Error::UserNotFound(target_name_or_id.to_string()))
+    .ok_or_else(|| Error::UserNotFound(target_name_or_id.to_string()))?;
+
+    user.is_default = is_default;
+
+    Ok(user)
 }
 
 fn resolve_target_group(
@@ -198,6 +203,7 @@ mod tests {
             shell: "/bin/sh".to_string(),
             passwd: String::new(),
             groups: None,
+            is_default: false,
         };
 
         assert_eq!(

--- a/lib/sudo-env/tests/env_tests.rs
+++ b/lib/sudo-env/tests/env_tests.rs
@@ -86,6 +86,7 @@ fn create_test_context<'a>(sudo_options: &'a SudoOptions) -> Context<'a> {
         shell: "/bin/sh".to_string(),
         passwd: String::new(),
         groups: None,
+        is_default: false,
     };
 
     let current_group = Group {
@@ -104,6 +105,7 @@ fn create_test_context<'a>(sudo_options: &'a SudoOptions) -> Context<'a> {
         shell: "/bin/bash".to_string(),
         passwd: String::new(),
         groups: None,
+        is_default: false,
     };
 
     let root_group = Group {

--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -31,7 +31,7 @@ pub fn run_command(ctx: Context<'_>, env: Environment) -> io::Result<ExitStatus>
     // reset env and set filtered environment
     command.args(ctx.command.arguments).env_clear().envs(env);
     // set target user and groups
-    set_target_user(&mut command, ctx.target_user, ctx.target_group);
+    set_target_user(&mut command, ctx.current_user, ctx.target_user, ctx.target_group);
     // spawn and exec to command
     let mut child = command.spawn()?;
 

--- a/lib/sudo-pam/src/lib.rs
+++ b/lib/sudo-pam/src/lib.rs
@@ -250,6 +250,7 @@ impl<'a, C: Converser> PamContext<'a, C> {
 
     /// Set the user that is requesting the authentication.
     pub fn set_requesting_user(&mut self, user: &str) -> PamResult<()> {
+        eprintln!("REQUIESTING USER: {:?}", user);
         let c_user = CString::new(user)?;
         let res = unsafe {
             pam_set_item(
@@ -271,6 +272,7 @@ impl<'a, C: Converser> PamContext<'a, C> {
 
     /// Set the user that will be authenticated.
     pub fn set_user(&mut self, user: &str) -> PamResult<()> {
+        eprintln!("SET USER: {:?}", user);
         let c_user = CString::new(user)?;
         let res = unsafe {
             pam_set_item(

--- a/test-framework/sudo-compliance-tests/src/flag_group.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_group.rs
@@ -28,7 +28,6 @@ fn changes_the_group_id() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn adds_group_to_groups_output() -> Result<()> {
     let extra_group = "rustaceans";
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD)


### PR DESCRIPTION
For some reason this breaks the `password_assignment_works`  due to an Authentication error but I'm not sure why.

Any help on figuring out why is it breaking would be greatly appreciated (:wink: @rnijveld)