### PR TITLE
Enable opt-in Miri tests in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: miri
-          args: test --release --all-features
+          args: test --workspace --all-features miri
 
   format:
     runs-on: ubuntu-latest

--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -76,7 +76,7 @@ mod test {
     use super::{into_leaky_cstring, string_from_ptr};
 
     #[test]
-    fn test_str_to_ptr() {
+    fn miri_test_str_to_ptr() {
         let strp = |ptr| unsafe { string_from_ptr(ptr) };
         assert_eq!(strp(std::ptr::null()), "");
         assert_eq!(strp("\0".as_ptr() as *const libc::c_char), "");
@@ -84,7 +84,7 @@ mod test {
     }
 
     #[test]
-    fn test_leaky_cstring() {
+    fn miri_test_leaky_cstring() {
         let test = |text| unsafe {
             let ptr = into_leaky_cstring(text);
             let result = string_from_ptr(ptr);

--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -382,7 +382,7 @@ mod test {
     }
 
     #[test]
-    fn pam_gpt() {
+    fn miri_pam_gpt() {
         let mut hello = Box::pin(ConverserData {
             converser: "tux".to_string(),
             panicked: false,

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
     }
 
     #[test]
-    fn test_group_impl() {
+    fn miri_test_group_impl() {
         use super::Group;
         use std::ffi::CString;
 


### PR DESCRIPTION
This adds a opt-in test to Miri. To have a unit-test run by miri, prefix it with `miri_`. Note that this can even be useful for safe code since Miri can detect memory leaks (but in safe code a static analysis should also be able to check that).

An alternative is to add `#[cfg(not(miri))]` on tests (i.e. "opt-out"), but that seems more annoying at the moment.

(Builds on top of #168.)

To see this in action, see PR #171.