### PR TITLE
Allow for multiple RunAs specs on one line.

### DIFF
--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -679,38 +679,3 @@ impl Parse for (String, ConfigValue) {
 }
 
 impl Many for (String, ConfigValue) {}
-
-/// A bit of the hack to make semantic analysis easier: a CommandSpec has attributes, but most
-/// other elements that occur in a [crate::ast::Qualified] wrapper do not.
-/// The [Tagged] trait allows getting these tags (defaulting to `()`, i.e. no attributes)
-
-pub trait Tagged<U> {
-    type Flags;
-    fn into(&self) -> &Spec<U>;
-    fn to_info(&self) -> &Self::Flags;
-}
-
-pub const NO_TAG: &() = &();
-
-/// Default implementation
-
-impl<T> Tagged<T> for Spec<T> {
-    type Flags = ();
-    fn into(&self) -> &Spec<T> {
-        self
-    }
-    fn to_info(&self) -> &() {
-        NO_TAG
-    }
-}
-/// Special implementation for [CommandSpec]
-
-impl Tagged<Command> for CommandSpec {
-    type Flags = Tag;
-    fn into(&self) -> &Spec<Command> {
-        &self.1
-    }
-    fn to_info(&self) -> &Self::Flags {
-        &self.0
-    }
-}

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -69,10 +69,12 @@ impl std::fmt::Debug for CommandSpec {
 }
 
 /// The main AST object for one sudoer-permission line
+type PairVec<A, B> = Vec<(A, Vec<B>)>;
+
 #[derive(Debug)]
 pub struct PermissionSpec {
     pub users: SpecList<UserSpecifier>,
-    pub permissions: Vec<(SpecList<Hostname>, Vec<(Option<RunAs>, CommandSpec)>)>,
+    pub permissions: PairVec<SpecList<Hostname>, (Option<RunAs>, CommandSpec)>,
 }
 
 #[derive(Debug)]
