### PR TITLE
Print error if target's user home directory does not exist

### DIFF
--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -61,11 +61,9 @@ pub fn run_command(
                     CString::new(bytes).expect("nul byte found in provided directory path");
 
                 if let Err(err) = sudo_system::chdir(&c_path) {
+                    user_error!("unable to change directory to {}: {}", path.display(), err);
                     if ctx.chdir.is_some() {
-                        user_error!("unable to change directory to {}: {}", path.display(), err);
                         return Err(err);
-                    } else {
-                        user_warn!("unable to change directory to {}: {}", path.display(), err);
                     }
                 }
 

--- a/test-framework/sudo-compliance-tests/src/flag_login.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_login.rs
@@ -14,7 +14,6 @@ macro_rules! assert_snapshot {
 }
 
 #[test]
-#[ignore]
 fn if_home_directory_does_not_exist_executes_program_without_changing_the_working_directory(
 ) -> Result<()> {
     let initial_working_directories = ["/", "/root"];


### PR DESCRIPTION
Fixes https://github.com/memorysafety/sudo-rs/issues/318