### PR TITLE
Remove globbing from the sudoers file for program arguments.

### DIFF
--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -283,11 +283,7 @@ fn match_token<T: basic_parser::Token + std::ops::Deref<Target = String>>(
 
 fn match_command<'a>((cmd, args): (&'a Path, &'a [String])) -> (impl Fn(&Command) -> bool + 'a) {
     move |(cmdpat, argpat)| {
-        cmdpat.matches_path(cmd)
-            && argpat
-                .as_ref()
-                .map(|vec| args == vec.as_ref())
-                .unwrap_or(true)
+        cmdpat.matches_path(cmd) && argpat.as_ref().map_or(true, |vec| args == vec.as_ref())
     }
 }
 

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -35,7 +35,7 @@ pub struct Request<'a, User: UnixUser, Group: UnixGroup> {
     pub user: &'a User,
     pub group: &'a Group,
     pub command: &'a Path,
-    pub arguments: &'a str,
+    pub arguments: &'a [String],
 }
 
 #[derive(Default)]
@@ -281,8 +281,8 @@ fn match_token<T: basic_parser::Token + std::ops::Deref<Target = String>>(
     move |token| token.as_str() == text
 }
 
-fn match_command<'a>((cmd, args): (&'a Path, &'a str)) -> (impl Fn(&Command) -> bool + 'a) {
-    move |(cmdpat, argpat)| cmdpat.matches_path(cmd) && argpat.matches(args)
+fn match_command<'a>((cmd, args): (&'a Path, &'a [String])) -> (impl Fn(&Command) -> bool + 'a) {
+    move |(cmdpat, argpat)| cmdpat.matches_path(cmd) && argpat.matches(&args.join(" "))
 }
 
 /// Find all the aliases that a object is a member of; this requires [sanitize_alias_table] to have run first;

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -282,7 +282,9 @@ fn match_token<T: basic_parser::Token + std::ops::Deref<Target = String>>(
 }
 
 fn match_command<'a>((cmd, args): (&'a Path, &'a [String])) -> (impl Fn(&Command) -> bool + 'a) {
-    move |(cmdpat, argpat)| cmdpat.matches_path(cmd) && argpat.matches(&args.join(" "))
+    move |(cmdpat, argpat)| {
+        cmdpat.matches_path(cmd) && argpat.as_ref().map(|vec| vec == args).unwrap_or(true)
+    }
 }
 
 /// Find all the aliases that a object is a member of; this requires [sanitize_alias_table] to have run first;

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -283,7 +283,11 @@ fn match_token<T: basic_parser::Token + std::ops::Deref<Target = String>>(
 
 fn match_command<'a>((cmd, args): (&'a Path, &'a [String])) -> (impl Fn(&Command) -> bool + 'a) {
     move |(cmdpat, argpat)| {
-        cmdpat.matches_path(cmd) && argpat.as_ref().map(|vec| vec == args).unwrap_or(true)
+        cmdpat.matches_path(cmd)
+            && argpat
+                .as_ref()
+                .map(|vec| args == vec.as_ref())
+                .unwrap_or(true)
     }
 }
 

