### PR TITLE
add regression test for argument processing with -s and -i

### DIFF
--- a/test-framework/sudo-compliance-tests/src/flag_shell.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_shell.rs
@@ -100,6 +100,26 @@ echo $@";
 }
 
 #[test]
+fn arguments_are_properly_distinguished() -> Result<()> {
+    let shell_path = "/root/my-shell";
+    let my_shell = "#!/bin/sh
+for arg in \"$@\"; do echo -n \"{$arg}\"; done";
+    let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
+        .file(shell_path, TextFile(my_shell).chmod("100"))
+        .build()?;
+
+    let output = Command::new("env")
+        .arg(format!("SHELL={shell_path}"))
+        .args(["sudo", "-s", "a b", "c d"])
+        .exec(&env)?
+        .stdout()?;
+
+    assert_eq!("{-c}{a\\ b c\\ d}", output);
+
+    Ok(())
+}
+
+#[test]
 fn arguments_are_escaped_with_backslashes() -> Result<()> {
     let shell_path = "/root/my-shell";
     let my_shell = "#!/bin/sh


### PR DESCRIPTION
Most test cases just use `echo $@`, which doesn't allow detecting where arguments begin or end.