### PR TITLE
add stderr checks for sudo-rs

### DIFF
--- a/test-framework/sudo-compliance-tests/src/cli.rs
+++ b/test-framework/sudo-compliance-tests/src/cli.rs
@@ -44,8 +44,11 @@ fn dash_dash_before_flag_is_an_error() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(stderr, "`\"-u\"': command not found");
     }
 
     Ok(())
@@ -94,9 +97,12 @@ fn dash_flag_equal_value_invalid_syntax() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr(), "sudo: unknown user: =root");
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "sudo: unknown user: =root"
+    } else {
+        "invalid option"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/flag_chdir.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_chdir.rs
@@ -10,12 +10,12 @@ fn cwd_not_set_cannot_change_dir() -> Result<()> {
         .exec(&env)?;
     assert_eq!(Some(1), output.status().code());
     assert_eq!(false, output.status().success());
-    if sudo_test::is_original_sudo() {
-        assert_contains!(
-            output.stderr(),
-            "you are not permitted to use the -D option with /bin/pwd"
-        );
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "you are not permitted to use the -D option with /bin/pwd"
+    } else {
+        "authenticated failed, no permission"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }
@@ -96,12 +96,12 @@ fn cwd_set_to_non_glob_value_then_cannot_use_chdir_flag() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(
-            output.stderr(),
-            "you are not permitted to use the -D option with /bin/pwd"
-        );
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "you are not permitted to use the -D option with /bin/pwd"
+    } else {
+        "authenticated failed, no permission"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }
@@ -118,12 +118,12 @@ fn cwd_set_to_non_glob_value_then_cannot_use_that_path_with_chdir_flag() -> Resu
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(
-            output.stderr(),
-            "you are not permitted to use the -D option with /bin/pwd"
-        );
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "you are not permitted to use the -D option with /bin/pwd"
+    } else {
+        "authenticated failed, no permission"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }
@@ -180,12 +180,12 @@ fn target_user_has_insufficient_perms() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(
-            output.stderr(),
-            "sudo: unable to change directory to /root: Permission denied"
-        );
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "sudo: unable to change directory to /root: Permission denied"
+    } else {
+        "FIXME"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/flag_login.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_login.rs
@@ -14,6 +14,7 @@ macro_rules! assert_snapshot {
 }
 
 #[test]
+#[ignore]
 fn if_home_directory_does_not_exist_executes_program_without_changing_the_working_directory(
 ) -> Result<()> {
     let initial_working_directories = ["/", "/root"];
@@ -27,8 +28,11 @@ fn if_home_directory_does_not_exist_executes_program_without_changing_the_workin
 
         assert!(output.status().success());
 
+        let stderr = output.stderr();
         if sudo_test::is_original_sudo() {
-            assert_snapshot!(output.stderr());
+            assert_snapshot!(stderr);
+        } else {
+            assert_contains!(stderr, "unable to change directory");
         }
 
         let actual = output.stdout()?;
@@ -194,8 +198,11 @@ fn shell_does_not_exist() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(stderr, "IO error: No such file or directory");
     }
 
     Ok(())
@@ -216,8 +223,11 @@ fn insufficient_permissions_to_execute_shell() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(stderr, "IO error: Permission denied");
     }
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/flag_shell.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_shell.rs
@@ -168,8 +168,11 @@ fn shell_does_not_exist() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(stderr, "IO error: No such file or directory");
     }
 
     Ok(())
@@ -190,8 +193,11 @@ fn shell_is_not_executable() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(stderr, "IO error: Permission denied");
     }
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/flag_user.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_user.rs
@@ -121,8 +121,11 @@ fn unassigned_user_id_is_rejected() -> Result<()> {
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());
 
+        let stderr = output.stderr();
         if sudo_test::is_original_sudo() {
-            assert_snapshot!(output.stderr());
+            assert_snapshot!(stderr);
+        } else {
+            assert_contains!(stderr, "user `#1234' not found");
         }
     }
 
