### PR TITLE
Execute commands using a pseudoterminal

### DIFF
--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -10,13 +10,6 @@ pub fn cerr<Int: Copy + TryInto<libc::c_long>>(res: Int) -> std::io::Result<Int>
     }
 }
 
-pub fn cerr_ssize_t(res: libc::ssize_t) -> std::io::Result<libc::ssize_t> {
-    match res {
-        -1 => Err(std::io::Error::last_os_error()),
-        _ => Ok(res),
-    }
-}
-
 extern "C" {
     #[cfg_attr(
         any(target_os = "macos", target_os = "ios", target_os = "freebsd"),

--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -10,6 +10,13 @@ pub fn cerr<Int: Copy + TryInto<libc::c_long>>(res: Int) -> std::io::Result<Int>
     }
 }
 
+pub fn cerr_ssize_t(res: libc::ssize_t) -> std::io::Result<libc::ssize_t> {
+    match res {
+        -1 => Err(std::io::Error::last_os_error()),
+        _ => Ok(res),
+    }
+}
+
 extern "C" {
     #[cfg_attr(
         any(target_os = "macos", target_os = "ios", target_os = "freebsd"),

--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -6,15 +6,16 @@ mod pty;
 use std::{
     ffi::{c_int, CString, OsStr},
     io,
-    os::unix::ffi::OsStrExt,
+    mem::size_of,
     os::unix::process::CommandExt,
+    os::unix::{ffi::OsStrExt, process::ExitStatusExt},
     process::{Command, ExitStatus},
 };
 
 use signal_hook::consts::*;
 use sudo_common::{context::LaunchType::Login, Context, Environment};
 use sudo_log::{user_error, user_warn};
-use sudo_system::{fork, openpty, pipe, set_target_user};
+use sudo_system::{fork, openpty, pipe, read, set_target_user, write};
 
 /// We only handle the signals that ogsudo handles.
 const SIGNALS: &[c_int] = &[
@@ -23,7 +24,7 @@ const SIGNALS: &[c_int] = &[
 ];
 
 /// Based on `ogsudo`s `exec_pty` function.
-pub fn run_command(ctx: Context, env: Environment) -> io::Result<ExitStatus> {
+pub fn run_command(ctx: Context, env: Environment) -> io::Result<std::convert::Infallible> {
     // FIXME: should we pipe the stdio streams?
     let mut command = Command::new(&ctx.command.command);
     // reset env and set filtered environment
@@ -80,6 +81,58 @@ pub fn run_command(ctx: Context, env: Environment) -> io::Result<ExitStatus> {
     if monitor_pid == 0 {
         match monitor::MonitorRelay::new(command, pty_follower, tx)?.run()? {}
     } else {
-        pty::PtyRelay::new(monitor_pid, ctx.process.pid, pty_leader, rx)?.run()
+        match pty::PtyRelay::new(monitor_pid, ctx.process.pid, pty_leader, rx)?.run()? {}
+    }
+}
+
+enum ExitReason {
+    Code(i32),
+    Signal(i32),
+}
+
+impl ExitReason {
+    fn send(self, tx: c_int) -> io::Result<()> {
+        let mut bytes = [0u8; size_of::<u8>() + size_of::<i32>()];
+        let (prefix_bytes, int_bytes) = bytes.split_at_mut(size_of::<u8>());
+        match self {
+            Self::Code(code) => {
+                int_bytes.copy_from_slice(&code.to_ne_bytes());
+            }
+            Self::Signal(signal) => {
+                prefix_bytes.copy_from_slice(&1u8.to_ne_bytes());
+                int_bytes.copy_from_slice(&signal.to_ne_bytes());
+            }
+        }
+
+        write(tx, &bytes)?;
+
+        Ok(())
+    }
+
+    fn recv(rx: c_int) -> io::Result<Self> {
+        let mut bytes = [0u8; size_of::<u8>() + size_of::<i32>()];
+
+        read(rx, &mut bytes)?;
+
+        let (prefix_bytes, int_bytes) = {
+            let (hd, tl) = bytes.split_at(size_of::<u8>());
+            (hd.try_into().unwrap(), tl.try_into().unwrap())
+        };
+
+        let prefix = u8::from_ne_bytes(prefix_bytes);
+        let int = i32::from_ne_bytes(int_bytes);
+        if prefix == 0 {
+            Ok(Self::Code(int))
+        } else {
+            Ok(Self::Signal(int))
+        }
+    }
+
+    fn from_status(status: ExitStatus) -> Self {
+        if let Some(code) = status.code() {
+            Self::Code(code)
+        } else {
+            Self::Signal(status.signal().unwrap())
+        }
     }
 }

--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -1,28 +1,20 @@
 #![deny(unsafe_code)]
 
+mod monitor;
+mod pty;
+
 use std::{
     ffi::{c_int, CString, OsStr},
     io,
     os::unix::ffi::OsStrExt,
-    os::unix::process::{CommandExt, ExitStatusExt},
-    process::{exit, Command, ExitStatus},
-    time::Duration,
+    os::unix::process::CommandExt,
+    process::{Command, ExitStatus},
 };
 
-use signal_hook::{
-    consts::*,
-    iterator::{exfiltrator::WithOrigin, SignalsInfo},
-    low_level::{
-        emulate_default_handler,
-        siginfo::{Cause, Process, Sent},
-    },
-};
+use signal_hook::consts::*;
 use sudo_common::{context::LaunchType::Login, Context, Environment};
-use sudo_log::{auth_warn, user_error, user_warn};
-use sudo_system::{
-    fork, getpgid, interface::ProcessId, kill, openpty, pipe, read, set_controlling_terminal,
-    set_target_user, setpgid, setsid, write,
-};
+use sudo_log::{user_error, user_warn};
+use sudo_system::{fork, openpty, pipe, set_target_user};
 
 /// We only handle the signals that ogsudo handles.
 const SIGNALS: &[c_int] = &[
@@ -80,204 +72,14 @@ pub fn run_command(ctx: Context, env: Environment) -> io::Result<ExitStatus> {
     // set target user and groups
     set_target_user(&mut command, ctx.target_user, ctx.target_group);
 
-    // FIXME: Look for `SFD_LEADER` occurences in `exec_pty` to decide what to do with the leader
-    // side of the pty. It should be used to handle signals like `SIGWINCH` and `SIGCONT`.
-    // FIXME: close this!
-    let (_pty_leader, pty_follower) = openpty()?;
-
-    // FIXME: close this!
+    let (pty_leader, pty_follower) = openpty()?;
     let (rx, tx) = pipe()?;
 
-    // FIXME: fork sucks. Find a better abstraction.
     let monitor_pid = fork()?;
-    // Monitor logic. Based on `exec_monitor`. It is very important that the content of this block
-    // diverges so the monitor doesn't execute code it shouldn't.
+    // Monitor logic. Based on `exec_monitor`.
     if monitor_pid == 0 {
-        // Create new terminal session.
-        setsid()?;
-
-        // Set the pty as the controlling terminal.
-        set_controlling_terminal(pty_follower)?;
-
-        // spawn and exec to command
-        let mut command = command.spawn()?;
-
-        let command_pid = command.id() as ProcessId;
-
-        // set the process group ID of the command to the command PID.
-        let command_pgrp = command_pid;
-        setpgid(command_pid, command_pgrp);
-
-        let mut signals = SignalsInfo::<WithOrigin>::new(SIGNALS)?;
-
-        // FIXME: There should be a nice abstraction for these loops that wait for something to
-        // happen and handle signals meanwhile.
-        loop {
-            // First we check if the command is finished
-            if let Some(status) = command.try_wait()? {
-                write(tx, &status.into_raw().to_ne_bytes())?;
-
-                // Given that we overwrote the default handlers for all the signals, we musti
-                // emulate them to handle the signal we just sent correctly.
-                for info in signals.pending() {
-                    emulate_default_handler(info.signal)?;
-                }
-
-                // We exit because we don't have anything else to do as a monitor.
-                exit(0);
-            }
-
-            // Then we check any pending signals that we received. Based on `mon_signal_cb`
-            for info in signals.pending() {
-                let user_signaled = info.cause == Cause::Sent(Sent::User);
-                match info.signal {
-                    SIGCHLD => {
-                        // FIXME: check `mon_handle_sigchld`
-                        // We just wait until all the children are done.
-                        continue;
-                    }
-                    _ => {
-                        // Skip the signal if it was sent by the user and it is self-terminating.
-                        if user_signaled
-                            && is_self_terminating_mon(info.process, command_pid, command_pgrp)
-                        {
-                            continue;
-                        }
-                    }
-                }
-
-                let status = if info.signal == SIGALRM {
-                    // Kill the command with increasing urgency.
-                    // Based on `terminate_command`.
-                    kill(command_pid, SIGHUP);
-                    kill(command_pid, SIGTERM);
-                    std::thread::sleep(Duration::from_secs(2));
-                    kill(command_pid, SIGKILL)
-                } else {
-                    kill(command_pid, info.signal)
-                };
-
-                if status != 0 {
-                    eprintln!("kill failed");
-                }
-            }
-        }
+        match monitor::MonitorRelay::new(command, pty_follower, tx)?.run()? {}
+    } else {
+        pty::PtyRelay::new(monitor_pid, ctx.process.pid, pty_leader, rx)?.run()
     }
-
-    let mut buf = 0i32.to_ne_bytes();
-
-    let mut signals = SignalsInfo::<WithOrigin>::new(SIGNALS)?;
-
-    loop {
-        // First we check if the monitor sent us the exit status of the command.
-        if read(rx, &mut buf).is_ok() {
-            let status = ExitStatus::from_raw(i32::from_ne_bytes(buf));
-
-            if let Some(signal) = status.signal() {
-                // If the command terminated because of a signal, we send this signal to sudo
-                // itself to match the original sudo behavior. If we fail we just return the status
-                // code.
-                if kill(ctx.process.pid, signal) != -1 {
-                    // Given that we overwrote the default handlers for all the signals, we musti
-                    // emulate them to handle the signal we just sent correctly.
-                    for info in signals.pending() {
-                        emulate_default_handler(info.signal)?;
-                    }
-                }
-            }
-
-            return Ok(status);
-        }
-
-        // Then we check any pending signals that we received. Based on `signal_cb_pty`
-        for info in signals.pending() {
-            let user_signaled = info.cause == Cause::Sent(Sent::User);
-            match info.signal {
-                SIGCHLD => {
-                    // FIXME: check `handle_sigchld_pty`
-                    // We just wait until all the children are done.
-                    continue;
-                }
-                SIGCONT => {
-                    // FIXME: check `resume_terminal`
-                    continue;
-                }
-                SIGWINCH => {
-                    // FIXME: check `sync_ttysize`
-                    continue;
-                }
-                _ => {
-                    // Skip the signal if it was sent by the user and it is self-terminating.
-                    if user_signaled && is_self_terminating_pty(info.process, -1, ctx.process.pid) {
-                        continue;
-                    }
-                }
-            }
-
-            // FIXME: check `send_command_status`
-            if kill(monitor_pid, info.signal) != 0 {
-                user_error!("kill failed");
-            }
-        }
-    }
-}
-
-/// Decides if the signal sent by the `signaler` process is self-terminating.
-///
-/// A signal is self-terminating if the PID of the `process`:
-/// - is the same PID of the command, or
-/// - is in the process group of the command and the command is the leader.
-fn is_self_terminating_mon(
-    signaler: Option<Process>,
-    command_pid: ProcessId,
-    command_prgp: ProcessId,
-) -> bool {
-    if let Some(signaler) = signaler {
-        if signaler.pid != 0 {
-            if signaler.pid == command_pid {
-                return true;
-            }
-            let grp_leader = getpgid(signaler.pid);
-
-            if grp_leader != -1 {
-                if grp_leader == command_prgp {
-                    return true;
-                }
-            } else {
-                eprintln!("Could not fetch process group ID");
-            }
-        }
-    }
-
-    false
-}
-
-/// Decides if the signal sent by the `signaler` process is self-terminating.
-///
-/// A signal is self-terminating if the PID of the `process`:
-/// - is the same PID of the command, or
-/// - is in the process group of the command and either sudo or the command is the leader.
-fn is_self_terminating_pty(
-    signaler: Option<Process>,
-    command_pid: ProcessId,
-    sudo_pid: ProcessId,
-) -> bool {
-    if let Some(signaler) = signaler {
-        if signaler.pid != 0 {
-            if signaler.pid == command_pid {
-                return true;
-            }
-
-            let signaler_pgrp = getpgid(signaler.pid);
-            if signaler_pgrp != -1 {
-                if signaler_pgrp == command_pid || signaler_pgrp == sudo_pid {
-                    return true;
-                }
-            } else {
-                auth_warn!("Could not fetch process group ID");
-            }
-        }
-    }
-
-    false
 }

--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
     io,
     os::unix::ffi::OsStrExt,
     os::unix::process::{CommandExt, ExitStatusExt},
-    process::{Command, ExitStatus},
+    process::{exit, Command, ExitStatus},
     time::Duration,
 };
 
@@ -19,7 +19,10 @@ use signal_hook::{
 };
 use sudo_common::{context::LaunchType::Login, Context, Environment};
 use sudo_log::{auth_warn, user_error, user_warn};
-use sudo_system::{getpgid, kill, set_target_user};
+use sudo_system::{
+    fork, getpgid, interface::ProcessId, kill, openpty, pipe, read, set_controlling_terminal,
+    set_target_user, setpgid, setsid, write,
+};
 
 /// We only handle the signals that ogsudo handles.
 const SIGNALS: &[c_int] = &[
@@ -27,7 +30,7 @@ const SIGNALS: &[c_int] = &[
     SIGCONT, SIGWINCH,
 ];
 
-/// Based on `ogsudo`s `exec_nopty` function.
+/// Based on `ogsudo`s `exec_pty` function.
 pub fn run_command(ctx: Context, env: Environment) -> io::Result<ExitStatus> {
     // FIXME: should we pipe the stdio streams?
     let mut command = Command::new(&ctx.command.command);
@@ -76,22 +79,106 @@ pub fn run_command(ctx: Context, env: Environment) -> io::Result<ExitStatus> {
 
     // set target user and groups
     set_target_user(&mut command, ctx.target_user, ctx.target_group);
-    // spawn and exec to command
-    let mut child = command.spawn()?;
 
-    let child_pid = child.id() as i32;
+    // FIXME: Look for `SFD_LEADER` occurences in `exec_pty` to decide what to do with the leader
+    // side of the pty. It should be used to handle signals like `SIGWINCH` and `SIGCONT`.
+    // FIXME: close this!
+    let (_pty_leader, pty_follower) = openpty()?;
+
+    // FIXME: close this!
+    let (rx, tx) = pipe()?;
+
+    // FIXME: fork sucks. Find a better abstraction.
+    let monitor_pid = fork()?;
+    // Monitor logic. Based on `exec_monitor`. It is very important that the content of this block
+    // diverges so the monitor doesn't execute code it shouldn't.
+    if monitor_pid == 0 {
+        // Create new terminal session.
+        setsid()?;
+
+        // Set the pty as the controlling terminal.
+        set_controlling_terminal(pty_follower)?;
+
+        // spawn and exec to command
+        let mut command = command.spawn()?;
+
+        let command_pid = command.id() as ProcessId;
+
+        // set the process group ID of the command to the command PID.
+        let command_pgrp = command_pid;
+        setpgid(command_pid, command_pgrp);
+
+        let mut signals = SignalsInfo::<WithOrigin>::new(SIGNALS)?;
+
+        // FIXME: There should be a nice abstraction for these loops that wait for something to
+        // happen and handle signals meanwhile.
+        loop {
+            // First we check if the command is finished
+            if let Some(status) = command.try_wait()? {
+                write(tx, &status.into_raw().to_ne_bytes())?;
+
+                // Given that we overwrote the default handlers for all the signals, we musti
+                // emulate them to handle the signal we just sent correctly.
+                for info in signals.pending() {
+                    emulate_default_handler(info.signal)?;
+                }
+
+                // We exit because we don't have anything else to do as a monitor.
+                exit(0);
+            }
+
+            // Then we check any pending signals that we received. Based on `mon_signal_cb`
+            for info in signals.pending() {
+                let user_signaled = info.cause == Cause::Sent(Sent::User);
+                match info.signal {
+                    SIGCHLD => {
+                        // FIXME: check `mon_handle_sigchld`
+                        // We just wait until all the children are done.
+                        continue;
+                    }
+                    _ => {
+                        // Skip the signal if it was sent by the user and it is self-terminating.
+                        if user_signaled
+                            && is_self_terminating_mon(info.process, command_pid, command_pgrp)
+                        {
+                            continue;
+                        }
+                    }
+                }
+
+                let status = if info.signal == SIGALRM {
+                    // Kill the command with increasing urgency.
+                    // Based on `terminate_command`.
+                    kill(command_pid, SIGHUP);
+                    kill(command_pid, SIGTERM);
+                    std::thread::sleep(Duration::from_secs(2));
+                    kill(command_pid, SIGKILL)
+                } else {
+                    kill(command_pid, info.signal)
+                };
+
+                if status != 0 {
+                    eprintln!("kill failed");
+                }
+            }
+        }
+    }
+
+    let mut buf = 0i32.to_ne_bytes();
 
     let mut signals = SignalsInfo::<WithOrigin>::new(SIGNALS)?;
 
     loop {
-        // First we check if the child is finished
-        if let Some(status) = child.try_wait()? {
+        // First we check if the monitor sent us the exit status of the command.
+        if read(rx, &mut buf).is_ok() {
+            let status = ExitStatus::from_raw(i32::from_ne_bytes(buf));
+
             if let Some(signal) = status.signal() {
-                // If the child terminated because of a signal, we send this signal to sudo
+                // If the command terminated because of a signal, we send this signal to sudo
                 // itself to match the original sudo behavior. If we fail we just return the status
                 // code.
                 if kill(ctx.process.pid, signal) != -1 {
-                    // Given that we overwrote the default handlers for all the signals, we must
+                    // Given that we overwrote the default handlers for all the signals, we musti
                     // emulate them to handle the signal we just sent correctly.
                     for info in signals.pending() {
                         emulate_default_handler(info.signal)?;
@@ -102,66 +189,88 @@ pub fn run_command(ctx: Context, env: Environment) -> io::Result<ExitStatus> {
             return Ok(status);
         }
 
-        // Then we check any pending signals that we received.
+        // Then we check any pending signals that we received. Based on `signal_cb_pty`
         for info in signals.pending() {
             let user_signaled = info.cause == Cause::Sent(Sent::User);
             match info.signal {
                 SIGCHLD => {
-                    // FIXME: check `handle_sigchld_nopty`
+                    // FIXME: check `handle_sigchld_pty`
                     // We just wait until all the children are done.
                     continue;
                 }
-                SIGWINCH | SIGINT | SIGQUIT | SIGTSTP => {
-                    // Skip the signal if it was not sent by the user or if it is self-terminating.
-                    if !user_signaled
-                        || is_self_terminating(info.process, child_pid, ctx.process.pid)
-                    {
-                        continue;
-                    }
+                SIGCONT => {
+                    // FIXME: check `resume_terminal`
+                    continue;
+                }
+                SIGWINCH => {
+                    // FIXME: check `sync_ttysize`
+                    continue;
                 }
                 _ => {
                     // Skip the signal if it was sent by the user and it is self-terminating.
-                    if user_signaled
-                        && is_self_terminating(info.process, child_pid, ctx.process.pid)
-                    {
+                    if user_signaled && is_self_terminating_pty(info.process, -1, ctx.process.pid) {
                         continue;
                     }
                 }
             }
 
-            let status = if info.signal == SIGALRM {
-                // Kill the child with increasing urgency.
-                // Based on `terminate_command`.
-                kill(child_pid, SIGHUP);
-                kill(child_pid, SIGTERM);
-                std::thread::sleep(Duration::from_secs(2));
-                kill(child_pid, SIGKILL)
-            } else {
-                kill(child_pid, info.signal)
-            };
-
-            if status != 0 {
+            // FIXME: check `send_command_status`
+            if kill(monitor_pid, info.signal) != 0 {
                 user_error!("kill failed");
             }
         }
     }
 }
 
-/// Decides if the signal sent by `process` is self-terminating.
+/// Decides if the signal sent by the `signaler` process is self-terminating.
 ///
 /// A signal is self-terminating if the PID of the `process`:
-/// - is the same PID of the child, or
-/// - is in the process group of the child and either sudo or the child is the leader.
-fn is_self_terminating(process: Option<Process>, child_pid: i32, sudo_pid: i32) -> bool {
-    if let Some(process) = process {
-        if process.pid != 0 {
-            if process.pid == child_pid {
+/// - is the same PID of the command, or
+/// - is in the process group of the command and the command is the leader.
+fn is_self_terminating_mon(
+    signaler: Option<Process>,
+    command_pid: ProcessId,
+    command_prgp: ProcessId,
+) -> bool {
+    if let Some(signaler) = signaler {
+        if signaler.pid != 0 {
+            if signaler.pid == command_pid {
                 return true;
             }
-            let grp_leader = getpgid(process.pid);
+            let grp_leader = getpgid(signaler.pid);
 
             if grp_leader != -1 {
-                if grp_leader == child_pid || grp_leader == sudo_pid {
+                if grp_leader == command_prgp {
+                    return true;
+                }
+            } else {
+                eprintln!("Could not fetch process group ID");
+            }
+        }
+    }
+
+    false
+}
+
+/// Decides if the signal sent by the `signaler` process is self-terminating.
+///
+/// A signal is self-terminating if the PID of the `process`:
+/// - is the same PID of the command, or
+/// - is in the process group of the command and either sudo or the command is the leader.
+fn is_self_terminating_pty(
+    signaler: Option<Process>,
+    command_pid: ProcessId,
+    sudo_pid: ProcessId,
+) -> bool {
+    if let Some(signaler) = signaler {
+        if signaler.pid != 0 {
+            if signaler.pid == command_pid {
+                return true;
+            }
+
+            let signaler_pgrp = getpgid(signaler.pid);
+            if signaler_pgrp != -1 {
+                if signaler_pgrp == command_pid || signaler_pgrp == sudo_pid {
                     return true;
                 }
             } else {

--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -7,8 +7,8 @@ use std::{
     ffi::{c_int, CString, OsStr},
     io,
     mem::size_of,
-    os::unix::process::CommandExt,
     os::unix::{ffi::OsStrExt, process::ExitStatusExt},
+    os::{fd::OwnedFd, unix::process::CommandExt},
     process::{Command, ExitStatus},
 };
 
@@ -91,7 +91,7 @@ enum ExitReason {
 }
 
 impl ExitReason {
-    fn send(self, tx: c_int) -> io::Result<()> {
+    fn send(self, tx: &OwnedFd) -> io::Result<()> {
         let mut bytes = [0u8; size_of::<u8>() + size_of::<i32>()];
         let (prefix_bytes, int_bytes) = bytes.split_at_mut(size_of::<u8>());
         match self {
@@ -109,7 +109,7 @@ impl ExitReason {
         Ok(())
     }
 
-    fn recv(rx: c_int) -> io::Result<Self> {
+    fn recv(rx: &OwnedFd) -> io::Result<Self> {
         let mut bytes = [0u8; size_of::<u8>() + size_of::<i32>()];
 
         read(rx, &mut bytes)?;

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -113,13 +113,13 @@ impl MonitorRelay {
             // Kill the command with increasing urgency.
             SIGALRM => {
                 // Based on `terminate_command`.
-                kill(self.command_pid, SIGHUP);
-                kill(self.command_pid, SIGTERM);
+                kill(self.command_pid, SIGHUP).ok();
+                kill(self.command_pid, SIGTERM).ok();
                 std::thread::sleep(Duration::from_secs(2));
-                kill(self.command_pid, SIGKILL);
+                kill(self.command_pid, SIGKILL).ok();
             }
             signal => {
-                kill(self.command_pid, signal);
+                kill(self.command_pid, signal).ok();
             }
         }
     }

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -135,9 +135,8 @@ impl MonitorRelay {
                 if signaler.pid == self.command_pid {
                     return true;
                 }
-                let grp_leader = getpgid(signaler.pid);
 
-                if grp_leader != -1 {
+                if let Ok(grp_leader) = getpgid(signaler.pid) {
                     if grp_leader == self.command_pgrp {
                         return true;
                     }

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -49,13 +49,9 @@ impl MonitorRelay {
             let command_pgrp = command_pid;
             setpgid(command_pid, command_pgrp);
 
-            Ok((
-                SignalsInfo::<WithOrigin>::new(super::SIGNALS)?,
-                command_pid,
-                command_pgrp,
-                command,
-                pty_follower,
-            ))
+            let signals = SignalsInfo::<WithOrigin>::new(super::SIGNALS)?;
+
+            Ok((signals, command_pid, command_pgrp, command, pty_follower))
         });
 
         if result.is_err() {

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -1,0 +1,135 @@
+use std::{
+    ffi::c_int,
+    io,
+    os::unix::process::ExitStatusExt,
+    process::{exit, Child, Command},
+    time::Duration,
+};
+
+use signal_hook::{
+    consts::*,
+    iterator::{exfiltrator::WithOrigin, SignalsInfo},
+    low_level::{
+        emulate_default_handler,
+        siginfo::{Cause, Origin, Process, Sent},
+    },
+};
+use sudo_log::user_error;
+use sudo_system::{
+    close, getpgid, interface::ProcessId, kill, set_controlling_terminal, setpgid, setsid, write,
+};
+
+pub(super) struct MonitorRelay {
+    signals: SignalsInfo<WithOrigin>,
+    command_pid: ProcessId,
+    command_pgrp: ProcessId,
+    command: Child,
+    pty_follower: c_int,
+    tx: c_int,
+}
+
+impl MonitorRelay {
+    pub(super) fn new(mut command: Command, pty_follower: c_int, tx: c_int) -> io::Result<Self> {
+        // Create new terminal session.
+        setsid()?;
+
+        // Set the pty as the controlling terminal.
+        set_controlling_terminal(pty_follower)?;
+
+        // spawn and exec to command
+        let command = command.spawn()?;
+
+        let command_pid = command.id() as ProcessId;
+
+        // set the process group ID of the command to the command PID.
+        let command_pgrp = command_pid;
+        setpgid(command_pid, command_pgrp);
+
+        Ok(Self {
+            signals: SignalsInfo::<WithOrigin>::new(super::SIGNALS)?,
+            command_pid,
+            command_pgrp,
+            command,
+            pty_follower,
+            tx,
+        })
+    }
+
+    /// FIXME: this should return `!` but it is not stable yet.
+    pub(super) fn run(mut self) -> io::Result<std::convert::Infallible> {
+        loop {
+            // First we check if the command is finished
+            self.wait_command()?;
+
+            // Then we check any pending signals that we received. Based on `mon_signal_cb`
+            for info in self.signals.pending() {
+                self.relay_signal(info);
+            }
+        }
+    }
+
+    fn wait_command(&mut self) -> io::Result<()> {
+        if let Some(status) = self.command.try_wait()? {
+            write(self.tx, &status.into_raw().to_ne_bytes())?;
+            close(self.tx)?;
+
+            // Given that we overwrote the default handlers for all the signals, we musti
+            // emulate them to handle the signal we just sent correctly.
+            for info in self.signals.pending() {
+                emulate_default_handler(info.signal)?;
+            }
+
+            close(self.pty_follower)?;
+            exit(0);
+        }
+
+        Ok(())
+    }
+
+    fn relay_signal(&self, info: Origin) {
+        let user_signaled = info.cause == Cause::Sent(Sent::User);
+        match info.signal {
+            // FIXME: check `mon_handle_sigchld`
+            SIGCHLD => {}
+            // Skip the signal if it was sent by the user and it is self-terminating.
+            _ if user_signaled && self.is_self_terminating(info.process) => {}
+            // Kill the command with increasing urgency.
+            SIGALRM => {
+                // Based on `terminate_command`.
+                kill(self.command_pid, SIGHUP);
+                kill(self.command_pid, SIGTERM);
+                std::thread::sleep(Duration::from_secs(2));
+                kill(self.command_pid, SIGKILL);
+            }
+            signal => {
+                kill(self.command_pid, signal);
+            }
+        }
+    }
+
+    /// Decides if the signal sent by the `signaler` process is self-terminating.
+    ///
+    /// A signal is self-terminating if the PID of the `process`:
+    /// - is the same PID of the command, or
+    /// - is in the process group of the command and the command is the leader.
+    fn is_self_terminating(&self, signaler: Option<Process>) -> bool {
+        if let Some(signaler) = signaler {
+            if signaler.pid != 0 {
+                if signaler.pid == self.command_pid {
+                    return true;
+                }
+                let grp_leader = getpgid(signaler.pid);
+
+                if grp_leader != -1 {
+                    if grp_leader == self.command_pgrp {
+                        return true;
+                    }
+                } else {
+                    user_error!("Could not fetch process group ID");
+                }
+            }
+        }
+
+        false
+    }
+}

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -77,7 +77,7 @@ impl MonitorRelay {
             self.wait_command()?;
 
             // Then we check any pending signals that we received. Based on `mon_signal_cb`
-            for info in self.signals.pending() {
+            for info in self.signals.wait() {
                 self.relay_signal(info);
             }
         }

--- a/lib/sudo-exec/src/pty.rs
+++ b/lib/sudo-exec/src/pty.rs
@@ -1,0 +1,128 @@
+use std::{ffi::c_int, io, os::unix::process::ExitStatusExt, process::ExitStatus};
+
+use signal_hook::{
+    consts::*,
+    iterator::{exfiltrator::WithOrigin, SignalsInfo},
+    low_level::{
+        emulate_default_handler,
+        siginfo::{Cause, Origin, Process, Sent},
+    },
+};
+use sudo_log::user_error;
+use sudo_system::{close, getpgid, interface::ProcessId, kill, read};
+
+pub(super) struct PtyRelay {
+    signals: SignalsInfo<WithOrigin>,
+    monitor_pid: ProcessId,
+    sudo_pid: ProcessId,
+    command_pid: ProcessId,
+    // FIXME: Look for `SFD_LEADER` occurences in `exec_pty` to decide what to do with the leader
+    // side of the pty. It should be used to handle signals like `SIGWINCH` and `SIGCONT`.
+    pty_leader: c_int,
+    rx: c_int,
+    buf: [u8; std::mem::size_of::<i32>()],
+}
+
+impl PtyRelay {
+    pub(super) fn new(
+        monitor_pid: ProcessId,
+        sudo_pid: ProcessId,
+        pty_leader: c_int,
+        rx: c_int,
+    ) -> io::Result<Self> {
+        Ok(Self {
+            signals: SignalsInfo::<WithOrigin>::new(super::SIGNALS)?,
+            monitor_pid,
+            sudo_pid,
+            // FIXME: is this ok? Check ogsudo's code.
+            command_pid: -1,
+            pty_leader,
+            rx,
+            buf: 0i32.to_ne_bytes(),
+        })
+    }
+
+    pub(super) fn run(mut self) -> io::Result<ExitStatus> {
+        loop {
+            // First we check if the monitor sent us the exit status of the command.
+            if let Some(status) = self.wait_monitor()? {
+                return Ok(status);
+            }
+
+            // Then we check any pending signals that we received. Based on `signal_cb_pty`
+            for info in self.signals.pending() {
+                self.relay_signal(info);
+            }
+        }
+    }
+
+    fn wait_monitor(&mut self) -> io::Result<Option<ExitStatus>> {
+        if read(self.rx, &mut self.buf).is_ok() {
+            close(self.rx)?;
+
+            let status = ExitStatus::from_raw(i32::from_ne_bytes(self.buf));
+
+            if let Some(signal) = status.signal() {
+                // If the command terminated because of a signal, we send this signal to sudo
+                // itself to match the original sudo behavior. If we fail we just return the status
+                // code.
+                if kill(self.sudo_pid, signal) != -1 {
+                    // Given that we overwrote the default handlers for all the signals, we musti
+                    // emulate them to handle the signal we just sent correctly.
+                    for info in self.signals.pending() {
+                        emulate_default_handler(info.signal)?;
+                    }
+                }
+            }
+
+            close(self.pty_leader)?;
+            Ok(Some(status))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn relay_signal(&self, info: Origin) {
+        let user_signaled = info.cause == Cause::Sent(Sent::User);
+        match info.signal {
+            // FIXME: check `handle_sigchld_pty`
+            SIGCHLD => {}
+            // FIXME: check `resume_terminal`
+            SIGCONT => {}
+            // FIXME: check `sync_ttysize`
+            SIGWINCH => {}
+            // Skip the signal if it was sent by the user and it is self-terminating.
+            _ if user_signaled && self.is_self_terminating(info.process) => {}
+            // FIXME: check `send_command_status`
+            signal => {
+                kill(self.monitor_pid, signal);
+            }
+        }
+    }
+
+    /// Decides if the signal sent by the `signaler` process is self-terminating.
+    ///
+    /// A signal is self-terminating if the PID of the `process`:
+    /// - is the same PID of the command, or
+    /// - is in the process group of the command and either sudo or the command is the leader.
+    fn is_self_terminating(&self, signaler: Option<Process>) -> bool {
+        if let Some(signaler) = signaler {
+            if signaler.pid != 0 {
+                if signaler.pid == self.command_pid {
+                    return true;
+                }
+
+                let signaler_pgrp = getpgid(signaler.pid);
+                if signaler_pgrp != -1 {
+                    if signaler_pgrp == self.command_pid || signaler_pgrp == self.sudo_pid {
+                        return true;
+                    }
+                } else {
+                    user_error!("Could not fetch process group ID");
+                }
+            }
+        }
+
+        false
+    }
+}

--- a/lib/sudo-exec/src/pty.rs
+++ b/lib/sudo-exec/src/pty.rs
@@ -108,8 +108,7 @@ impl PtyRelay {
                     return true;
                 }
 
-                let signaler_pgrp = getpgid(signaler.pid);
-                if signaler_pgrp != -1 {
+                if let Ok(signaler_pgrp) = getpgid(signaler.pid) {
                     if signaler_pgrp == self.command_pid || signaler_pgrp == self.sudo_pid {
                         return true;
                     }

--- a/lib/sudo-exec/src/pty.rs
+++ b/lib/sudo-exec/src/pty.rs
@@ -63,7 +63,7 @@ impl PtyRelay {
                     // If the command terminated because of a signal, we send this signal to sudo
                     // itself to match the original sudo behavior. If we fail we exit with code 1
                     // to be safe.
-                    if kill(self.sudo_pid, signal) == -1 {
+                    if kill(self.sudo_pid, signal).is_err() {
                         exit(1);
                     }
                     // Given that we overwrote the default handlers for all the signals, we musti
@@ -91,7 +91,7 @@ impl PtyRelay {
             _ if user_signaled && self.is_self_terminating(info.process) => {}
             // FIXME: check `send_command_status`
             signal => {
-                kill(self.monitor_pid, signal);
+                kill(self.monitor_pid, signal).ok();
             }
         }
     }

--- a/lib/sudo-exec/src/pty.rs
+++ b/lib/sudo-exec/src/pty.rs
@@ -49,7 +49,7 @@ impl PtyRelay {
             self.wait_monitor()?;
 
             // Then we check any pending signals that we received. Based on `signal_cb_pty`
-            for info in self.signals.pending() {
+            for info in self.signals.wait() {
                 self.relay_signal(info);
             }
         }

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
 pub use audit::secure_open;
 use interface::{DeviceId, GroupId, ProcessId, UserId};
 pub use libc::PATH_MAX;
+use libc::{O_CLOEXEC, O_NONBLOCK};
 use sudo_cutils::*;
 use time::SystemTime;
 
@@ -40,7 +41,7 @@ pub fn close(fd: libc::c_int) -> io::Result<()> {
 
 pub fn pipe() -> io::Result<(libc::c_int, libc::c_int)> {
     let mut fds = [0; 2];
-    cerr(unsafe { libc::pipe(fds.as_mut_ptr()) })?;
+    cerr(unsafe { libc::pipe2(fds.as_mut_ptr(), O_CLOEXEC | O_NONBLOCK) })?;
     Ok((fds[0], fds[1]))
 }
 

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -111,10 +111,10 @@ pub fn set_target_user(
 }
 
 /// Send a signal to a process.
-pub fn kill(pid: ProcessId, signal: c_int) -> c_int {
+pub fn kill(pid: ProcessId, signal: c_int) -> io::Result<()> {
     // SAFETY: This function cannot cause UB even if `pid` is not a valid process ID or if
     // `signal` is not a valid signal code.
-    unsafe { libc::kill(pid, signal) }
+    cerr(unsafe { libc::kill(pid, signal) }).map(|_| ())
 }
 
 /// Get a process group ID.

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -118,9 +118,9 @@ pub fn kill(pid: ProcessId, signal: c_int) -> c_int {
 }
 
 /// Get a process group ID.
-pub fn getpgid(pid: ProcessId) -> ProcessId {
+pub fn getpgid(pid: ProcessId) -> io::Result<ProcessId> {
     // SAFETY: This function cannot cause UB even if `pid` is not a valid process ID
-    unsafe { libc::getpgid(pid) }
+    cerr(unsafe { libc::getpgid(pid) })
 }
 
 /// Set a process group ID.

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -33,6 +33,11 @@ pub fn read(fd: libc::c_int, buf: &mut [u8]) -> io::Result<libc::ssize_t> {
     cerr(unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) })
 }
 
+pub fn close(fd: libc::c_int) -> io::Result<()> {
+    cerr(unsafe { libc::close(fd) })?;
+    Ok(())
+}
+
 pub fn pipe() -> io::Result<(libc::c_int, libc::c_int)> {
     let mut fds = [0; 2];
     cerr(unsafe { libc::pipe(fds.as_mut_ptr()) })?;

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -609,7 +609,7 @@ mod tests {
     #[test]
     fn pgid_test() {
         use super::getpgid;
-        assert_eq!(getpgid(std::process::id() as i32), getpgid(0));
+        assert_eq!(getpgid(std::process::id() as i32).unwrap(), getpgid(0).unwrap());
     }
     #[test]
     fn kill_test() {

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -609,7 +609,10 @@ mod tests {
     #[test]
     fn pgid_test() {
         use super::getpgid;
-        assert_eq!(getpgid(std::process::id() as i32).unwrap(), getpgid(0).unwrap());
+        assert_eq!(
+            getpgid(std::process::id() as i32).unwrap(),
+            getpgid(0).unwrap()
+        );
     }
     #[test]
     fn kill_test() {

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -85,7 +85,7 @@ do this then this software is not suited for you at this time."
     }
 }
 
-fn sudo_process() -> Result<std::process::ExitStatus, Error> {
+fn sudo_process() -> Result<std::convert::Infallible, Error> {
     sudo_log::SudoLogger::new().into_global_logger();
 
     // parse cli options
@@ -129,13 +129,7 @@ fn sudo_process() -> Result<std::process::ExitStatus, Error> {
 
 fn main() {
     match sudo_process() {
-        Ok(status) => {
-            if let Some(code) = status.code() {
-                std::process::exit(code);
-            } else {
-                std::process::exit(1);
-            }
-        }
+        Ok(inf) => match inf {},
         Err(error) => {
             diagnostic!("{error}");
             std::process::exit(1);

--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/kill-sudo.sh
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/kill-sudo.sh
@@ -1,10 +1,20 @@
 # because the sudo process is `spawn`-ed it may not be immediately visible so
 # retry `pidof` until it becomes visible
 for _ in $(seq 1 20); do
-	sudopid="$(pidof sudo)"
-	if [ -n "$sudopid" ]; then
-		# give `expects-signal.sh ` some time to execute the `trap` command otherwise
-		# it'll be terminated before the signal handler is installed
+    # when sudo runs with `use_pty` there are two sudo processes as sudo spawns
+    # a monitor process. We want the PID of the sudo process so we assume it
+    # must be the smallest of the returned PIDs. 
+    sudopid="-1"
+	pids="$(pidof sudo)"
+    for pid in $pids; do
+        if [ $pid -le $sudopid ] || [ $sudopid -eq -1 ]; then
+            sudopid=$pid
+        fi
+    done
+
+	if [ $sudopid -ne -1 ]; then
+        # give `expects-signal.sh ` some time to execute the `trap` command
+        # otherwise it'll be terminated before the signal handler is installed
 		sleep 0.1
 		kill "$sudopid"
 		exit 0


### PR DESCRIPTION
This replaces the old behavior based around `exec_nopty` and uses `exec_pty` instead. The rough logic described in `man sudo` is implemented but some details are missing:

1. Allocate a new pseudoterminal
2. Create a monitor process
3. Create a new terminal session with the monitor as the leader and the follower end of the pseudoterminal as the controlling terminal.
4. Spawn the command from the monitor.
5. Relay signals between sudo and the monitor and between the monitor and the command.
6. Propagate the exit status of the command to sudo.