### PR TITLE
Improve warning messages from sudoers parser

### DIFF
--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -577,6 +577,7 @@ impl Parse for (String, ConfigValue) {
                     },
                     _checker,
                 )) => ConfigValue::Num(val),
+                None => unrecoverable!(pos = value_pos, stream, "unknown setting: `{name}'"),
                 _ => unrecoverable!(
                     pos = value_pos,
                     stream,

--- a/lib/sudoers/src/ast.rs
+++ b/lib/sudoers/src/ast.rs
@@ -577,18 +577,18 @@ impl Parse for (String, ConfigValue) {
                     },
                     _checker,
                 )) => ConfigValue::Num(val),
-                None => unrecoverable!(pos = value_pos, stream, "unknown setting: `{name}'"),
+                None => unrecoverable!(pos = value_pos, stream, "unknown setting: '{name}'"),
                 _ => unrecoverable!(
                     pos = value_pos,
                     stream,
-                    "`{name}' cannot be used in a boolean context"
+                    "'{name}' cannot be used in a boolean context"
                 ),
             };
             make((name, value))
         } else {
             let EnvVar(name) = try_nonterminal(stream)?;
             let Some(cfg) = sudo_default(&name) else {
-                unrecoverable!(pos = id_pos, stream, "unknown setting: `{name}'");
+                unrecoverable!(pos = id_pos, stream, "unknown setting: '{name}'");
             };
 
             if is_syntax('+', stream)? {
@@ -599,7 +599,7 @@ impl Parse for (String, ConfigValue) {
                 let value_pos = stream.get_pos();
                 match cfg {
                     Setting::Flag(_) => {
-                        unrecoverable!(stream, "can't assign to boolean setting `{name}'")
+                        unrecoverable!(stream, "can't assign to boolean setting '{name}'")
                     }
                     Setting::Integer(_, checker) => {
                         let Numeric(denotation) = expect_nonterminal(stream)?;
@@ -609,7 +609,7 @@ impl Parse for (String, ConfigValue) {
                             unrecoverable!(
                                 pos = value_pos,
                                 stream,
-                                "`{denotation}' is not a valid value for {name}"
+                                "'{denotation}' is not a valid value for {name}"
                             );
                         }
                     }
@@ -627,7 +627,7 @@ impl Parse for (String, ConfigValue) {
                             unrecoverable!(
                                 pos = value_pos,
                                 stream,
-                                "`{text}' is not a valid value for {name}"
+                                "'{text}' is not a valid value for {name}"
                             );
                         };
                         make((name, ConfigValue::Enum(value)))
@@ -635,7 +635,7 @@ impl Parse for (String, ConfigValue) {
                 }
             } else {
                 if !matches!(cfg, Setting::Flag(_)) {
-                    unrecoverable!(pos = id_pos, stream, "`{name}' is not a boolean setting");
+                    unrecoverable!(pos = id_pos, stream, "'{name}' is not a boolean setting");
                 }
                 make((name, ConfigValue::Flag(true)))
             }

--- a/lib/sudoers/src/ast_names.rs
+++ b/lib/sudoers/src/ast_names.rs
@@ -90,7 +90,7 @@ mod names {
     }
 
     impl UserFriendly for tokens::ChDir {
-        const DESCRIPTION: &'static str = "directory or `*'";
+        const DESCRIPTION: &'static str = "directory or '*'";
     }
 
     impl UserFriendly for (String, ConfigValue) {

--- a/lib/sudoers/src/basic_parser.rs
+++ b/lib/sudoers/src/basic_parser.rs
@@ -176,7 +176,7 @@ pub fn expect_syntax(syntax: char, stream: &mut impl CharStream) -> Parsed<()> {
         } else {
             "EOF".to_string()
         };
-        unrecoverable!(stream, "expecting `{syntax}' but found `{str}'")
+        unrecoverable!(stream, "expecting '{syntax}' but found '{str}'")
     }
     make(())
 }

--- a/lib/sudoers/src/lib.rs
+++ b/lib/sudoers/src/lib.rs
@@ -375,7 +375,7 @@ fn analyze(sudoers: impl IntoIterator<Item = basic_parser::Parsed<Sudo>>) -> (Su
             if *count >= INCLUDE_LIMIT {
                 diagnostics.push(Error(
                     None,
-                    format!("include file limit reached opening `{}'", path.display()),
+                    format!("include file limit reached opening '{}'", path.display()),
                 ))
             } else if let Ok(subsudoer) = read_sudoers(path) {
                 *count += 1;
@@ -383,7 +383,7 @@ fn analyze(sudoers: impl IntoIterator<Item = basic_parser::Parsed<Sudo>>) -> (Su
             } else {
                 diagnostics.push(Error(
                     None,
-                    format!("cannot open sudoers file `{}'", path.display()),
+                    format!("cannot open sudoers file '{}'", path.display()),
                 ))
             }
         }
@@ -524,7 +524,7 @@ fn sanitize_alias_table<T>(table: &Vec<Def<T>>, diagnostics: &mut Vec<Error>) ->
                 for elem in members {
                     let Meta::Alias(name) = remqualify(elem) else { break };
                     let Some(dependency) = self.table.iter().position(|Def(id,_)| id==name) else {
-                        self.complain(format!("undefined alias: `{name}'"));
+                        self.complain(format!("undefined alias: '{name}'"));
                         continue;
                     };
                     self.visit(dependency);
@@ -532,7 +532,7 @@ fn sanitize_alias_table<T>(table: &Vec<Def<T>>, diagnostics: &mut Vec<Error>) ->
                 self.order.push(pos);
             } else if !self.order.contains(&pos) {
                 let Def(id, _) = &self.table[pos];
-                self.complain(format!("recursive alias: `{id}'"));
+                self.complain(format!("recursive alias: '{id}'"));
             }
         }
     }
@@ -547,7 +547,7 @@ fn sanitize_alias_table<T>(table: &Vec<Def<T>>, diagnostics: &mut Vec<Error>) ->
     let mut dupe = HashSet::new();
     for (i, Def(name, _)) in table.iter().enumerate() {
         if !dupe.insert(name) {
-            visitor.complain(format!("multiple occurrences of `{name}'"));
+            visitor.complain(format!("multiple occurrences of '{name}'"));
         } else {
             visitor.visit(i);
         }

--- a/lib/sudoers/src/tokens.rs
+++ b/lib/sudoers/src/tokens.rs
@@ -264,7 +264,7 @@ impl Token for ChDir {
         if s == "*" {
             Ok(ChDir::Any)
         } else if s.contains('*') {
-            Err("path cannot contain `*'".to_string())
+            Err("path cannot contain '*'".to_string())
         } else {
             Ok(ChDir::Path(s.into()))
         }


### PR DESCRIPTION
1. `!unknownsetting` would give a cryptic "cannot use 'unknownsetting' in a boolean context" instead if just "this setting doesn't exist"
2. replace backticks with single quotes