### PR TITLE
Remove rpassword dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "libc",
  "sudo-cutils",
  "sudo-pam-sys",
+ "sudo-system",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,27 +369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "rpassword"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
-dependencies = [
- "libc",
- "rtoolbox",
- "winapi",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,7 +498,6 @@ name = "sudo-pam"
 version = "0.1.0-alpha.1"
 dependencies = [
  "libc",
- "rpassword",
  "sudo-cutils",
  "sudo-pam-sys",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,6 @@ dependencies = [
  "libc",
  "sudo-cutils",
  "sudo-pam-sys",
- "sudo-system",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ publish = true
 clap = "4.0.32"
 libc = "0.2.139"
 thiserror = "1.0.38"
-rpassword = "7.2.0"
 glob = "0.3.1"
 sha2 = "0.10.6"
 digest = "0.10.6"

--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -72,65 +72,9 @@ pub unsafe fn os_string_from_ptr(ptr: *const libc::c_char) -> OsString {
     }
 }
 
-/// Create a copy of a Rust byte slice as a null-terminated char pointer
-/// (i.e. "a null terminated string") allocated by libc::malloc().
-///
-/// The returned pointer **must** be cleaned up via a call to `libc::free`.
-pub fn copy_as_libc_cstring(s: &[u8]) -> *const libc::c_char {
-    let alloc_len: isize = s.len().try_into().expect("absurd string size");
-    let mem = unsafe { libc::malloc(alloc_len as usize + 1) } as *mut u8;
-    if mem.is_null() {
-        panic!("libc malloc failed");
-    } else {
-        unsafe {
-            std::ptr::copy_nonoverlapping(s.as_ptr(), mem, alloc_len as usize);
-            *mem.offset(alloc_len) = 0;
-        }
-    }
-
-    mem as *mut libc::c_char
-}
-
-/// A "secure" storage that gets wiped before dropping; inspired by Conrad Kleinespel's
-/// Rustatic rtoolbox::SafeString, https://crates.io/crates/rtoolbox/0.0.1 and std::Pin<>
-pub struct Secure<T: AsMut<[u8]>>(T);
-
-impl<T: AsMut<[u8]>> Secure<T> {
-    pub fn new(value: T) -> Self {
-        Secure(value)
-    }
-}
-
-impl<T: AsMut<[u8]>> std::ops::Deref for Secure<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        &self.0
-    }
-}
-
-impl<T: AsMut<[u8]>> Drop for Secure<T> {
-    fn drop(&mut self) {
-        wipe_memory(self.0.as_mut())
-    }
-}
-
-/// Used to zero out memory and protect sensitive data from leaking; inspired by Conrad Kleinespel's
-/// Rustatic rtoolbox::SafeString, https://crates.io/crates/rtoolbox/0.0.1
-fn wipe_memory(memory: &mut [u8]) {
-    use std::sync::atomic;
-
-    let nonsense: u8 = 0x55;
-    for c in memory {
-        unsafe { std::ptr::write_volatile(c, nonsense) };
-    }
-
-    atomic::fence(atomic::Ordering::SeqCst);
-    atomic::compiler_fence(atomic::Ordering::SeqCst);
-}
-
 #[cfg(test)]
 mod test {
-    use super::{copy_as_libc_cstring, os_string_from_ptr, string_from_ptr};
+    use super::{os_string_from_ptr, string_from_ptr};
 
     #[test]
     fn miri_test_str_to_ptr() {
@@ -146,26 +90,5 @@ mod test {
         assert_eq!(strp(std::ptr::null()), "");
         assert_eq!(strp("\0".as_ptr() as *const libc::c_char), "");
         assert_eq!(strp("hello\0".as_ptr() as *const libc::c_char), "hello");
-    }
-
-    #[test]
-    fn miri_test_leaky_cstring() {
-        let test = |text: &str| unsafe {
-            let ptr = copy_as_libc_cstring(text.as_bytes());
-            let result = string_from_ptr(ptr);
-            libc::free(ptr as *mut libc::c_void);
-            result
-        };
-        assert_eq!(test(""), "");
-        assert_eq!(test("hello"), "hello");
-    }
-
-    #[test]
-    fn miri_test_wipe() {
-        let mut memory: [u8; 3] = [1, 2, 3];
-        let fix = crate::Secure::new(&mut memory);
-        assert_eq!(*fix, &[1, 2, 3]);
-        std::mem::drop(fix);
-        assert_eq!(memory, [0x55, 0x55, 0x55]);
     }
 }

--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -158,4 +158,13 @@ mod test {
         assert_eq!(test(""), "");
         assert_eq!(test("hello"), "hello");
     }
+
+    #[test]
+    fn miri_test_wipe() {
+        let mut memory: [u8; 3] = [1, 2, 3];
+        let fix = crate::Secure::new(&mut memory);
+        assert_eq!(*fix, &[1, 2, 3]);
+        std::mem::drop(fix);
+        assert_eq!(memory, [0x55, 0x55, 0x55]);
+    }
 }

