### PR TITLE
Set the working directory when using the `-i` flag

### DIFF
--- a/test-framework/sudo-compliance-tests/src/flag_login.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_login.rs
@@ -31,7 +31,6 @@ fn if_home_directory_does_not_exist_executes_program_without_changing_the_workin
 }
 
 #[test]
-#[ignore]
 fn sets_home_directory_as_working_directory() -> Result<()> {
     let expected = format!("/home/{USERNAME}");
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD)


### PR DESCRIPTION
With these changes, the working directory is set to the user home if the `-i` flag is passed to `sudo`. Even then, `chdir` still takes precedence.