### PR TITLE
Extend `cerr` so it allows `isize`

### DIFF
--- a/lib/sudo-cutils/src/lib.rs
+++ b/lib/sudo-cutils/src/lib.rs
@@ -3,9 +3,9 @@ use std::{
     os::unix::prelude::OsStrExt,
 };
 
-pub fn cerr<Int: Copy + Into<libc::c_long>>(res: Int) -> std::io::Result<Int> {
-    match res.into() {
-        -1 => Err(std::io::Error::last_os_error()),
+pub fn cerr<Int: Copy + TryInto<libc::c_long>>(res: Int) -> std::io::Result<Int> {
+    match res.try_into() {
+        Ok(-1) => Err(std::io::Error::last_os_error()),
         _ => Ok(res),
     }
 }


### PR DESCRIPTION
Some types, like `isize/ssize_t`, do not implement `Into<c_long>`. These changes soften this requirement to be `TryInto<c_long>` instead. Given that the error value used by `cerr` is always `-1` it is reasonably safe to assume that if the conversion fails, the value wasn't `-1` as such value fits in `c_long` anyway.