### PR TITLE
Switch to resolver version 2 for cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ members = [
 ]
 default-members = ["sudo"]
 
+resolver = "2"
+
 [workspace.package]
 version = "0.1.0-alpha.1"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Doesn't change anything right now, but prevents issues such as as the one in #290 (note that we already use edition 2021 that makes resolver=2 the default, but it appears this does not apply for workspaces).