### PR TITLE
CI: use caching to speed up compliance-tests job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,9 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: set up docker buildx
+        run: docker buildx create --name builder --use
+
       - name: cache docker layers
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,13 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: cache docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: docker-buildx-${{ github.sha }}
+          restore-keys: docker-buildx-
+
       - name: Test sudo-test itself
         working-directory: test-framework
         run: cargo test -p sudo-test
@@ -45,6 +52,11 @@ jobs:
           tmpfile="$(mktemp)"
           cargo test -p sudo-compliance-tests -- --ignored | tee "$tmpfile"
           grep 'test result: FAILED. 0 passed' "$tmpfile" || exit 1
+
+      - name: prevent the cache from growing too large
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,9 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            test-framework
 
       - name: Test sudo-test itself
         working-directory: test-framework

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,9 @@ jobs:
           key: docker-buildx-${{ github.sha }}
           restore-keys: docker-buildx-
 
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Test sudo-test itself
         working-directory: test-framework
         run: cargo test -p sudo-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           SUDO_UNDER_TEST: ours
         run: cargo test -p sudo-compliance-tests
 
-      - name: Check that we didn't forgot to gate a passing compliance test
+      - name: Check that we didn't forget to gate a passing compliance test
         working-directory: test-framework
         env:
           SUDO_UNDER_TEST: ours

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ on:
 jobs:
   compliance-tests:
     runs-on: ubuntu-latest
+    env:
+      SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
     steps:
       - uses: actions/checkout@v2
 

--- a/test-framework/README.md
+++ b/test-framework/README.md
@@ -25,6 +25,15 @@ To run the "gated" compliance tests against sudo-rs set the `SUDO_UNDER_TEST` va
 $ SUDO_UNDER_TEST=ours cargo test -p sudo-compliance-tests
 ```
 
+## Verbose docker build
+
+The first unit test that runs will build a docker image that the rest of unit tests will use.
+To print the output of the `docker build` command set the `SUDO_TEST_VERBOSE_DOCKER_BUILD` variable.
+
+``` console
+$ SUDO_TEST_VERBOSE_DOCKER_BUILD=1 cargo test -p sudo-compliance-tests -- --include-ignored
+```
+
 ## Gating CI on selected tests
 
 Tests (`#[test]` functions) that exercise behavior not yet implemented in sudo-rs MUST be marked as `#[ignored]`.

--- a/test-framework/sudo-test/src/docker.rs
+++ b/test-framework/sudo-test/src/docker.rs
@@ -130,7 +130,13 @@ pub fn build_base_image() -> Result<()> {
         }
     }
 
-    run(&mut cmd, None)?.assert_success()?;
+    if env::var_os("SUDO_TEST_VERBOSE_DOCKER_BUILD").is_none() {
+        cmd.stderr(Stdio::null()).stdout(Stdio::null());
+    }
+
+    if !cmd.status()?.success() {
+        return Err("`docker build` failed".into());
+    }
 
     Ok(())
 }

--- a/test-framework/sudo-test/src/docker.rs
+++ b/test-framework/sudo-test/src/docker.rs
@@ -1,5 +1,6 @@
 use core::str;
 use std::{
+    env,
     fs::{self, File},
     io::{Seek, SeekFrom, Write},
     path::PathBuf,
@@ -107,6 +108,13 @@ pub fn build_base_image() -> Result<()> {
     let mut cmd = StdCommand::new("docker");
 
     cmd.args(["buildx", "build", "-t", base_image(), "--load"]);
+
+    if env::var_os("CI").is_some() {
+        cmd.args([
+            "--cache-from=type=local,src=/tmp/.buildx-cache",
+            "--cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max",
+        ]);
+    }
 
     match SudoUnderTest::from_env()? {
         SudoUnderTest::Ours => {

--- a/test-framework/sudo-test/src/docker.rs
+++ b/test-framework/sudo-test/src/docker.rs
@@ -106,13 +106,11 @@ pub fn build_base_image() -> Result<()> {
     let repo_root = repo_root();
     let mut cmd = StdCommand::new("docker");
 
-    cmd.args(["build", "-t", base_image()]);
+    cmd.args(["buildx", "build", "-t", base_image(), "--load"]);
 
     match SudoUnderTest::from_env()? {
         SudoUnderTest::Ours => {
             // needed for dockerfile-specific dockerignore (e.g. `Dockerfile.dockerignore`) support
-            cmd.env("DOCKER_BUILDKIT", "1");
-
             cmd.current_dir(repo_root);
             cmd.args(["-f", "test-framework/sudo-test/src/ours.Dockerfile", "."]);
         }

--- a/test-framework/sudo-test/src/ours.Dockerfile.dockerignore
+++ b/test-framework/sudo-test/src/ours.Dockerfile.dockerignore
@@ -1,4 +1,9 @@
-target/**
-.git/**
-# changes in test framework not trigger a rebuild of sudo binary
-test-framework/**
+# ignore everything
+*
+
+# but these
+!Cargo.lock
+!Cargo.toml
+!lib/**/*
+!test-binaries/**/*
+!sudo/**/*


### PR DESCRIPTION
this PR adds two forms of caching: caching of docker layers to speed up `docker build` and caching of rust artifacts. caching the docker layers cuts down the runtime from ~9m10s to ~6m30s (when sudo-rs source code didn't change). the rust caching brings down the time a bit further to ~6m10s

the PR also adds an env var, SUDO_TEST_VERBOSE_DOCKER_BUILD, that prints the output of `docker build` when running tests. this helps debugs issues where the docker image is rebuild when it shouldn't