### PR TITLE
CI: improve diagnostics of compliance tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         run: |
           tmpfile="$(mktemp)"
           cargo test -p sudo-compliance-tests -- --ignored | tee "$tmpfile"
-          grep 'test result: FAILED. 0 passed' "$tmpfile" || exit 1
+          grep 'test result: FAILED. 0 passed' "$tmpfile" || ( echo "expected ALL tests to fail but at least one passed; the passing tests must be un-#[ignore]-d" && exit 1 )
 
       - name: prevent the cache from growing too large
         run: |


### PR DESCRIPTION
the CI output is misleading because it usually shows a bunch of test failures and it's not clear that *all* tests are expected to fail so add a message saying so and how to fix the build step