--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -43,6 +43,8 @@ pub fn sysconf(name: libc::c_int) -> Option<libc::c_long> {
 }
 
 /// Create a Rust string copy from a C string pointer
+/// WARNING: This uses `to_string_lossy` so should not be used for data where
+/// information loss is unacceptable (use `os_string_from_ptr` instead)
 ///
 /// # Safety
 /// This function assumes that the pointer is either a null pointer or that
@@ -73,7 +75,7 @@ pub unsafe fn os_string_from_ptr(ptr: *const libc::c_char) -> OsString {
 /// Create a C string copy of a Rust string copy, allocated by libc::malloc()
 ///
 /// The returned pointer **must** be cleaned up via a call to `libc::free`.
-pub fn into_leaky_cstring(s: &str) -> *const libc::c_char {
+pub fn into_leaky_cstring(s: &[u8]) -> *const libc::c_char {
     let alloc_len: isize = s.len().try_into().expect("absurd string size");
     let mem = unsafe { libc::malloc(alloc_len as usize + 1) } as *mut u8;
     if mem.is_null() {
@@ -147,8 +149,8 @@ mod test {
 
     #[test]
     fn miri_test_leaky_cstring() {
-        let test = |text| unsafe {
-            let ptr = into_leaky_cstring(text);
+        let test = |text: &str| unsafe {
+            let ptr = into_leaky_cstring(text.as_bytes());
             let result = string_from_ptr(ptr);
             libc::free(ptr as *mut libc::c_void);
             result

--- a/lib/sudo-pam/Cargo.toml
+++ b/lib/sudo-pam/Cargo.toml
@@ -10,5 +10,6 @@ publish.workspace = true
 [dependencies]
 sudo-pam-sys.workspace = true
 sudo-cutils.workspace = true
+sudo-system.workspace = true
 thiserror.workspace = true
 libc.workspace = true

--- a/lib/sudo-pam/Cargo.toml
+++ b/lib/sudo-pam/Cargo.toml
@@ -12,4 +12,3 @@ sudo-pam-sys.workspace = true
 sudo-cutils.workspace = true
 thiserror.workspace = true
 libc.workspace = true
-rpassword.workspace = true

--- a/lib/sudo-pam/Cargo.toml
+++ b/lib/sudo-pam/Cargo.toml
@@ -10,6 +10,5 @@ publish.workspace = true
 [dependencies]
 sudo-pam-sys.workspace = true
 sudo-cutils.workspace = true
-sudo-system.workspace = true
 thiserror.workspace = true
 libc.workspace = true

--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -237,13 +237,11 @@ pub(crate) unsafe extern "C" fn converse<C: Converser>(
         }
 
         // Store the responses
-        for i in 0..num_msg as isize {
-            let response: &mut pam_response = unsafe { &mut *(temp_resp.offset(i)) };
+        for (i, msg) in conversation.messages.into_iter().enumerate() {
+            let response: &mut pam_response = unsafe { &mut *(temp_resp.add(i)) };
 
-            // Unwrap here should be ok because we previously allocated an array of the same size
-            let our_resp = &conversation.messages.get(i as usize).unwrap().response;
-            if let Some(secbuf) = our_resp {
-                response.resp = secbuf.leak_as_ptr() as *mut _;
+            if let Some(secbuf) = msg.response {
+                response.resp = secbuf.leak() as *mut _;
             }
         }
 

--- a/lib/sudo-pam/src/converse.rs
+++ b/lib/sudo-pam/src/converse.rs
@@ -135,17 +135,20 @@ where
 /// input from the user.
 pub struct CLIConverser;
 
+// TODO: all of these functions should communicate via the TTY; refactor
+// some code from the rpassword.rs module into here
 impl SequentialConverser for CLIConverser {
     fn handle_normal_prompt(&self, msg: &str) -> PamResult<Vec<u8>> {
-        print!("[Sudo: input needed] {msg}");
+        print!("[Sudo: input needed] {msg} ");
         std::io::stdout().flush().unwrap();
 
-        let mut s = Vec::new();
+        let mut s = String::new();
 
-        let newline = 0x0A;
-        std::io::stdin().lock().read_until(newline, &mut s).unwrap();
+        std::io::stdin().lock().read_line(&mut s)?;
+        // temporary fix: get rid of the \n that read_line adds
+        s.pop();
 
-        Ok(s)
+        Ok(s.into_bytes())
     }
 
     fn handle_hidden_prompt(&self, msg: &str) -> PamResult<PamBuffer> {

--- a/lib/sudo-pam/src/lib.rs
+++ b/lib/sudo-pam/src/lib.rs
@@ -6,11 +6,14 @@ use std::{
 use converse::{Converser, ConverserData};
 use error::pam_err;
 pub use error::{PamError, PamErrorType, PamResult};
-use sudo_cutils::string_from_ptr;
+use sudo_cutils::{string_from_ptr, Secure};
 use sudo_pam_sys::*;
 
 mod converse;
 mod error;
+mod rpassword;
+
+pub(crate) type Password = Secure<Vec<u8>>;
 
 pub use converse::CLIConverser;
 

--- a/lib/sudo-pam/src/lib.rs
+++ b/lib/sudo-pam/src/lib.rs
@@ -6,14 +6,13 @@ use std::{
 use converse::{Converser, ConverserData};
 use error::pam_err;
 pub use error::{PamError, PamErrorType, PamResult};
-use sudo_cutils::{string_from_ptr, Secure};
+use sudo_cutils::string_from_ptr;
 use sudo_pam_sys::*;
 
 mod converse;
 mod error;
 mod rpassword;
-
-pub(crate) type Password = Secure<Vec<u8>>;
+mod securemem;
 
 pub use converse::CLIConverser;
 

--- a/lib/sudo-pam/src/rpassword.rs
+++ b/lib/sudo-pam/src/rpassword.rs
@@ -89,7 +89,10 @@ fn read_password(source: &mut (impl io::Read + AsRawFd)) -> io::Result<PamBuffer
 
 /// Prompts on the TTY and then reads a password from TTY
 pub fn prompt_password(prompt: impl ToString) -> io::Result<PamBuffer> {
-    let mut stream = std::fs::File::open("/dev/tty")?;
+    let mut stream = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")?;
     stream
         .write_all(prompt.to_string().as_str().as_bytes())
         .and_then(|_| stream.flush())

--- a/lib/sudo-pam/src/rpassword.rs
+++ b/lib/sudo-pam/src/rpassword.rs
@@ -1,0 +1,105 @@
+/// Derived work from rpassword and rtoolbox, Copyright (c) 2023, Conrad Kleinespel et al
+///
+/// This module contains code that was originally written by Conrad Kleinespel for the rpassword
+/// crate. No copyright notices were found in the original code.
+
+/// See: https://docs.rs/rpassword/latest/rpassword/
+///
+/// CHANGES TO THE ORIGINAL CODE:
+/// - {prompt,read}_password_from_bufread deleted (we don't need them)
+/// - rtool_box::print_tty was inlined
+/// - SafeString was removed and replaced with more general Secure<> type (and moved to cutils);
+///   also, the original code actually allowed the string to quickly escape the security net
+/// - instead of String, password are read as [u8]
+/// - this also removes the need for 'fix_line_issues', since we know we read a \n
+use std::io::{self, BufRead, Write};
+use std::mem;
+use std::os::unix::io::AsRawFd;
+
+use libc::{c_int, tcsetattr, termios, ECHO, ECHONL, TCSANOW};
+
+use sudo_cutils::Secure;
+
+struct HiddenInput {
+    fd: i32,
+    term_orig: termios,
+}
+
+impl HiddenInput {
+    fn new(fd: i32) -> io::Result<HiddenInput> {
+        // Make two copies of the terminal settings. The first one will be modified
+        // and the second one will act as a backup for when we want to set the
+        // terminal back to its original state.
+        let mut term = safe_tcgetattr(fd)?;
+        let term_orig = safe_tcgetattr(fd)?;
+
+        // Hide the password. This is what makes this function useful.
+        term.c_lflag &= !ECHO;
+
+        // But don't hide the NL character when the user hits ENTER.
+        term.c_lflag |= ECHONL;
+
+        // Save the settings for now.
+        io_result(unsafe { tcsetattr(fd, TCSANOW, &term) })?;
+
+        Ok(HiddenInput { fd, term_orig })
+    }
+}
+
+impl Drop for HiddenInput {
+    fn drop(&mut self) {
+        // Set the the mode back to normal
+        unsafe {
+            tcsetattr(self.fd, TCSANOW, &self.term_orig);
+        }
+    }
+}
+
+/// Turns a C function return into an IO Result
+fn io_result(ret: c_int) -> std::io::Result<()> {
+    match ret {
+        0 => Ok(()),
+        _ => Err(std::io::Error::last_os_error()),
+    }
+}
+
+fn safe_tcgetattr(fd: c_int) -> std::io::Result<termios> {
+    let mut term = mem::MaybeUninit::<termios>::uninit();
+    io_result(unsafe { ::libc::tcgetattr(fd, term.as_mut_ptr()) })?;
+    Ok(unsafe { term.assume_init() })
+}
+
+/// Reads a password from the TTY
+pub fn read_password() -> std::io::Result<Secure<Vec<u8>>> {
+    let tty = std::fs::File::open("/dev/tty")?;
+    let fd = tty.as_raw_fd();
+    let mut reader = io::BufReader::new(tty);
+
+    read_password_from_fd_with_hidden_input(&mut reader, fd)
+}
+
+/// Reads a password from a given file descriptor
+fn read_password_from_fd_with_hidden_input(
+    reader: &mut impl BufRead,
+    fd: i32,
+) -> std::io::Result<Secure<Vec<u8>>> {
+    let mut password = Vec::new();
+
+    let hidden_input = HiddenInput::new(fd)?;
+
+    let status = reader.read_until(0x0a, &mut password);
+    let password = Secure::new(password);
+
+    std::mem::drop(hidden_input);
+
+    status.map(|_| password)
+}
+
+/// Prompts on the TTY and then reads a password from TTY
+pub fn prompt_password(prompt: impl ToString) -> std::io::Result<Secure<Vec<u8>>> {
+    let mut stream = std::fs::OpenOptions::new().write(true).open("/dev/tty")?;
+    stream
+        .write_all(prompt.to_string().as_str().as_bytes())
+        .and_then(|_| stream.flush())
+        .and_then(|_| read_password())
+}

--- a/lib/sudo-pam/src/securemem.rs
+++ b/lib/sudo-pam/src/securemem.rs
@@ -22,6 +22,7 @@ impl PamBuffer {
         let mut buffer = PamBuffer::default();
         let src = src.as_mut();
         buffer[..src.len()].copy_from_slice(src);
+        wipe_memory(src);
 
         buffer
     }

--- a/lib/sudo-pam/src/securemem.rs
+++ b/lib/sudo-pam/src/securemem.rs
@@ -8,7 +8,7 @@ impl<T: AsMut<[u8]> + AsRef<[u8]>> Secure<T> {
         Secure(value)
     }
 
-    pub fn leak_as_ptr(&self) -> *const u8 {
+    pub fn leak(self) -> *const u8 {
         copy_as_libc_cstring(self.0.as_ref()) as *const _
     }
 }

--- a/lib/sudo-pam/src/securemem.rs
+++ b/lib/sudo-pam/src/securemem.rs
@@ -1,28 +1,59 @@
-///! Routines for "secure" memory operations
-pub type SecureBuffer = Secure<Vec<u8>>;
+///! Routines for "secure" memory operations; i.e. data that we need to send to Linux-PAM and don't
+///! want any copies to leak (that we would then need to zeroize).
+use std::slice;
 
-pub struct Secure<T: AsMut<[u8]>>(T);
+pub struct PamBuffer(*mut u8);
 
-impl<T: AsMut<[u8]> + AsRef<[u8]>> Secure<T> {
-    pub fn new(value: T) -> Self {
-        Secure(value)
-    }
+impl PamBuffer {
+    const SIZE: usize = sudo_pam_sys::PAM_MAX_RESP_SIZE as usize;
 
+    // consume this buffer and return its internal pointer
+    // (ending the type-level security, but guaranteeing you need unsafe code to access the data)
     pub fn leak(self) -> *const u8 {
-        copy_as_libc_cstring(self.0.as_ref()) as *const _
+        let result = self.0;
+        std::mem::forget(self);
+
+        result
+    }
+
+    // initialized the buffer with already existing data (otherwise populating it is a bit hairy)
+    // this is inferior than placing the data into the securebuffer directly
+    pub fn new(mut src: impl AsMut<[u8]>) -> Self {
+        let mut buffer = PamBuffer::default();
+        let src = src.as_mut();
+        buffer[..src.len()].copy_from_slice(src);
+
+        buffer
     }
 }
 
-impl<T: AsMut<[u8]>> std::ops::Deref for Secure<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        &self.0
+impl Default for PamBuffer {
+    fn default() -> Self {
+        PamBuffer(unsafe { libc::calloc(1, Self::SIZE) as *mut u8 })
     }
 }
 
-impl<T: AsMut<[u8]>> Drop for Secure<T> {
+impl std::ops::Deref for PamBuffer {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        // make the slice one less in size to guarantee the existence of a terminating NUL
+        unsafe { slice::from_raw_parts(self.0, Self::SIZE - 1) }
+    }
+}
+
+impl std::ops::DerefMut for PamBuffer {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.0, Self::SIZE - 1) }
+    }
+}
+
+impl Drop for PamBuffer {
     fn drop(&mut self) {
-        wipe_memory(self.0.as_mut())
+        if !self.0.is_null() {
+            wipe_memory(unsafe { &mut *(self.0 as *mut [u8; Self::SIZE]) });
+            unsafe { libc::free(self.0 as *mut _) }
+        }
     }
 }
 
@@ -40,32 +71,17 @@ fn wipe_memory(memory: &mut [u8]) {
     atomic::compiler_fence(atomic::Ordering::SeqCst);
 }
 
-/// Create a copy of a Rust byte slice as a null-terminated char pointer
-/// (i.e. "a null terminated string") allocated by libc::malloc().
-///
-/// The returned pointer **must** be cleaned up via a call to `libc::free`.
-fn copy_as_libc_cstring(s: &[u8]) -> *const libc::c_char {
-    let alloc_len: isize = s.len().try_into().expect("absurd string size");
-    let mem = unsafe { libc::malloc(alloc_len as usize + 1) } as *mut u8;
-    if mem.is_null() {
-        panic!("libc malloc failed");
-    } else {
-        unsafe {
-            std::ptr::copy_nonoverlapping(s.as_ptr(), mem, alloc_len as usize);
-            *mem.offset(alloc_len) = 0;
-        }
-    }
-
-    mem as *mut libc::c_char
-}
-
 #[cfg(test)]
 mod test {
+    use super::{wipe_memory, PamBuffer};
+
     #[test]
     fn miri_test_leaky_cstring() {
         let test = |text: &str| unsafe {
-            let ptr = super::copy_as_libc_cstring(text.as_bytes());
-            let result = sudo_cutils::string_from_ptr(ptr);
+            let mut buf = PamBuffer::default();
+            buf[..text.len()].copy_from_slice(text.as_bytes());
+            let ptr = buf.leak();
+            let result = sudo_cutils::string_from_ptr(ptr as *mut _);
             libc::free(ptr as *mut libc::c_void);
             result
         };
@@ -75,10 +91,9 @@ mod test {
 
     #[test]
     fn miri_test_wipe() {
-        let mut memory: [u8; 3] = [1, 2, 3];
-        let fix = super::Secure::new(&mut memory);
-        assert_eq!(*fix, &[1, 2, 3]);
-        std::mem::drop(fix);
-        assert_eq!(memory, [0x55, 0x55, 0x55]);
+        let mut fix = [1, 2, 3];
+        assert_eq!(fix, [1, 2, 3]);
+        wipe_memory(&mut fix);
+        assert_eq!(fix, [0x55, 0x55, 0x55]);
     }
 }

--- a/lib/sudo-pam/src/securemem.rs
+++ b/lib/sudo-pam/src/securemem.rs
@@ -1,0 +1,84 @@
+///! Routines for "secure" memory operations
+pub type SecureBuffer = Secure<Vec<u8>>;
+
+pub struct Secure<T: AsMut<[u8]>>(T);
+
+impl<T: AsMut<[u8]> + AsRef<[u8]>> Secure<T> {
+    pub fn new(value: T) -> Self {
+        Secure(value)
+    }
+
+    pub fn leak_as_ptr(&self) -> *const u8 {
+        copy_as_libc_cstring(self.0.as_ref()) as *const _
+    }
+}
+
+impl<T: AsMut<[u8]>> std::ops::Deref for Secure<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T: AsMut<[u8]>> Drop for Secure<T> {
+    fn drop(&mut self) {
+        wipe_memory(self.0.as_mut())
+    }
+}
+
+/// Used to zero out memory and protect sensitive data from leaking; inspired by Conrad Kleinespel's
+/// Rustatic rtoolbox::SafeString, https://crates.io/crates/rtoolbox/0.0.1
+fn wipe_memory(memory: &mut [u8]) {
+    use std::sync::atomic;
+
+    let nonsense: u8 = 0x55;
+    for c in memory {
+        unsafe { std::ptr::write_volatile(c, nonsense) };
+    }
+
+    atomic::fence(atomic::Ordering::SeqCst);
+    atomic::compiler_fence(atomic::Ordering::SeqCst);
+}
+
+/// Create a copy of a Rust byte slice as a null-terminated char pointer
+/// (i.e. "a null terminated string") allocated by libc::malloc().
+///
+/// The returned pointer **must** be cleaned up via a call to `libc::free`.
+fn copy_as_libc_cstring(s: &[u8]) -> *const libc::c_char {
+    let alloc_len: isize = s.len().try_into().expect("absurd string size");
+    let mem = unsafe { libc::malloc(alloc_len as usize + 1) } as *mut u8;
+    if mem.is_null() {
+        panic!("libc malloc failed");
+    } else {
+        unsafe {
+            std::ptr::copy_nonoverlapping(s.as_ptr(), mem, alloc_len as usize);
+            *mem.offset(alloc_len) = 0;
+        }
+    }
+
+    mem as *mut libc::c_char
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn miri_test_leaky_cstring() {
+        let test = |text: &str| unsafe {
+            let ptr = super::copy_as_libc_cstring(text.as_bytes());
+            let result = sudo_cutils::string_from_ptr(ptr);
+            libc::free(ptr as *mut libc::c_void);
+            result
+        };
+        assert_eq!(test(""), "");
+        assert_eq!(test("hello"), "hello");
+    }
+
+    #[test]
+    fn miri_test_wipe() {
+        let mut memory: [u8; 3] = [1, 2, 3];
+        let fix = super::Secure::new(&mut memory);
+        assert_eq!(*fix, &[1, 2, 3]);
+        std::mem::drop(fix);
+        assert_eq!(memory, [0x55, 0x55, 0x55]);
+    }
+}


### PR DESCRIPTION
This ~~is~~was mostly a copy from rpassword sourcecode (Apache 2.0 licensed), heavily changed.
- ~~We use "read_until" instead of "read_line" so we can give raw bytes to PAM~~
- rpassword had some memory clearing code (SafeString) that was almost immediately circumvented (i.e. it released password as a raw string); this PR replaces it with a slightly stronger type (but keeping the memory-wiping code intact)
- this memory buffer also removes the need for the strange `into_leaky_cstring`.

Note: this is prep-work for #97 and closes #220 