### PR TITLE
compliance tests: bump sudo version to 1.9.5

### DIFF
--- a/test-framework/sudo-test/src/theirs.Dockerfile
+++ b/test-framework/sudo-test/src/theirs.Dockerfile
@@ -1,3 +1,3 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends sudo


### PR DESCRIPTION
this PR changes the base of the ogsudo docker image from debian buster (1.8.27) to debian bullseye (1.9.5)

because of change in ogsudo [defaults](https://github.com/memorysafety/sudo-rs/issues/137#issuecomment-1483656845) this effectively
closes #137 
closes #138 

the tests associated to those two issues have been updated to check for "rejection" rather than "acceptance"

if we decide to support `allow_unknown_runas_id` we can bring the old versions of the tests back (they'll be in the git history)