@@ -139,9 +142,13 @@ fn user_does_not_exist() -> Result<()> {
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr(), "unknown user: ghost");
-    }
+
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "unknown user: ghost"
+    } else {
+        "user `ghost' not found"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/misc.rs
@@ -25,8 +25,11 @@ fn user_not_in_passwd_database_cannot_use_sudo() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(stderr, "user `current user' not found");
     }
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/pam.rs
@@ -34,9 +34,12 @@ fn given_pam_deny_then_password_auth_always_fails() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr(), "3 incorrect password attempts");
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "3 incorrect password attempts"
+    } else {
+        "Authentication failure"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/pass_auth.rs
+++ b/test-framework/sudo-compliance-tests/src/pass_auth.rs
@@ -35,9 +35,12 @@ fn incorrect_password() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr(), "incorrect password attempt");
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "incorrect password attempt"
+    } else {
+        "Authentication failure"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }
@@ -54,9 +57,12 @@ fn no_password() -> Result<()> {
         .exec(&env)?;
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr(), "no password was provided");
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "no password was provided"
+    } else {
+        "Authentication failure"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/path_search.rs
+++ b/test-framework/sudo-compliance-tests/src/path_search.rs
@@ -53,8 +53,11 @@ fn when_path_is_unset_does_not_search_in_default_path_set_for_command_execution(
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(stderr, "`\"my-script\"': command not found");
     }
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/sudoers/cwd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/cwd.rs
@@ -44,12 +44,12 @@ fn non_absolute_path_is_rejected() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(
-            output.stderr(),
-            "values for \"CWD\" must start with a '/', '~', or '*'"
-        );
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "values for \"CWD\" must start with a '/', '~', or '*'"
+    } else {
+        "expected directory or `*'"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }
@@ -65,12 +65,12 @@ fn dot_slash_is_rejected() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(
-            output.stderr(),
-            "values for \"CWD\" must start with a '/', '~', or '*'"
-        );
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "values for \"CWD\" must start with a '/', '~', or '*'"
+    } else {
+        "expected directory or `*'"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }
@@ -140,12 +140,10 @@ fn path_does_not_exist() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(
-            output.stderr(),
-            "sudo: unable to change directory to /path/to/nowhere: No such file or directory"
-        );
-    }
+    assert_contains!(
+        output.stderr(),
+        "sudo: unable to change directory to /path/to/nowhere: No such file or directory"
+    );
 
     Ok(())
 }
@@ -162,12 +160,10 @@ fn path_is_file() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(
-            output.stderr(),
-            "sudo: unable to change directory to /dev/null: Not a directory"
-        );
-    }
+    assert_contains!(
+        output.stderr(),
+        "sudo: unable to change directory to /dev/null: Not a directory"
+    );
 
     Ok(())
 }
@@ -187,12 +183,10 @@ fn target_user_has_insufficient_permissions() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(
-            output.stderr(),
-            "sudo: unable to change directory to /root: Permission denied"
-        );
-    }
+    assert_contains!(
+        output.stderr(),
+        "sudo: unable to change directory to /root: Permission denied"
+    );
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/sudoers/host_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/host_list.rs
@@ -37,8 +37,14 @@ fn given_specific_hostname_then_sudo_from_different_hostname_is_rejected() -> Re
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(
+            stderr,
+            "authenticated failed, i'm sorry root, i'm afraid i can't do that"
+        );
     }
 
     Ok(())
@@ -79,8 +85,14 @@ fn negation_rejects() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(
+            stderr,
+            "authenticated failed, i'm sorry root, i'm afraid i can't do that"
+        );
     }
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/sudoers/run_as.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/run_as.rs
@@ -59,8 +59,14 @@ fn when_empty_then_as_someone_else_is_not_allowed() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(
+            stderr,
+            "authenticated failed, i'm sorry root, i'm afraid i can't do that"
+        );
     }
 
     Ok(())
@@ -115,8 +121,14 @@ fn when_specific_user_then_as_a_different_user_is_not_allowed() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(
+            stderr,
+            "authenticated failed, i'm sorry root, i'm afraid i can't do that"
+        );
     }
 
     Ok(())
@@ -131,8 +143,14 @@ fn when_specific_user_then_as_self_is_not_allowed() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(
+            stderr,
+            "authenticated failed, i'm sorry root, i'm afraid i can't do that"
+        );
     }
 
     Ok(())
@@ -161,12 +179,12 @@ fn when_only_user_is_specified_then_group_flag_is_not_allowed() -> Result<()> {
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());
 
-        if sudo_test::is_original_sudo() {
-            assert_contains!(
-                output.stderr(),
-                " is not allowed to execute '/bin/true' as "
-            );
-        }
+        let diagnostic = if sudo_test::is_original_sudo() {
+            " is not allowed to execute '/bin/true' as ".to_string()
+        } else {
+            format!("authenticated failed, i'm sorry {user}, i'm afraid i can't do that")
+        };
+        assert_contains!(output.stderr(), diagnostic);
     }
 
     Ok(())