@@ -376,11 +378,10 @@ impl Many for (SpecList<Hostname>, Vec<(Option<RunAs>, CommandSpec)>) {
 impl Parse for (Option<RunAs>, CommandSpec) {
     fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
         let runas: Option<RunAs> = try_nonterminal(stream)?;
-        let cmd;
-        if runas.is_some() {
-            cmd = expect_nonterminal(stream)?
+        let cmd = if runas.is_some() {
+            expect_nonterminal(stream)?
         } else {
-            cmd = try_nonterminal(stream)?
+            try_nonterminal(stream)?
         };
 
         make((runas, cmd))

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -3,8 +3,7 @@ use crate::basic_parser::*;
 use crate::tokens::*;
 
 /// The Sudoers file allows negating items with the exclamation mark.
-#[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Qualified<T> {
     Allow(T),
     Forbid(T),
@@ -15,16 +14,14 @@ pub type Spec<T> = Qualified<Meta<T>>;
 pub type SpecList<T> = Vec<Spec<T>>;
 
 /// An identifier is a name or a #number
-#[derive(Debug)]
-#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
+#[cfg_attr(test, derive(Clone, Debug, PartialEq, Eq))]
 pub enum Identifier {
     Name(String),
     ID(u32),
 }
 
 /// A userspecifier is either a username, or a (non-unix) group name, or netgroup
-#[derive(Debug)]
-#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
+#[cfg_attr(test, derive(Clone, Debug, PartialEq, Eq))]
 pub enum UserSpecifier {
     User(Identifier),
     Group(Identifier),
@@ -32,15 +29,14 @@ pub enum UserSpecifier {
 }
 
 /// The RunAs specification consists of a (possibly empty) list of userspecifiers, followed by a (possibly empty) list of groups.
-#[derive(Debug, Default)]
 pub struct RunAs {
     pub users: SpecList<UserSpecifier>,
     pub groups: SpecList<Identifier>,
 }
 
 /// Commands in /etc/sudoers can have attributes attached to them, such as NOPASSWD, NOEXEC, ...
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct Tag {
     pub passwd: bool,
     pub cwd: Option<ChDir>,
@@ -58,30 +54,17 @@ impl Default for Tag {
 /// Commands with attached attributes.
 pub struct CommandSpec(pub Vec<Modifier>, pub Spec<Command>, pub Sha2);
 
-impl std::fmt::Debug for CommandSpec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("CommandSpec")
-            .field(&format!("<{} modifiers>", self.0.len()))
-            .field(&self.1)
-            .field(&self.2)
-            .finish()
-    }
-}
-
 /// The main AST object for one sudoer-permission line
 type PairVec<A, B> = Vec<(A, Vec<B>)>;
 
-#[derive(Debug)]
 pub struct PermissionSpec {
     pub users: SpecList<UserSpecifier>,
     pub permissions: PairVec<SpecList<Hostname>, (Option<RunAs>, CommandSpec)>,
 }
 
-#[derive(Debug)]
 pub struct Def<T>(pub String, pub SpecList<T>);
 
 /// AST object for directive specifications (aliases, arguments, etc)
-#[derive(Debug)]
 pub enum Directive {
     UserAlias(Def<UserSpecifier>),
     HostAlias(Def<Hostname>),
@@ -92,7 +75,6 @@ pub enum Directive {
 
 pub type TextEnum = sudo_defaults::StrEnum<'static>;
 
-#[derive(Debug)]
 pub enum ConfigValue {
     Flag(bool),
     Text(Option<Box<str>>),
@@ -101,7 +83,6 @@ pub enum ConfigValue {
     Enum(TextEnum),
 }
 
-#[derive(Debug)]
 pub enum Mode {
     Add,
     Set,
@@ -109,7 +90,6 @@ pub enum Mode {
 }
 
 /// The Sudoers file can contain permissions and directives
-#[derive(Debug)]
 pub enum Sudo {
     Spec(PermissionSpec),
     Decl(Directive),

--- a/lib/sudoers/src/ast_names.rs
+++ b/lib/sudoers/src/ast_names.rs
@@ -39,17 +39,17 @@ mod names {
         const DESCRIPTION: &'static str = "path to binary (or sudoedit)";
     }
 
-    impl UserFriendly for CommandSpec {
-        const DESCRIPTION: &'static str = tokens::Command::DESCRIPTION;
-    }
-
     impl UserFriendly
         for (
             SpecList<tokens::Hostname>,
-            PairVec<Option<RunAs>, CommandSpec>,
+            Vec<(Option<RunAs>, CommandSpec)>,
         )
     {
         const DESCRIPTION: &'static str = tokens::Hostname::DESCRIPTION;
+    }
+
+    impl UserFriendly for (Option<RunAs>, CommandSpec) {
+        const DESCRIPTION: &'static str = "(users:groups) specification";
     }
 
     // this can never happen, as parse<Sudo> always succeeds
@@ -89,8 +89,8 @@ mod names {
         const DESCRIPTION: &'static str = "digest";
     }
 
-    impl UserFriendly for ProtoCommandSpec {
-        const DESCRIPTION: &'static str = CommandSpec::DESCRIPTION;
+    impl UserFriendly for CommandSpec {
+        const DESCRIPTION: &'static str = tokens::Command::DESCRIPTION;
     }
 
     impl UserFriendly for tokens::ChDir {

--- a/lib/sudoers/src/ast_names.rs
+++ b/lib/sudoers/src/ast_names.rs
@@ -43,7 +43,12 @@ mod names {
         const DESCRIPTION: &'static str = tokens::Command::DESCRIPTION;
     }
 
-    impl UserFriendly for (SpecList<tokens::Hostname>, Option<RunAs>, Vec<CommandSpec>) {
+    impl UserFriendly
+        for (
+            SpecList<tokens::Hostname>,
+            PairVec<Option<RunAs>, CommandSpec>,
+        )
+    {
         const DESCRIPTION: &'static str = tokens::Hostname::DESCRIPTION;
     }
 

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -138,8 +138,12 @@ fn check_permission<User: UnixUser + PartialEq<User>, Group: UnixGroup>(
             Some(&sudo.permissions)
         })
         .flatten()
-        .filter_map(|(hosts, runas, cmds)| {
+        .filter_map(|(hosts, runas_cmds)| {
             find_item(hosts, &match_token(on_host), &host_aliases)?;
+            Some(runas_cmds)
+        })
+        .flatten()
+        .filter_map(|(runas, cmds)| {
             if let Some(RunAs { users, groups }) = runas {
                 if !users.is_empty() || request.user != am_user {
                     find_item(users, &match_user(request.user), &runas_user_aliases)?

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -189,6 +189,41 @@ where
     None
 }
 
+/// A bit of the hack to make semantic analysis easier: a CommandSpec has attributes, but most
+/// other elements that occur in a [crate::ast::Qualified] wrapper do not.
+/// The [Tagged] trait allows getting these tags (defaulting to `()`, i.e. no attributes)
+
+pub trait Tagged<U> {
+    type Flags;
+    fn into(&self) -> &Spec<U>;
+    fn to_info(&self) -> &Self::Flags;
+}
+
+pub const NO_TAG: &() = &();
+
+/// Default implementation
+
+impl<T> Tagged<T> for Spec<T> {
+    type Flags = ();
+    fn into(&self) -> &Spec<T> {
+        self
+    }
+    fn to_info(&self) -> &() {
+        NO_TAG
+    }
+}
+/// Special implementation for [CommandSpec]
+
+impl Tagged<Command> for CommandSpec {
+    type Flags = Tag;
+    fn into(&self) -> &Spec<Command> {
+        &self.1
+    }
+    fn to_info(&self) -> &Self::Flags {
+        &self.0
+    }
+}
+
 fn match_user(user: &impl UnixUser) -> impl Fn(&UserSpecifier) -> bool + '_ {
     move |spec| match spec {
         UserSpecifier::User(id) => match_identifier(user, id),

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -38,7 +38,7 @@ pub struct Request<'a, User: UnixUser, Group: UnixGroup> {
     pub arguments: &'a str,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Judgement {
     flags: Option<Tag>,
     settings: Settings,
@@ -314,7 +314,7 @@ fn match_identifier(user: &impl UnixUser, ident: &ast::Identifier) -> bool {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Settings {
     pub flags: HashSet<String>,
     pub str_value: HashMap<String, Option<Box<str>>>,

--- a/lib/sudoers/src/test/mod.rs
+++ b/lib/sudoers/src/test/mod.rs
@@ -3,16 +3,6 @@ use crate::ast;
 use basic_parser::{parse_eval, parse_lines, parse_string};
 use std::iter;
 
-// parsing a single CommandSpec is useful in some tests
-impl basic_parser::Parse for CommandSpec {
-    fn parse(stream: &mut impl basic_parser::CharStream) -> basic_parser::Parsed<Self> {
-        let vec: Vec<_> = basic_parser::try_nonterminal(stream)?;
-        assert_eq!(vec.len(), 1);
-        let result = vec.into_iter().next().unwrap();
-        Ok(result)
-    }
-}
-
 #[derive(PartialEq)]
 struct Named(&'static str);
 

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -2,7 +2,6 @@
 
 use crate::basic_parser::{Many, Token};
 
-#[derive(Debug)]
 #[cfg_attr(test, derive(Clone, PartialEq, Eq))]
 pub struct Username(pub String);
 
@@ -23,7 +22,6 @@ impl Token for Username {
 
 impl Many for Username {}
 
-#[derive(Debug)]
 pub struct Digits(pub u32);
 
 impl Token for Digits {
@@ -38,7 +36,6 @@ impl Token for Digits {
     }
 }
 
-#[derive(Debug)]
 pub struct Numeric(pub String);
 
 impl Token for Numeric {
@@ -54,7 +51,6 @@ impl Token for Numeric {
 }
 
 /// A hostname consists of alphanumeric characters and ".", "-",  "_"
-#[derive(Debug)]
 pub struct Hostname(pub String);
 
 impl std::ops::Deref for Hostname {
@@ -79,8 +75,7 @@ impl Many for Hostname {}
 
 /// This enum allows items to use the ALL wildcard or be specified with aliases, or directly.
 /// (Maybe this is better defined not as a Token but simply directly as an implementation of [crate::basic_parser::Parse])
-#[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum Meta<T> {
     All,
     Only(T),
@@ -122,7 +117,6 @@ impl<T: Many> Many for Meta<T> {
 }
 
 /// An identifier that consits of only uppercase characters.
-#[derive(Debug)]
 pub struct Upper(pub String);
 
 impl Token for Upper {
@@ -250,8 +244,8 @@ impl Token for StringParameter {
 }
 
 // a path used for in CWD and CHROOT specs
-#[derive(Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum ChDir {
     Path(std::path::PathBuf),
     Any,
@@ -286,7 +280,6 @@ impl Token for ChDir {
 
 /// A digest specifier; note that the type of hash is implied by the length; if sudo would support
 /// multiple hashes with the same hash length, this needs to be recorded explicity.
-#[derive(Debug)]
 pub struct Sha2(pub Box<[u8]>);
 
 impl Token for Sha2 {

--- a/test-binaries/checkpermit.rs
+++ b/test-binaries/checkpermit.rs
@@ -1,6 +1,6 @@
 use std::env;
 use sudo_system::interface::{UnixGroup, UnixUser};
-use sudoers::Sudoers;
+use sudoers::{Authorization, Policy, Sudoers};
 
 fn chatty_check_permission(
     sudoers: sudoers::Sudoers,
@@ -28,7 +28,14 @@ fn chatty_check_permission(
             arguments: &arguments,
         },
     );
-    println!("OUTCOME: {result:?}");
+    println!(
+        "OUTCOME: {}",
+        match result.authorization() {
+            Authorization::Passed => "NOPASSWD",
+            Authorization::Forbidden => "<not allowed>",
+            Authorization::Required => "PASSWD",
+        }
+    );
 }
 
 /// This is the "canonical" info that we need

--- a/test-binaries/sudoers
+++ b/test-binaries/sudoers
@@ -21,3 +21,4 @@ rob ALL=(ALL:ALL) sha256:553d3aab148c4d11d76b4f96b5664b42cfc38c236dacbaf9e42d6a6
 rob ALL=(ALL:ALL) /bin/ps
 
 ALL ALL=(ALL:ALL) sha384:2385983b239c9480f330a210ff59d2fedb9df00713187ecd143e9790503c9b3cf0e322b264d60cab381a2b07f975493c /bin/more
+ALL ALL=(ALL:ALL) /bin/ps, (root) /bin/true

--- a/test-framework/sudo-compliance-tests/src/sudoers/cmnd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/cmnd.rs
@@ -129,7 +129,6 @@ fn nopasswd_override() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn runas_override() -> Result<()> {
     let env = Env(format!("ALL ALL = (root) /bin/ls, ({USERNAME}) /bin/true"))
         .user(USERNAME)
@@ -177,7 +176,6 @@ fn runas_override() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn runas_override_repeated_cmnd_means_runas_union() -> Result<()> {
     let env = Env(format!(
         "ALL ALL = (root) /bin/true, ({USERNAME}) /bin/true"


### PR DESCRIPTION
Some guides to this PR:
- since adding multiple runas-specs would add a third nesting level, the check_permission function is changed to be more linear (by chaining iterators)
- the second and third commits move the "Tagged" trait closer to the `find_item` function (which needs it), and makes it a bit more readable
- the fourth commit gently changes the AST (without a functional change) so `check_permission` already has the right shape

After that happen the actual changes to the parser; previously we processed the accumulation of tags like "NOPASSWD:" in the parser (by first parsing the raw sudo syntax and then cooking them into a `Vec<CommandSpec>`). After this change the parser itself is a bit dumber and all the logic happens in `distribute_tags` in lib.rs)

Fun was had discovering a bug caused by an improper use of `map()`, fixed by c1fab8c.