--- a/lib/sudoers/src/test/mod.rs
+++ b/lib/sudoers/src/test/mod.rs
@@ -153,15 +153,16 @@ fn permission_test() {
     pass!(["user ALL=/bin/hello  arg"], "user" => root(), "server"; "/bin/hello arg");
     pass!(["user ALL=/bin/hello arg"], "user" => root(), "server"; "/bin/hello  arg");
     FAIL!(["user ALL=/bin/hello arg"], "user" => root(), "server"; "/bin/hello boo");
-    pass!(["user ALL=/bin/hello a*g"], "user" => root(), "server"; "/bin/hello  aaaarg");
-    FAIL!(["user ALL=/bin/hello a*g"], "user" => root(), "server"; "/bin/hello boo");
+    // several test cases with globbing in the arguments are explicitly not supported by sudo-rs
+    //pass!(["user ALL=/bin/hello a*g"], "user" => root(), "server"; "/bin/hello  aaaarg");
+    //FAIL!(["user ALL=/bin/hello a*g"], "user" => root(), "server"; "/bin/hello boo");
     pass!(["user ALL=/bin/hello"], "user" => root(), "server"; "/bin/hello boo");
     FAIL!(["user ALL=/bin/hello \"\""], "user" => root(), "server"; "/bin/hello boo");
     pass!(["user ALL=/bin/hello \"\""], "user" => root(), "server"; "/bin/hello");
     pass!(["user ALL=/bin/hel*"], "user" => root(), "server"; "/bin/hello");
     pass!(["user ALL=/bin/hel*"], "user" => root(), "server"; "/bin/help");
     pass!(["user ALL=/bin/hel*"], "user" => root(), "server"; "/bin/help me");
-    pass!(["user ALL=/bin/hel* *"], "user" => root(), "server"; "/bin/help");
+    //pass!(["user ALL=/bin/hel* *"], "user" => root(), "server"; "/bin/help");
     FAIL!(["user ALL=/bin/hel* me"], "user" => root(), "server"; "/bin/help");
     pass!(["user ALL=/bin/hel* me"], "user" => root(), "server"; "/bin/help me");
     FAIL!(["user ALL=/bin/hel* me"], "user" => root(), "server"; "/bin/help me please");

--- a/lib/sudoers/src/test/mod.rs
+++ b/lib/sudoers/src/test/mod.rs
@@ -89,8 +89,8 @@ fn permission_test() {
     macro_rules! FAIL {
         ([$($sudo:expr),*], $user:expr => $req:expr, $server:expr; $command:expr) => {
             let (Sudoers { rules,aliases,settings }, _) = analyze(sudoer![$($sudo),*]);
-            let cmdvec = $command.split_whitespace().collect::<Vec<_>>();
-            let req = Request { user: $req.0, group: $req.1, command: cmdvec[0].as_ref(), arguments: &cmdvec[1..].join(" ") };
+            let cmdvec = $command.split_whitespace().map(String::from).collect::<Vec<_>>();
+            let req = Request { user: $req.0, group: $req.1, command: cmdvec[0].as_ref(), arguments: &cmdvec[1..].to_vec() };
             assert_eq!(Sudoers { rules, aliases, settings }.check(&Named($user), $server, req).flags, None);
         }
     }
@@ -98,8 +98,8 @@ fn permission_test() {
     macro_rules! pass {
         ([$($sudo:expr),*], $user:expr => $req:expr, $server:expr; $command:expr $(=> [$($key:ident : $val:expr),*])?) => {
             let (Sudoers { rules,aliases,settings }, _) = analyze(sudoer![$($sudo),*]);
-            let cmdvec = $command.split_whitespace().collect::<Vec<_>>();
-            let req = Request { user: $req.0, group: $req.1, command: &cmdvec[0].as_ref(), arguments: &cmdvec[1..].join(" ") };
+            let cmdvec = $command.split_whitespace().map(String::from).collect::<Vec<_>>();
+            let req = Request { user: $req.0, group: $req.1, command: &cmdvec[0].as_ref(), arguments: &cmdvec[1..].to_vec() };
             let result = Sudoers { rules, aliases, settings }.check(&Named($user), $server, req).flags;
             assert!(!result.is_none());
             $(

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -131,7 +131,7 @@ impl Token for Upper {
 
 /// A struct that represents valid command strings; this can contain escape sequences and are
 /// limited to 1024 characters.
-pub type Command = (glob::Pattern, Option<Vec<String>>);
+pub type Command = (glob::Pattern, Option<Box<[String]>>);
 
 impl Token for Command {
     const MAX_LEN: usize = 1024;
@@ -154,7 +154,7 @@ impl Token for Command {
                 // if the magic "" appears, no (further) arguments are allowed
                 args.pop();
             }
-            Some(args)
+            Some(args.into_boxed_slice())
         };
 
         Ok((cvt_err(glob::Pattern::new(cmd))?, argpat))

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -35,7 +35,7 @@ fn check_sudoers(sudoers: &Sudoers, context: &Context) -> sudoers::Judgement {
             user: &context.target_user,
             group: &context.target_group,
             command: &context.command.command,
-            arguments: &context.command.arguments.join(" "),
+            arguments: &context.command.arguments,
         },
     )
 }

--- a/test-binaries/checkpermit.rs
+++ b/test-binaries/checkpermit.rs
@@ -15,7 +15,10 @@ fn chatty_check_permission(
     );
     let (command, arguments) = {
         let mut items = chosen_poison.split_whitespace();
-        (items.next().unwrap(), items.collect::<Vec<_>>().join(" "))
+        (
+            items.next().unwrap(),
+            items.map(|x| x.to_string()).collect::<Vec<_>>(),
+        )
     };
 
     let result = sudoers.check(


### PR DESCRIPTION
Closes issue #333

Note: maybe we should even go further and produce an explicit parse error if an unquoted "*" is present in command spec? Please request that change if you think so.