@@ -209,8 +227,14 @@ fn when_specific_group_then_as_a_different_group_is_not_allowed() -> Result<()> 
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());
 
+        let stderr = output.stderr();
         if sudo_test::is_original_sudo() {
-            assert_snapshot!(output.stderr());
+            assert_snapshot!(stderr);
+        } else {
+            assert_contains!(
+                stderr,
+                format!("authenticated failed, i'm sorry {user}, i'm afraid i can't do that")
+            );
         }
     }
 
@@ -236,8 +260,14 @@ fn when_only_group_is_specified_then_as_some_user_is_not_allowed() -> Result<()>
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());
 
+        let stderr = output.stderr();
         if sudo_test::is_original_sudo() {
-            assert_snapshot!(output.stderr());
+            assert_snapshot!(stderr);
+        } else {
+            assert_contains!(
+                stderr,
+                format!("authenticated failed, i'm sorry {user}, i'm afraid i can't do that")
+            );
         }
     }
 

--- a/test-framework/sudo-compliance-tests/src/sudoers/secure_path.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/secure_path.rs
@@ -75,8 +75,11 @@ ALL ALL=(ALL:ALL) NOPASSWD: ALL")
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(stderr, "`\"true\"': command not found");
     }
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
@@ -23,8 +23,14 @@ fn no_match() -> Result<()> {
     let output = Command::new("sudo").arg("true").exec(&env)?;
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(
+            stderr,
+            "authenticated failed, i'm sorry root, i'm afraid i can't do that"
+        );
     }
 
     Ok(())
@@ -152,8 +158,14 @@ fn negation_excludes_group_members() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(
+            stderr,
+            "authenticated failed, i'm sorry ghost, i'm afraid i can't do that"
+        );
     }
 
     Ok(())
@@ -209,8 +221,14 @@ fn user_alias_works() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
+    let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_snapshot!(output.stderr());
+        assert_snapshot!(stderr);
+    } else {
+        assert_contains!(
+            stderr,
+            "authenticated failed, i'm sorry ghost, i'm afraid i can't do that"
+        );
     }
 
     Ok(())
@@ -243,9 +261,12 @@ User_Alias ADMINS = %users, !ghost
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr(), "ferris is not in the sudoers file");
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "ferris is not in the sudoers file"
+    } else {
+        "authenticated failed, i'm sorry ferris, i'm afraid i can't do that"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }
@@ -299,8 +320,14 @@ fn negated_supergroup() -> Result<()> {
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());
 
+        let stderr = output.stderr();
         if sudo_test::is_original_sudo() {
-            assert_snapshot!(output.stderr());
+            assert_snapshot!(stderr);
+        } else {
+            assert_contains!(
+                stderr,
+                format!("authenticated failed, i'm sorry {user}, i'm afraid i can't do that")
+            );
         }
     }
 

--- a/test-framework/sudo-compliance-tests/src/timestamp.rs
+++ b/test-framework/sudo-compliance-tests/src/timestamp.rs
@@ -40,9 +40,12 @@ Defaults timestamp_timeout=0.1"
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr(), "a password is required");
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "a password is required"
+    } else {
+        "Authentication failure"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }
@@ -68,9 +71,12 @@ Defaults timestamp_timeout=0"
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr(), "a password is required");
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "a password is required"
+    } else {
+        "Authentication failure"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }
@@ -96,9 +102,12 @@ fn flag_reset_timsetamp() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr(), "a password is required");
-    }
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "a password is required"
+    } else {
+        "Authentication failed"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }
@@ -141,11 +150,12 @@ fn flag_validate_prompts_for_password() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-    if sudo_test::is_original_sudo() {
-        assert_contains!(output.stderr(), "a password is required");
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "a password is required"
     } else {
-        assert_contains!(output.stderr(), "Authentication failure");
-    }
+        "Authentication failure"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }


### PR DESCRIPTION
closes #313 

this PR ungates the following tests as they are now failing after modifying them:
- `flag_login::if_home_directory_does_not_exist_executes_program_without_changing_the_working_directory` see #318 
- `password_retry::three_retries_allowed_by_default` password retry is not yet implemented
- `defaults_passwd_tries` password retry is not yet implemented