### PR TITLE
Mark `sudo_system::fork` as `unsafe`

### DIFF
--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -75,8 +75,10 @@ pub fn run_command(ctx: Context, env: Environment) -> io::Result<std::convert::I
 
     let (pty_leader, pty_follower) = openpty()?;
     let (rx, tx) = pipe()?;
-
-    let monitor_pid = fork()?;
+    // SAFETY: we don't call any function that is not `async-signal-safe` inside this `fork` as all
+    // the signal handling is done by `signal_hook` which protects us from it.
+    #[allow(unsafe_code)]
+    let monitor_pid = unsafe { fork() }?;
     // Monitor logic. Based on `exec_monitor`.
     if monitor_pid == 0 {
         match monitor::MonitorRelay::new(command, pty_follower, tx)?.run()? {}

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -40,7 +40,7 @@ pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
 }
 
-pub fn fork() -> io::Result<ProcessId> {
+pub unsafe fn fork() -> io::Result<ProcessId> {
     cerr(unsafe { libc::fork() })
 }
 


### PR DESCRIPTION
Just paraphrasing @japaric here: The `fork` function should be unsafe because calling any signal handling related function inside the fork itself is UB. `signal_hook` takes care of this but we might be on the safe side and document this behavior instead.