### PR TITLE
Replace clap with custom CLI parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,55 +3,6 @@
 version = 3
 
 [[package]]
-name = "anstream"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is-terminal",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
-dependencies = [
- "anstyle",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,7 +20,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn",
  "which",
 ]
 
@@ -112,62 +63,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
-dependencies = [
- "clap_builder",
- "clap_derive",
- "once_cell",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
-dependencies = [
- "anstream",
- "anstyle",
- "bitflags",
- "clap_lex",
- "once_cell",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -237,12 +139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
 name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,18 +172,6 @@ checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
-dependencies = [
- "hermit-abi",
- "io-lifetimes",
- "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -412,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -474,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 
 [[package]]
 name = "shlex"
@@ -505,12 +389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "sudo"
 version = "0.1.0-alpha.1"
 dependencies = [
@@ -528,7 +406,6 @@ dependencies = [
 name = "sudo-cli"
 version = "0.1.0-alpha.1"
 dependencies = [
- "clap",
  "pretty_assertions",
 ]
 
@@ -631,17 +508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "syslog"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,12 +576,6 @@ name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ homepage = "https://github.com/memorysafety/sudo-rs"
 publish = true
 
 [workspace.dependencies]
-clap = "4.0.32"
 libc = "0.2.139"
 glob = "0.3.1"
 signal-hook = "0.3.15"

--- a/lib/sudo-cli/Cargo.toml
+++ b/lib/sudo-cli/Cargo.toml
@@ -7,8 +7,5 @@ repository.workspace = true
 homepage.workspace = true
 publish.workspace = true
 
-[dependencies]
-clap = { workspace = true, features = ["derive", "cargo"] }
-
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/lib/sudo-cli/src/help.rs
+++ b/lib/sudo-cli/src/help.rs
@@ -1,0 +1,42 @@
+pub const HELP_MSG: &str = "sudo - execute a command as another user
+
+usage: sudo -h | -K | -k | -V
+usage: sudo -v [-AknS] [-g group] [-h host] [-u user]
+usage: sudo -l [-AknS] [-g group] [-h host] [-U user] [-u user] [command]
+usage: sudo [-AbEHknPS] [-D directory] [-g group] [-h host] [-R
+            directory] [-u user] [VAR=value] [-i|-s] [<command>]
+usage: sudo -e [-AknS] [-D directory] [-g group] [-h host] [-R
+            directory] [-u user] file ...
+
+Options:
+  -A, --askpass                 use a helper program for password prompting
+  -b, --background              run command in the background
+  -D, --chdir=directory         change the working directory before running command
+  -E, --preserve-env=list       preserve specific environment variables
+  -e, --edit                    edit files instead of running a command
+  -g, --group=group             run command as the specified group name or ID
+  -H, --set-home                set HOME variable to target user's home dir
+  -h, --help                    display help message and exit
+  -h, --host=host               run command on host (if supported by plugin)
+  -i, --login                   run login shell as the target user; a command may also be
+                                specified
+  -K, --remove-timestamp        remove timestamp file completely
+  -k, --reset-timestamp         invalidate timestamp file
+  -l, --list                    list user's privileges or check a specific command; use twice
+                                for longer format
+  -n, --non-interactive         non-interactive mode, no prompts are used
+  -P, --preserve-groups         preserve group vector instead of setting to target's
+  -R, --chroot=directory        change the root directory before running command
+  -S, --stdin                   read password from standard input
+  -s, --shell                   run shell as the target user; a command may also be specified
+  -U, --other-user=user         in list mode, display privileges for user
+  -u, --user=user               run command (or edit file) as specified user name or ID
+  -V, --version                 display version information and exit
+  -v, --validate                update user's timestamp without running a command
+  --                            stop processing command line arguments";
+
+pub const USAGE_MSG: &str = "usage: sudo -h | -K | -k | -V
+usage: sudo -v [-AknS] [-g group] [-h host] [-u user]
+usage: sudo -l [-AknS] [-g group] [-h host] [-U user] [-u user] [command]
+usage: sudo [-AbEHknPS] [-D directory] [-g group] [-h host] [-R directory] [-u user] [VAR=value] [-i|-s] [<command>]
+usage: sudo -e [-AknS] [-D directory] [-g group] [-h host] [-R directory] [-u user] file ...";

--- a/lib/sudo-cli/src/help.rs
+++ b/lib/sudo-cli/src/help.rs
@@ -1,15 +1,14 @@
 pub const HELP_MSG: &str = "sudo - execute a command as another user
 
 usage: sudo -h | -K | -k | -V
-usage: sudo -v [-AknS] [-g group] [-h host] [-u user]
-usage: sudo -l [-AknS] [-g group] [-h host] [-U user] [-u user] [command]
-usage: sudo [-AbEHknPS] [-D directory] [-g group] [-h host] [-R
+usage: sudo -v [-knS] [-g group] [-h host] [-u user]
+usage: sudo -l [-knS] [-g group] [-h host] [-U user] [-u user] [command]
+usage: sudo [-bEHknPS] [-D directory] [-g group] [-h host] [-R
             directory] [-u user] [VAR=value] [-i|-s] [<command>]
-usage: sudo -e [-AknS] [-D directory] [-g group] [-h host] [-R
+usage: sudo -e [-knS] [-D directory] [-g group] [-h host] [-R
             directory] [-u user] file ...
 
 Options:
-  -A, --askpass                 use a helper program for password prompting
   -b, --background              run command in the background
   -D, --chdir=directory         change the working directory before running command
   -E, --preserve-env=list       preserve specific environment variables
@@ -36,7 +35,7 @@ Options:
   --                            stop processing command line arguments";
 
 pub const USAGE_MSG: &str = "usage: sudo -h | -K | -k | -V
-usage: sudo -v [-AknS] [-g group] [-h host] [-u user]
-usage: sudo -l [-AknS] [-g group] [-h host] [-U user] [-u user] [command]
-usage: sudo [-AbEHknPS] [-D directory] [-g group] [-h host] [-R directory] [-u user] [VAR=value] [-i|-s] [<command>]
-usage: sudo -e [-AknS] [-D directory] [-g group] [-h host] [-R directory] [-u user] file ...";
+usage: sudo -v [-knS] [-g group] [-h host] [-u user]
+usage: sudo -l [-knS] [-g group] [-h host] [-U user] [-u user] [command]
+usage: sudo [-bEHknPS] [-D directory] [-g group] [-h host] [-R directory] [-u user] [VAR=value] [-i|-s] [<command>]
+usage: sudo -e [-knS] [-D directory] [-g group] [-h host] [-R directory] [-u user] file ...";

--- a/lib/sudo-cli/src/lib.rs
+++ b/lib/sudo-cli/src/lib.rs
@@ -96,7 +96,7 @@ impl SudoOptions {
                         if let Some(next) = arg_iter.next() {
                             processed.push(SudoArg::Argument(arg, next));
                         } else {
-                            Err(format!("invalid argument provided to '{}'", &long_arg))?;
+                            Err(format!("'{}' expects an argument", &long_arg))?;
                         }
                     } else {
                         processed.push(SudoArg::Flag(arg));
@@ -121,7 +121,7 @@ impl SudoOptions {
                                 // short version of --help has no arguments
                                 processed.push(SudoArg::Flag(flag));
                             } else {
-                                Err(format!("invalid argument provided to '-{}'", char))?;
+                                Err(format!("'-{}' expects an argument", char))?;
                             }
                             break;
                         } else {
@@ -186,7 +186,7 @@ impl SudoOptions {
         }
     }
 
-    /// verify that tha passed arguments are valid given the action and there are no conflicts
+    /// verify that the passed arguments are valid given the action and there are no conflicts
     fn validate(&self) -> Result<(), String> {
         // conflicting arguments
         if self.remove_timestamp && self.reset_timestamp {

--- a/lib/sudo-cli/src/lib.rs
+++ b/lib/sudo-cli/src/lib.rs
@@ -19,7 +19,6 @@ pub enum SudoAction {
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct SudoOptions {
-    pub askpass: bool,
     pub background: bool,
     pub chroot: Option<PathBuf>,
     pub directory: Option<PathBuf>,
@@ -253,9 +252,6 @@ impl SudoOptions {
         for arg in arg_iter {
             match arg {
                 SudoArg::Flag(flag) => match flag.as_str() {
-                    "-A" | "--askpass" => {
-                        options.askpass = true;
-                    }
                     "-b" | "--background" => {
                         options.background = true;
                     }

--- a/lib/sudo-cli/src/lib.rs
+++ b/lib/sudo-cli/src/lib.rs
@@ -1,7 +1,6 @@
 #![forbid(unsafe_code)]
 
-use clap::{error::Error, Parser};
-use std::{path::PathBuf, process::exit};
+use std::path::PathBuf;
 
 const HELP_MSG: &str = "sudo - execute a command as another user
 
@@ -45,182 +44,13 @@ Options:
   -v, --validate                update user's timestamp without running a command
   --                            stop processing command line arguments";
 
-#[derive(Debug, Parser, Clone, PartialEq)]
-#[clap(
-    name = "sudo-rs",
-    about = "sudo - execute a command as another user",
-    version,
-    disable_version_flag = true,
-    disable_help_flag = true,
-    trailing_var_arg = true,
-    override_usage = "usage: sudo -h | -K | -k | -V
-    usage: sudo -v [-AknS] [-g group] [-h host] [-p prompt] [-u user]
-    usage: sudo -l [-AknS] [-g group] [-h host] [-p prompt] [-U user] [-u user] [command]
-    usage: sudo [-AbEHknPS] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] [-u user] [VAR=value] [-i|-s] [<command>]
-    usage: sudo -e [-AknS] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] [-u user] file ..."
-)]
-struct Cli {
-    #[arg(
-        long,
-        short = 'A',
-        help = "use a helper program for password prompting",
-        action
-    )]
-    askpass: bool,
-    #[arg(short = 'b', long, help = "run command in the background", action)]
-    background: bool,
-    #[arg(short = 'B', long, help = "ring bell when prompting", action)]
-    bell: bool,
-    #[arg(
-        short = 'C',
-        long = "close-from",
-        help = "close all file descriptors >= num"
-    )]
-    num: Option<i16>,
-    #[arg(
-        short = 'D',
-        long = "chdir",
-        help = "change the working directory before running command"
-    )]
-    directory: Option<PathBuf>,
-    #[arg(long, help = "preserve specific environment variables", value_name = "list", value_delimiter=',', default_value = None, default_missing_value = "", require_equals = true, num_args = 0..)]
-    preserve_env: Vec<String>,
-    #[arg(short = 'E', help = "preserve user environment when running command")]
-    short_preserve_env: bool,
-    #[arg(
-        short = 'e',
-        long,
-        help = "edit files instead of running a command",
-        action
-    )]
-    edit: bool,
-    #[arg(
-        short = 'g',
-        long = "group",
-        help = "run command as the specified group name or ID"
-    )]
-    group: Option<String>,
-    #[arg(
-        short = 'H',
-        long = "set-home",
-        help = "set HOME variable to target user's home dir",
-        action
-    )]
-    set_home: bool,
-    #[arg(
-        short = 'i',
-        long,
-        help = "run login shell as the target user; a command may also be specified",
-        action,
-        conflicts_with("shell")
-    )]
-    login: bool,
-    #[arg(
-        short = 'K',
-        long = "remove-timestamp",
-        help = "remove timestamp file completely",
-        action,
-        conflicts_with("reset_timestamp"),
-        conflicts_with("version")
-    )]
-    remove_timestamp: bool,
-    #[arg(
-        short = 'k',
-        long = "reset-timestamp",
-        help = "invalidate timestamp file",
-        action,
-        conflicts_with("remove_timestamp"),
-        conflicts_with("version")
-    )]
-    reset_timestamp: bool,
-    #[arg(
-        short,
-        long,
-        help = "list user's privileges or check a specific command; use twice for longer format",
-        action
-    )]
-    list: bool,
-    #[arg(
-        short = 'n',
-        long = "non-interactive",
-        help = "non-interactive mode, no prompts are used",
-        action
-    )]
-    non_interactive: bool,
-    #[arg(
-        short = 'P',
-        long = "preserve-groups",
-        help = "preserve group vector instead of setting to target's",
-        action
-    )]
-    preserve_groups: bool,
-    #[arg(
-        short = 'p',
-        long = "prompt",
-        help = "use the specified password prompt"
-    )]
-    prompt: Option<String>,
-    #[arg(
-        short = 'R',
-        long = "chroot",
-        help = "change the root directory before running command",
-        value_name = "directory"
-    )]
-    chroot: Option<PathBuf>,
-    #[arg(short = 'S', long, help = "read password from standard input", action)]
-    stdin: bool,
-    #[arg(
-        short = 's',
-        long,
-        help = "run shell as the target user; a command may also be specified",
-        action
-    )]
-    shell: bool,
-    #[arg(
-        short = 'T',
-        long = "command-timeout",
-        help = "terminate command after the specified time limit",
-        value_name = "timeout"
-    )]
-    command_timeout: Option<String>, // To Do: This is the wrong type. Which one is correct?
-    #[arg(
-        short = 'U',
-        long = "other-user",
-        help = "in list mode, display privileges for user",
-        value_name = "user"
-    )]
-    other_user: Option<String>,
-    #[arg(
-        short = 'u',
-        long = "user",
-        help = "run command (or edit file) as specified user name or ID"
-    )]
-    user: Option<String>,
-    #[arg(
-        short = 'v',
-        long,
-        help = "update user's timestamp without running a command",
-        action
-    )]
-    validate: bool,
-    #[arg(short = 'V', action = clap::ArgAction::Version, required = false)]
-    version: (),
-    #[arg(short = 'h', value_name = "host", default_value = None, default_missing_value = "", require_equals = true, num_args = 0..=1)]
-    host_or_help: Option<String>,
-    #[arg(long, value_name = "host")]
-    host: Option<String>,
-    #[arg(long)]
-    help: bool,
-    // this is a hack to make help show up for `--`, which wouldn't be allowed as a flag in clap.
-    // Ignore value of `stop_processing_args`.
-    #[arg(long = " ", help = "stop processing command line arguments", action)]
-    stop_processing_args: bool,
-    // Arguments passed straight through, either seperated by -- or just trailing.
-    #[arg(hide = true)]
-    external_args: Vec<String>,
-}
+const USAGE_MSG: &str = "usage: sudo -h | -K | -k | -V
+usage: sudo -v [-AknS] [-g group] [-h host] [-p prompt] [-u user]
+usage: sudo -l [-AknS] [-g group] [-h host] [-p prompt] [-U user] [-u user] [command]
+usage: sudo [-AbEHknPS] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] [-u user] [VAR=value] [-i|-s] [<command>]
+usage: sudo -e [-AknS] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] [-u user] file ...";
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct SudoOptions {
     pub askpass: bool,
     pub background: bool,
@@ -234,6 +64,7 @@ pub struct SudoOptions {
     pub edit: bool,
     pub group: Option<String>,
     pub set_home: bool,
+    pub help: bool,
     pub login: bool,
     pub remove_timestamp: bool,
     pub reset_timestamp: bool,
@@ -244,9 +75,10 @@ pub struct SudoOptions {
     pub chroot: Option<PathBuf>,
     pub stdin: bool,
     pub shell: bool,
-    pub command_timeout: Option<String>,
+    pub command_timeout: Option<u64>,
     pub other_user: Option<String>,
     pub user: Option<String>,
+    pub version: bool,
     pub validate: bool,
     pub host: Option<String>,
     // Arguments passed straight through, either seperated by -- or just trailing.
@@ -254,210 +86,230 @@ pub struct SudoOptions {
     pub env_var_list: Vec<(String, String)>,
 }
 
-impl TryFrom<Cli> for SudoOptions {
-    type Error = Error;
-
-    fn try_from(command: Cli) -> Result<Self, Self::Error> {
-        let is_help = command.host_or_help.as_deref() == Some("");
-
-        if is_help || command.help {
-            println!("{HELP_MSG}");
-            exit(0);
-        };
-
-        let host = if command.host.is_some() {
-            return Err(Error::raw(
-                clap::error::ErrorKind::ArgumentConflict,
-                "Cannot use `-h=<HOST>` and `--host=<HOST>` at the same time",
-            ));
-        } else {
-            command.host_or_help
-        };
-
-        // This lets us know if the user passed `--preserve-env` with no args
-        let preserve_env_no_args = command.preserve_env.iter().any(String::is_empty);
-
-        Ok(Self {
-            preserve_env: command.short_preserve_env || preserve_env_no_args,
-            preserve_env_list: {
-                // Filter any empty item from the list as this means that the user passed
-                // `--preserve-env` with no args which is not relevant for this list.
-                command
-                    .preserve_env
-                    .into_iter()
-                    .filter(|s| !s.is_empty())
-                    .collect()
-            },
-            askpass: command.askpass,
-            background: command.background,
-            bell: command.bell,
-            num: command.num,
-            directory: command.directory,
-            edit: command.edit,
-            group: command.group,
-            set_home: command.set_home,
-            login: command.login,
-            remove_timestamp: command.remove_timestamp,
-            reset_timestamp: command.reset_timestamp,
-            list: command.list,
-            non_interactive: command.non_interactive,
-            preserve_groups: command.preserve_groups,
-            prompt: command.prompt,
-            chroot: command.chroot,
-            stdin: command.stdin,
-            shell: command.shell,
-            command_timeout: command.command_timeout,
-            other_user: command.other_user,
-            user: command.user,
-            validate: command.validate,
-            host,
-            external_args: command.external_args,
-            env_var_list: Default::default(),
-        })
-    }
-}
-
 impl SudoOptions {
-    pub fn try_parse_from<I, T>(iter: I) -> Result<Self, Error>
+    const TAKES_ARGUMENT: &[char] = &['C', 'D', 'E', 'g', 'h', 'p', 'R', 'T', 'U', 'u'];
+
+    pub fn normalize_arguments<I, T>(iter: I) -> impl Iterator<Item = String>
     where
         I: IntoIterator<Item = T>,
         T: Into<String> + Clone,
     {
-        // We need all this extra logic because `clap` cannot handle environment variable
-        // declarations. This means that we must filter any args with the shape `NAME=VALUE` before
-        // passing the arguments to `clap`.
-        //
-        // However, this is not straightforward because such args could be part of the command that
-        // `sudo` is supposed to execute. For example, in `sudo FOO=1 -b cmd BAR=2`, `FOO=1` should
-        // be filtered but `BAR=2` should not because it is part of the `cmd BAR=2` command.
+        iter.into_iter().flat_map(|item| {
+            let segment = item.into();
+            if segment.starts_with("--") && segment.contains('=') {
+                // convert argument assignment to seperate segment
+                segment.splitn(2, '=').map(str::to_string).collect()
+            } else if segment.starts_with('-') && !segment.starts_with("--") && segment.len() > 2 {
+                // split combined shorthand options
+                let mut flags: Vec<String> = vec![];
 
-        // Keep the original arguments into `vec_args` in case we need them later.
-        let mut vec_args = iter.into_iter().map(Into::into).collect::<Vec<String>>();
-        let mut args = vec_args.iter();
+                for (n, char) in segment.trim_start_matches('-').chars().enumerate() {
+                    flags.push(format!("-{char}"));
 
-        // Store which args are environment variable declarations.
-        let mut vec_env_vars = vec![false; vec_args.len()];
-        let mut env_vars = vec_env_vars.iter_mut();
+                    // convert option argument to seperate segment
+                    if Self::TAKES_ARGUMENT.contains(&char) {
+                        let rest = segment[(n + 2)..].trim().to_string();
 
-        // Store the arguments that were environment variable declarations.
-        let mut env_var_list = Vec::new();
-        // Store the arguments that were not environment variable declarations.
-        let mut remaining_args = Vec::new();
-        // Whether the args had a `"--"` to separate the external args from the regular args.
-        let mut had_separator = false;
+                        if rest.starts_with('=') {
+                            flags.push("=".to_string());
+                            break;
+                        }
 
-        while let (Some(arg), Some(is_env_var)) = (args.next(), env_vars.next()) {
-            // If we found `--` we know that the remaining arguments are not env variable
-            // definitions.
-            if arg == "--" {
-                had_separator = true;
-                // Push the separator.
-                remaining_args.push(arg);
-                // None of the remaining arguments were environment variable declarations.
-                remaining_args.extend(args);
-                break;
-            }
+                        if !rest.is_empty() {
+                            flags.push(rest);
+                        }
+                        break;
+                    }
+                }
 
-            if let Some((name, value)) = try_to_env_var(arg) {
-                // If this arg is an environment variable we store it as so.
-                *is_env_var = true;
-                env_var_list.push((name.to_owned(), value.to_owned()));
+                flags
             } else {
-                // If this arg is not environment variable we store it as so.
-                remaining_args.push(arg);
+                vec![segment]
+            }
+        })
+    }
+
+    fn try_to_env_var(arg: &str) -> Option<(String, String)> {
+        if let Some((name, value)) = arg.split_once('=').and_then(|(name, value)| {
+            name.chars()
+                .all(|c| c.is_alphanumeric() || c == '_')
+                .then_some((name, value))
+        }) {
+            Some((name.to_owned(), value.to_owned()))
+        } else {
+            None
+        }
+    }
+
+    pub fn parse() -> SudoOptions {
+        match Self::try_parse_from(std::env::args()) {
+            Ok(options) => {
+                if options.help {
+                    eprintln!("{HELP_MSG}");
+                    std::process::exit(1);
+                }
+
+                options
+            }
+            Err(e) => {
+                eprintln!("{e}\n{USAGE_MSG}");
+                std::process::exit(1);
             }
         }
+    }
 
-        // Now that the remaining args are not environment variable declarations we can let `clap`
-        // do its magic.
-        let mut opts: SudoOptions = Cli::try_parse_from(remaining_args)?.try_into()?;
-        // Populate the environment variable declarations.
-        opts.env_var_list = env_var_list;
+    pub fn try_parse_from<I, T>(iter: I) -> Result<Self, &'static str>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<String> + Clone,
+    {
+        let mut options: SudoOptions = SudoOptions::default();
+        let normalized_args = Self::normalize_arguments(iter).collect::<Vec<_>>();
 
-        // If there was a separator or if there is no command to run, there is nothing else to do.
-        if had_separator || opts.external_args.is_empty() {
-            return Ok(opts);
-        }
+        let mut arg_iter = normalized_args.into_iter().peekable();
+        let _command = arg_iter.next();
 
-        // Otherwise, it could be that some of the environment variable declarations were actually
-        // part of the command to be executed by `sudo`. For example, in `sudo env FOO=1 ls`,
-        // `FO0=1` is not a sudo argument but part of the command to be executed.
-
-        // We will traverse the external args and the original args in reverse amd try to figure
-        // out which args were not actually environment variable declarations but external args
-        // instead.
-        let mut external_args = opts.external_args.iter().rev();
-        // Then we will add a separator manually so we can reprocess everything by calling this
-        // function recursively. To do this, we need to figure out where this separator actually
-        // goes.
-        let mut index = None;
-
-        for (i, last_arg) in vec_args.iter().enumerate().rev() {
-            // If the arg was an environment variable declaration, then we must put the separator
-            // before this arg.
-            if vec_env_vars[i] {
-                continue;
-            }
-            // If the last external arg is the same as this arg, we know that the separator must go
-            // before this arg.
-            if let Some(last_external) = external_args.next() {
-                if last_arg == last_external {
-                    continue;
+        while let Some(arg) = arg_iter.next() {
+            match arg.as_str() {
+                "-A" | "--askpass" => {
+                    options.askpass = true;
+                }
+                "-b" | "--background" => {
+                    options.background = true;
+                }
+                "-B" | "--bell" => {
+                    options.bell = true;
+                }
+                "-C" | "--close-from" => {
+                    // pass
+                }
+                "-D" | "--chdir" => {
+                    let arg: String = arg_iter.next().ok_or("no working directory provided")?;
+                    let path_arg = PathBuf::from(arg);
+                    options.directory = Some(path_arg);
+                }
+                "-E" | "--preserve-env" => {
+                    if let Some(next) = arg_iter.peek() {
+                        if next.starts_with('-') || next.starts_with('=') {
+                            options.preserve_env = true;
+                        } else {
+                            options.preserve_env_list = arg_iter
+                                .next()
+                                .unwrap()
+                                .split(',')
+                                .map(str::to_string)
+                                .collect()
+                        }
+                    } else {
+                        options.preserve_env = true;
+                    }
+                }
+                "-e" | "--edit" => {
+                    options.edit = true;
+                }
+                "-g" | "--group" => {
+                    options.group = Some(arg_iter.next().ok_or("no group provided")?);
+                }
+                "-H" | "--set-home" => {
+                    options.set_home = true;
+                }
+                "--help" => {
+                    options.help = true;
+                }
+                "-h" | "--host=host" => {
+                    // -h is both host and help
+                    if let Some(next) = arg_iter.peek() {
+                        if next.starts_with('-') {
+                            options.help = true;
+                        } else {
+                            options.host = Some(arg_iter.next().unwrap());
+                        }
+                    } else {
+                        options.help = true;
+                    }
+                }
+                "-i" | "--login" => {
+                    options.login = true;
+                }
+                "-K" | "--remove-timestamp" => {
+                    if options.reset_timestamp {
+                        Err("conflicting arguments")?;
+                    }
+                    options.remove_timestamp = true;
+                }
+                "-k" | "--reset-timestamp" => {
+                    if options.remove_timestamp {
+                        Err("conflicting arguments")?;
+                    }
+                    options.reset_timestamp = true;
+                }
+                "-l" | "--list" => {
+                    options.list = true;
+                }
+                "-n" | "--non-interactive" => {
+                    options.non_interactive = true;
+                }
+                "-P" | "--preserve-groups" => {
+                    options.preserve_groups = true;
+                }
+                "-p" | "--prompt" => {
+                    options.prompt = Some(arg_iter.next().ok_or("no password prompt provided")?);
+                }
+                "-R" | "--chroot" => {
+                    let arg: String = arg_iter.next().ok_or("no chroot directory provided")?;
+                    let path_arg = PathBuf::from(arg);
+                    options.chroot = Some(path_arg);
+                }
+                "-S" | "--stdin" => {
+                    options.stdin = true;
+                }
+                "-s" | "--shell" => {
+                    options.shell = true;
+                }
+                "-T" | "--command-timeout" => {
+                    options.command_timeout = Some(
+                        arg_iter
+                            .next()
+                            .ok_or("no command timeout provided")?
+                            .parse()
+                            .map_err(|_| "invalid command timeout provided")?,
+                    )
+                }
+                "-U" | "--other-user" => {
+                    options.other_user = Some(arg_iter.next().ok_or("no other user provided")?);
+                }
+                "-u" | "--user" => {
+                    options.user = Some(arg_iter.next().ok_or("no user provided")?);
+                }
+                "-V" | "--version" => {
+                    options.version = true;
+                }
+                "-v" | "--validate" => {
+                    options.validate = true;
+                }
+                "=" => {
+                    Err("invalid option '='")?;
+                }
+                "--" => {
+                    options.external_args.extend(arg_iter);
+                    break;
+                }
+                option if option.starts_with('-') => {
+                    Err("invalid option provided")?;
+                }
+                env_var if SudoOptions::try_to_env_var(env_var).is_some() => {
+                    options
+                        .env_var_list
+                        .push(SudoOptions::try_to_env_var(env_var).unwrap());
+                }
+                _argument => {
+                    options.external_args.push(arg);
+                    options.external_args.extend(arg_iter);
+                    break;
                 }
             }
-            // Otherwise, this arg is already a non-external arg.
-            index = Some(i + 1);
-            break;
         }
 
-        if let Some(mut index) = index {
-            // There is one last catch. In this command `sudo FOO=1 env BAR=2 ls`, `FOO=1` is not
-            // part of the external command. So we need to ignore the first environment variable
-            // declarations before putting the separator.
-            while vec_env_vars[index] {
-                index += 1;
-            }
-            // Then we insert the separator and parse the arguments again. This will not recurse
-            // indefinitely because we don't do any of this extra logic if there was a separator.
-            vec_args.insert(index, "--".to_owned());
-            Self::try_parse_from(vec_args)
-        } else {
-            // If `index` were `None`, it would mean that all the args were environment variable
-            // declarations or part of the external args. But this cannot happen because the first
-            // argument should be the name of the binary being run and that is neither an
-            // environment variable declaration nor a external argument
-            unreachable!()
-        }
-    }
-
-    pub fn parse() -> Self {
-        match Self::try_parse_from(std::env::args()) {
-            Ok(options) => options,
-            Err(err) => {
-                eprintln!("{err}");
-                exit(1);
-            }
-        }
-    }
-}
-
-fn try_to_env_var(arg: &str) -> Option<(String, String)> {
-    if let Some((name, value)) = arg.split_once('=').and_then(|(name, value)| {
-        name.chars()
-            .all(|c| c.is_alphanumeric() || c == '_')
-            .then_some((name, value))
-    }) {
-        Some((name.to_owned(), value.to_owned()))
-    } else {
-        None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn verify_cli() {
-        use clap::CommandFactory;
-        super::Cli::command().debug_assert()
+        Ok(options)
     }
 }

--- a/lib/sudo-cli/tests/lib.rs
+++ b/lib/sudo-cli/tests/lib.rs
@@ -178,15 +178,6 @@ fn shorthand_without_argument() {
 }
 
 #[test]
-fn ask_pass() {
-    let cmd = SudoOptions::try_parse_from(["sudo", "-A"]).unwrap();
-    assert!(cmd.askpass);
-
-    let cmd = SudoOptions::try_parse_from(["sudo", "--askpass"]).unwrap();
-    assert!(cmd.askpass);
-}
-
-#[test]
 fn set_home() {
     let cmd = SudoOptions::try_parse_from(["sudo", "-H"]).unwrap();
     assert!(cmd.set_home);

--- a/lib/sudo-cli/tests/lib.rs
+++ b/lib/sudo-cli/tests/lib.rs
@@ -323,7 +323,7 @@ fn help() {
     let cmd = SudoOptions::try_parse_from(["sudo", "-h"]).unwrap();
     assert_eq!(cmd.action, SudoAction::Help);
 
-    let cmd = SudoOptions::try_parse_from(["sudo", "-Abh"]).unwrap();
+    let cmd = SudoOptions::try_parse_from(["sudo", "-bh"]).unwrap();
     assert_eq!(cmd.action, SudoAction::Help);
 
     let cmd = SudoOptions::try_parse_from(["sudo", "--help"]).unwrap();

--- a/lib/sudo-common/src/command.rs
+++ b/lib/sudo-common/src/command.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::{resolve::resolve_path, Error};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct CommandAndArguments {
     pub command: PathBuf,

--- a/lib/sudo-env/tests/env_tests.rs
+++ b/lib/sudo-env/tests/env_tests.rs
@@ -76,8 +76,7 @@ fn parse_env_commands(input: &str) -> Vec<(&str, Environment)> {
 fn create_test_context<'a>(sudo_options: &'a SudoOptions) -> Context {
     let path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string();
     let command =
-        CommandAndArguments::try_from_args(None, sudo_options.external_args.clone(), &path)
-            .unwrap();
+        CommandAndArguments::try_from_args(None, sudo_options.clone().args(), &path).unwrap();
 
     let current_user = User {
         uid: 1000,
@@ -130,7 +129,7 @@ fn create_test_context<'a>(sudo_options: &'a SudoOptions) -> Context {
             root_group
         },
         set_home: sudo_options.set_home,
-        preserve_env_list: sudo_options.preserve_env_list.clone(),
+        preserve_env: sudo_options.preserve_env.clone(),
         path,
         launch: sudo_common::context::LaunchType::Direct,
         chdir: sudo_options.directory.clone(),

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -2,7 +2,7 @@
 
 use pam::authenticate;
 use std::env;
-use sudo_cli::SudoOptions;
+use sudo_cli::{help, SudoAction, SudoOptions};
 use sudo_common::{Context, Error};
 use sudo_env::environment;
 use sudoers::{Authorization, DirChange, Judgement, Policy, PreJudgementPolicy, Sudoers};
@@ -85,11 +85,44 @@ do this then this software is not suited for you at this time."
     }
 }
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 fn sudo_process() -> Result<std::convert::Infallible, Error> {
     sudo_log::SudoLogger::new().into_global_logger();
 
     // parse cli options
-    let sudo_options = SudoOptions::parse();
+    let sudo_options = match SudoOptions::from_env() {
+        Ok(options) => match options.action {
+            SudoAction::Help => {
+                eprintln!("{}", help::HELP_MSG);
+                std::process::exit(0);
+            }
+            SudoAction::Version => {
+                eprintln!("sudo-rs {VERSION}");
+                std::process::exit(0);
+            }
+            SudoAction::Validate => {
+                unimplemented!();
+            }
+            SudoAction::RemoveTimestamp => {
+                unimplemented!();
+            }
+            SudoAction::ResetTimestamp => {
+                unimplemented!();
+            }
+            SudoAction::Run(_) => options,
+            SudoAction::List(_) => {
+                unimplemented!();
+            }
+            SudoAction::Edit(_) => {
+                unimplemented!();
+            }
+        },
+        Err(e) => {
+            eprintln!("{e}\n{}", help::USAGE_MSG);
+            std::process::exit(1);
+        }
+    };
 
     unstable_warning();
 

--- a/test-framework/sudo-compliance-tests/src/cli.rs
+++ b/test-framework/sudo-compliance-tests/src/cli.rs
@@ -84,7 +84,6 @@ fn dash_flag_no_space_value_syntax() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn dash_flag_equal_value_invalid_syntax() -> Result<()> {
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD).build()?;
 


### PR DESCRIPTION
Replaced the CLI parser based on clap with a custom parser and removed clap as a dependency.
Note that the remaining integration test for the cli has been enabled and the new implementations is shorter (in loc) than the previous version using clap.