### PR TITLE
Unsafe code review

### DIFF
--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -55,17 +55,17 @@ pub unsafe fn string_from_ptr(ptr: *const libc::c_char) -> String {
 
 /// Create a C string copy of a Rust string copy, allocated by libc::malloc()
 ///
-/// # Safety
-/// This function assumes that the caller will clean up the returned pointer
-/// via a call to libc::free.
-pub unsafe fn into_leaky_cstring(s: &str) -> *const libc::c_char {
+/// The returned pointer **must** be cleaned up via a call to `libc::free`.
+pub fn into_leaky_cstring(s: &str) -> *const libc::c_char {
     let alloc_len: isize = s.len().try_into().expect("absurd string size");
-    let mem = libc::malloc(alloc_len as usize + 1) as *mut u8;
+    let mem = unsafe { libc::malloc(alloc_len as usize + 1) } as *mut u8;
     if mem.is_null() {
         panic!("libc malloc failed");
     } else {
-        std::ptr::copy_nonoverlapping(s.as_ptr(), mem, alloc_len as usize);
-        *mem.offset(alloc_len) = 0;
+        unsafe {
+            std::ptr::copy_nonoverlapping(s.as_ptr(), mem, alloc_len as usize);
+            *mem.offset(alloc_len) = 0;
+        }
     }
 
     mem as *mut libc::c_char

--- a/lib/sudo-defaults/src/lib.rs
+++ b/lib/sudo-defaults/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 // FUTURE IDEA: use a representation that allows for more Rust-type structure rather than passing
 // strings around; some settings in sudoers file are more naturally represented like that, such as
 // "verifypw" and "logfile"

--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -181,7 +181,7 @@ pub(crate) struct ConverserData<C> {
 /// * If called with an appdata_ptr that does not correspond with the Converser
 ///   this function will exhibit undefined behavior.
 /// * The messages from PAM are assumed to be formatted correctly.
-pub(crate) extern "C" fn converse<C: Converser>(
+pub(crate) unsafe extern "C" fn converse<C: Converser>(
     num_msg: libc::c_int,
     msg: *mut *const pam_message,
     response: *mut *mut pam_response,

--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -239,7 +239,7 @@ pub(crate) unsafe extern "C" fn converse<C: Converser>(
             // Unwrap here should be ok because we previously allocated an array of the same size
             let our_resp = &conversation.messages.get(i as usize).unwrap().response;
             if let Some(r) = our_resp {
-                let cstr = unsafe { sudo_cutils::into_leaky_cstring(r) };
+                let cstr = sudo_cutils::into_leaky_cstring(r);
                 response.resp = cstr as *mut _;
             }
         }
@@ -293,7 +293,7 @@ mod test {
         let pam_msgs = msgs
             .iter()
             .map(|PamMessage { msg, style, .. }| pam_message {
-                msg: unsafe { sudo_cutils::into_leaky_cstring(msg) },
+                msg: sudo_cutils::into_leaky_cstring(msg),
                 msg_style: *style as i32,
             })
             .rev()

--- a/lib/sudo-system/src/audit.rs
+++ b/lib/sudo-system/src/audit.rs
@@ -41,3 +41,22 @@ pub fn secure_open(path: &Path) -> io::Result<File> {
         Ok(file)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::secure_open;
+    use std::path::Path;
+
+    #[test]
+    fn secure_open_is_predictable() {
+        // /etc/hosts should be readable and "secure" (if this test fails, you have been compromised)
+        assert!(std::fs::File::open("/etc/hosts").is_ok());
+        assert!(secure_open(Path::new("/etc/hosts")).is_ok());
+        // /var/log/utmp should be readable, but not secure (writeable by group other than root)
+        assert!(std::fs::File::open("/var/log/wtmp").is_ok());
+        assert!(secure_open(Path::new("/var/log/wtmp")).is_err());
+        // /etc/shadow should not be readable
+        assert!(std::fs::File::open("/etc/shadow").is_err());
+        assert!(secure_open(Path::new("/etc/shadow")).is_err());
+    }
+}

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -106,15 +106,18 @@ pub struct User {
 }
 
 impl User {
-    pub fn from_libc(pwd: &libc::passwd) -> User {
+    /// # Safety
+    /// This function expects `pwd` to be a result from a succesful call to `getpwXXX_r`.
+    /// (It can cause UB if any of `pwd`'s pointed-to strings does not have a null-terminator.)
+    unsafe fn from_libc(pwd: &libc::passwd) -> User {
         User {
             uid: pwd.pw_uid,
             gid: pwd.pw_gid,
-            name: unsafe { string_from_ptr(pwd.pw_name) },
-            gecos: unsafe { string_from_ptr(pwd.pw_gecos) },
-            home: unsafe { string_from_ptr(pwd.pw_dir) },
-            shell: unsafe { string_from_ptr(pwd.pw_shell) },
-            passwd: unsafe { string_from_ptr(pwd.pw_passwd) },
+            name: string_from_ptr(pwd.pw_name),
+            gecos: string_from_ptr(pwd.pw_gecos),
+            home: string_from_ptr(pwd.pw_dir),
+            shell: string_from_ptr(pwd.pw_shell),
+            passwd: string_from_ptr(pwd.pw_passwd),
             groups: None,
             is_default: false,
         }
@@ -138,7 +141,7 @@ impl User {
             Ok(None)
         } else {
             let pwd = unsafe { pwd.assume_init() };
-            Ok(Some(Self::from_libc(&pwd)))
+            Ok(Some(unsafe { Self::from_libc(&pwd) }))
         }
     }
 
@@ -177,7 +180,7 @@ impl User {
             Ok(None)
         } else {
             let pwd = unsafe { pwd.assume_init() };
-            Ok(Some(Self::from_libc(&pwd)))
+            Ok(Some(unsafe { Self::from_libc(&pwd) }))
         }
     }
 
@@ -219,6 +222,7 @@ impl User {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Group {
     pub gid: libc::gid_t,
     pub name: String,
@@ -227,24 +231,28 @@ pub struct Group {
 }
 
 impl Group {
-    pub fn from_libc(grp: &libc::group) -> Group {
+    /// # Safety
+    /// This function expects `grp` to be a result from a succesful call to `getgrXXX_r`.
+    /// In particular the grp.gr_mem pointer is assumed to be non-null, and pointing to a
+    /// null-terminated list; the pointed-to strings are expected to be null-terminated.
+    unsafe fn from_libc(grp: &libc::group) -> Group {
         // find out how many members we have
         let mut mem_count = 0;
-        while unsafe { !(*grp.gr_mem.offset(mem_count)).is_null() } {
+        while !(*grp.gr_mem.offset(mem_count)).is_null() {
             mem_count += 1;
         }
 
         // convert the members to a slice and then put them into a vec of strings
         let mut members = Vec::with_capacity(mem_count as usize);
-        let mem_slice = unsafe { std::slice::from_raw_parts(grp.gr_mem, mem_count as usize) };
+        let mem_slice = std::slice::from_raw_parts(grp.gr_mem, mem_count as usize);
         for mem in mem_slice {
-            members.push(unsafe { string_from_ptr(*mem) });
+            members.push(string_from_ptr(*mem));
         }
 
         Group {
             gid: grp.gr_gid,
-            name: unsafe { string_from_ptr(grp.gr_name) },
-            passwd: unsafe { string_from_ptr(grp.gr_passwd) },
+            name: string_from_ptr(grp.gr_name),
+            passwd: string_from_ptr(grp.gr_passwd),
             members,
         }
     }
@@ -283,7 +291,7 @@ impl Group {
             Ok(None)
         } else {
             let grp = unsafe { grp.assume_init() };
-            Ok(Some(Group::from_libc(&grp)))
+            Ok(Some(unsafe { Group::from_libc(&grp) }))
         }
     }
 
@@ -306,7 +314,7 @@ impl Group {
             Ok(None)
         } else {
             let grp = unsafe { grp.assume_init() };
-            Ok(Some(Group::from_libc(&grp)))
+            Ok(Some(unsafe { Group::from_libc(&grp) }))
         }
     }
 }
@@ -393,5 +401,45 @@ mod tests {
 
         assert_eq!(root.uid, 0);
         assert_eq!(root.name, "root");
+    }
+
+    #[test]
+    fn test_group_impl() {
+        use super::Group;
+        use std::ffi::CString;
+
+        fn test(name: &str, passwd: &str, gid: libc::gid_t, mem: &[&str]) {
+            assert_eq!(
+                {
+                    let c_mem: Vec<CString> =
+                        mem.iter().map(|&s| CString::new(s).unwrap()).collect();
+                    let c_name = CString::new(name).unwrap();
+                    let c_passwd = CString::new(passwd).unwrap();
+                    unsafe {
+                        Group::from_libc(&libc::group {
+                            gr_name: c_name.as_ptr() as *mut _,
+                            gr_passwd: c_passwd.as_ptr() as *mut _,
+                            gr_gid: gid,
+                            gr_mem: c_mem
+                                .iter()
+                                .map(|cs| cs.as_ptr() as *mut _)
+                                .chain(std::iter::once(std::ptr::null_mut()))
+                                .collect::<Vec<*mut libc::c_char>>()
+                                .as_mut_ptr(),
+                        })
+                    }
+                },
+                Group {
+                    name: name.to_string(),
+                    passwd: passwd.to_string(),
+                    gid,
+                    members: mem.iter().map(|s| s.to_string()).collect(),
+                }
+            )
+        }
+
+        test("dr. bill", "fidelio", 1999, &["eyes", "wide", "shut"]);
+        test("eris", "fnord", 5, &[]);
+        test("abc", "password123", 42, &[""]);
     }
 }


### PR DESCRIPTION
I walked through the code base looking for `unsafe`; most of them are simple and safe calls to `libc` functions, with the exception of the PAM conversation handler and some conversion functions in `sudo-system`.

Changes in this PR (none of them change any observable behaviour):

* sudo-defaults
   - we forgot to slap "forbid(unsafe_code)" on here.
* sudo-cutils:
  - declares leaky_c_string to be safe; this doesn't matter much since it's only called from unsafe functions & was only declared unsafe because it leaked memory.
* sudo-pam:
  - adds missing unsafe to the conversation function
* sudo-system:
  - marks 'from_libc' fn's as unsafe (it can UB on wrong inputs) and private (no reason to call them outside this crate)
  - adds a unit test for the Group::from_libc function (the user one was already tested)
  - adds a unit test for `secure_open` (*should* work on any reasonable Linux box)
 