### PR TITLE
Increase test coverage

### DIFF
--- a/lib/sudoers/src/policy.rs
+++ b/lib/sudoers/src/policy.rs
@@ -16,6 +16,8 @@ pub trait Policy {
     }
 }
 
+#[must_use]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub enum Authorization {
     Required,
     Passed,
@@ -66,5 +68,27 @@ impl PreJudgementPolicy for Sudoers {
         } else {
             Some(path)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn authority_xlat_test() {
+        use crate::Tag;
+        let mut judge: Judgement = Default::default();
+        assert_eq!(judge.authorization(), Authorization::Forbidden);
+        judge.flags = Some(Tag {
+            passwd: true,
+            ..judge.flags.unwrap_or_default()
+        });
+        assert_eq!(judge.authorization(), Authorization::Required);
+        judge.flags = Some(Tag {
+            passwd: false,
+            ..judge.flags.unwrap_or_default()
+        });
+        assert_eq!(judge.authorization(), Authorization::Passed);
     }
 }

--- a/lib/sudoers/src/test/mod.rs
+++ b/lib/sudoers/src/test/mod.rs
@@ -225,6 +225,11 @@ fn permission_test() {
     pass!(["%#1466 server=(ALL:ALL) ALL"], "user" => root(), "server"; "/bin/hello");
     FAIL!(["#1466 server=(ALL:ALL) ALL"], "root" => root(), "server"; "/bin/hello");
     FAIL!(["%#1466 server=(ALL:ALL) ALL"], "root" => root(), "server"; "/bin/hello");
+    pass!(["#1466,#1234,foo server=(ALL:ALL) ALL"], "user" => root(), "server"; "/bin/hello");
+    pass!(["#1234,foo,#1466 server=(ALL:ALL) ALL"], "user" => root(), "server"; "/bin/hello");
+    pass!(["foo,#1234,#1466 server=(ALL:ALL) ALL"], "user" => root(), "server"; "/bin/hello");
+    FAIL!(["foo,#1234,#1366 server=(ALL:ALL) ALL"], "user" => root(), "server"; "/bin/hello");
+    FAIL!(["#1366,#1234,foo server=(ALL:ALL) ALL"], "user" => root(), "server"; "/bin/hello");
     pass!(["user ALL=(ALL:#1466) /bin/foo"], "user" => request! { root, root }, "server"; "/bin/foo");
     FAIL!(["user ALL=(ALL:#1466) /bin/foo"], "user" => request! { root, other }, "server"; "/bin/foo");
     pass!(["user ALL=(ALL:#1466) /bin/foo"], "user" => request! { root, user }, "server"; "/bin/foo");


### PR DESCRIPTION
There was a missing test-case for the code path that handled `#1, #2 machine=(runas) command`; also putting `must_use` on the authorization type is probably a good idea :-)