### PR TITLE
sudo-test: remove default sudoers from ogsudo image

### DIFF
--- a/test-framework/sudo-test/src/theirs.Dockerfile
+++ b/test-framework/sudo-test/src/theirs.Dockerfile
@@ -1,3 +1,4 @@
 FROM debian:buster-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends sudo
+    apt-get install -y --no-install-recommends sudo && \
+    rm /etc/sudoers


### PR DESCRIPTION
this has no effect on compliance tests because all start by creating a `/etc/sudoers` file. however, when using the sudo-test docker image as a sudo playground I have sometimes forgotten to override the stock `/etc/sudoers` include in the ogsudo image which has let to confusion when comparing sudo-rs (configured with a truly minimal one-line sudoers file) and ogsudo (configured with debian's stock sudoers file)

with this change, both images start with no sudoers file reducing the chance of comparing two sudo implementations that are configured differently