### PR TITLE
update error messages

### DIFF
--- a/lib/sudo-common/src/command.rs
+++ b/lib/sudo-common/src/command.rs
@@ -11,7 +11,10 @@ pub struct CommandAndArguments<'a> {
 impl<'a> CommandAndArguments<'a> {
     pub fn try_from_args(external_args: &'a [String], path: &str) -> Result<Self, Error> {
         let mut iter = external_args.iter();
-        let command = iter.next().ok_or(Error::InvalidCommand)?.to_string();
+        let command = iter
+            .next()
+            .ok_or(Error::InvalidCommand(String::new()))?
+            .to_string();
 
         // resolve the binary if the path is not absolute
         let command = if command.starts_with('/') {
@@ -19,7 +22,8 @@ impl<'a> CommandAndArguments<'a> {
         } else {
             // TODO: use value of secure_path setting to possible override current path
             // FIXME: propagating the error is a possible security problem since it leaks information before any permission check is done
-            resolve_path(&PathBuf::from(command), path).ok_or_else(|| Error::InvalidCommand)?
+            resolve_path(&PathBuf::from(&command), path)
+                .ok_or_else(|| Error::InvalidCommand(command))?
         };
 
         Ok(CommandAndArguments {

--- a/lib/sudo-common/src/error.rs
+++ b/lib/sudo-common/src/error.rs
@@ -3,17 +3,17 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("command not found")]
-    InvalidCommand,
-    #[error("user '{0}' not found")]
+    #[error("`{0}': command not found")]
+    InvalidCommand(String),
+    #[error("user `{0}' not found")]
     UserNotFound(String),
-    #[error("group '{0}' not found")]
+    #[error("group `{0}' not found")]
     GroupNotFound(String),
     #[error("could not spawn child process")]
     Exec,
-    #[error("authentication error: {0}")]
+    #[error("authenticated failed, {0}")]
     Authentication(String),
-    #[error("configuration error: {0}")]
+    #[error("invalid configuration, {0}")]
     Configuration(String),
     #[error("PAM error: {0}")]
     Pam(#[from] PamError),

--- a/sudo/src/diagnostic.rs
+++ b/sudo/src/diagnostic.rs
@@ -42,11 +42,11 @@ macro_rules! diagnostic {
         if let Some(range) = $pos {
             $crate::diagnostic::cited_error(&format!($str), range, $path);
         } else {
-            eprintln!($str);
+            eprintln!("sudo-rs: {}", format!($str));
         }
     };
     ($str:expr) => {
-        eprintln!($str);
+        eprintln!("sudo-rs: {}", format!($str));
     };
 }
 

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -16,8 +16,8 @@ fn parse_sudoers() -> Result<Sudoers, Error> {
     // TODO: move to global configuration
     let sudoers_path = "/etc/sudoers.test";
 
-    let (sudoers, syntax_errors) = Sudoers::new(sudoers_path)
-        .map_err(|e| Error::Configuration(format!("no valid sudoers file: {e}")))?;
+    let (sudoers, syntax_errors) =
+        Sudoers::new(sudoers_path).map_err(|e| Error::Configuration(format!("{e}")))?;
 
     for sudoers::Error(pos, error) in syntax_errors {
         diagnostic!("{error}", sudoers_path @ pos);
@@ -110,7 +110,7 @@ fn sudo_process() -> Result<std::process::ExitStatus, Error> {
         Authorization::Passed => {}
         Authorization::Forbidden => {
             return Err(Error::auth(&format!(
-                "i'm afraid i can't do that, {}",
+                "i'm sorry {}, i'm afraid i can't do that",
                 context.current_user.name
             )));
         }


### PR DESCRIPTION
See #181. We don't yet differentiate between the various reasons why you may not be allowed to do something (this can probably better be done by the time we implement ` sudo -l`. You can also ask whether or not users need to be told why they cannot `sudo'.)