### PR TITLE
Change `home` and `shell` fields to be `PathBuf`s.

### DIFF
--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -90,11 +90,19 @@ pub fn into_leaky_cstring(s: &str) -> *const libc::c_char {
 
 #[cfg(test)]
 mod test {
-    use super::{into_leaky_cstring, string_from_ptr};
+    use super::{into_leaky_cstring, os_string_from_ptr, string_from_ptr};
 
     #[test]
     fn miri_test_str_to_ptr() {
         let strp = |ptr| unsafe { string_from_ptr(ptr) };
+        assert_eq!(strp(std::ptr::null()), "");
+        assert_eq!(strp("\0".as_ptr() as *const libc::c_char), "");
+        assert_eq!(strp("hello\0".as_ptr() as *const libc::c_char), "hello");
+    }
+
+    #[test]
+    fn miri_test_os_str_to_ptr() {
+        let strp = |ptr| unsafe { os_string_from_ptr(ptr) };
         assert_eq!(strp(std::ptr::null()), "");
         assert_eq!(strp("\0".as_ptr() as *const libc::c_char), "");
         assert_eq!(strp("hello\0".as_ptr() as *const libc::c_char), "hello");

--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -1,4 +1,7 @@
-use std::ffi::CStr;
+use std::{
+    ffi::{CStr, OsStr, OsString},
+    os::unix::prelude::OsStrExt,
+};
 
 pub fn cerr(res: libc::c_int) -> std::io::Result<libc::c_int> {
     match res {
@@ -50,6 +53,20 @@ pub unsafe fn string_from_ptr(ptr: *const libc::c_char) -> String {
     } else {
         let cstr = unsafe { CStr::from_ptr(ptr) };
         cstr.to_string_lossy().to_string()
+    }
+}
+
+/// Create an `OsString` copy from a C string pointer.
+///
+/// # Safety
+/// This function assumes that the pointer is either a null pointer or that
+/// it points to a valid NUL-terminated C string.
+pub unsafe fn os_string_from_ptr(ptr: *const libc::c_char) -> OsString {
+    if ptr.is_null() {
+        OsString::new()
+    } else {
+        let cstr = unsafe { CStr::from_ptr(ptr) };
+        OsStr::from_bytes(cstr.to_bytes()).to_owned()
     }
 }
 

--- a/lib/sudo-env/src/environment.rs
+++ b/lib/sudo-env/src/environment.rs
@@ -45,12 +45,18 @@ fn add_extra_env(context: &Context, environment: &mut Environment) {
     );
     // The current SHELL variable should determine the shell to run when -s is passed, if none set use passwd entry
     // FIXME(pvdrz): this is lossy as not every `PathBuf` is a valid `String`.
-    environment.insert("SHELL".to_string(), context.target_user.shell.display().to_string());
+    environment.insert(
+        "SHELL".to_string(),
+        context.target_user.shell.display().to_string(),
+    );
     // HOME' Set to the home directory of the target user if -i or -H are specified, env_reset or always_set_home are
     // set in sudoers, or when the -s option is specified and set_home is set in sudoers.
     // Since we always want to do env_reset -> always set HOME
     // FIXME(pvdrz): this is lossy as not every `PathBuf` is a valid `String`.
-    environment.insert("HOME".to_string(), context.target_user.home.display().to_string());
+    environment.insert(
+        "HOME".to_string(),
+        context.target_user.home.display().to_string(),
+    );
     // Set to the login name of the target user when the -i option is specified,
     // when the set_logname option is enabled in sudoers, or when the env_reset option
     // is enabled in sudoers (unless LOGNAME is present in the env_keep list).

--- a/lib/sudo-env/src/environment.rs
+++ b/lib/sudo-env/src/environment.rs
@@ -44,11 +44,13 @@ fn add_extra_env(context: &Context, environment: &mut Environment) {
         format!("{PATH_MAILDIR}/{}", context.target_user.name),
     );
     // The current SHELL variable should determine the shell to run when -s is passed, if none set use passwd entry
-    environment.insert("SHELL".to_string(), context.target_user.shell.clone());
+    // FIXME(pvdrz): this is lossy as not every `PathBuf` is a valid `String`.
+    environment.insert("SHELL".to_string(), context.target_user.shell.display().to_string());
     // HOME' Set to the home directory of the target user if -i or -H are specified, env_reset or always_set_home are
     // set in sudoers, or when the -s option is specified and set_home is set in sudoers.
     // Since we always want to do env_reset -> always set HOME
-    environment.insert("HOME".to_string(), context.target_user.home.clone());
+    // FIXME(pvdrz): this is lossy as not every `PathBuf` is a valid `String`.
+    environment.insert("HOME".to_string(), context.target_user.home.display().to_string());
     // Set to the login name of the target user when the -i option is specified,
     // when the set_logname option is enabled in sudoers, or when the env_reset option
     // is enabled in sudoers (unless LOGNAME is present in the env_keep list).

--- a/lib/sudo-env/tests/env_tests.rs
+++ b/lib/sudo-env/tests/env_tests.rs
@@ -83,8 +83,8 @@ fn create_test_context<'a>(sudo_options: &'a SudoOptions) -> Context<'a> {
         gid: 1000,
         name: "test".to_string(),
         gecos: String::new(),
-        home: "/home/test".to_string(),
-        shell: "/bin/sh".to_string(),
+        home: "/home/test".into(),
+        shell: "/bin/sh".into(),
         passwd: String::new(),
         groups: vec![],
     };
@@ -101,8 +101,8 @@ fn create_test_context<'a>(sudo_options: &'a SudoOptions) -> Context<'a> {
         gid: 0,
         name: "root".to_string(),
         gecos: String::new(),
-        home: "/root".to_string(),
-        shell: "/bin/bash".to_string(),
+        home: "/root".into(),
+        shell: "/bin/bash".into(),
         passwd: String::new(),
         groups: vec![],
     };

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -65,8 +65,8 @@ pub struct User {
     pub gid: libc::gid_t,
     pub name: String,
     pub gecos: String,
-    pub home: String,
-    pub shell: String,
+    pub home: PathBuf,
+    pub shell: PathBuf,
     pub passwd: String,
     pub groups: Vec<libc::gid_t>,
 }
@@ -108,8 +108,8 @@ impl User {
             gid: pwd.pw_gid,
             name: string_from_ptr(pwd.pw_name),
             gecos: string_from_ptr(pwd.pw_gecos),
-            home: string_from_ptr(pwd.pw_dir),
-            shell: string_from_ptr(pwd.pw_shell),
+            home: os_string_from_ptr(pwd.pw_dir).into(),
+            shell: os_string_from_ptr(pwd.pw_shell).into(),
             passwd: string_from_ptr(pwd.pw_passwd),
             groups: groups_buffer,
         }


### PR DESCRIPTION
These two fields of the `User` type are more useful as proper OS paths than as Rust strings. For example, the `-i` flag changes the current directory to the user's home directory, which requires checking that the path exists.