### PR TITLE
`-k` with a command support and show usage by default

### DIFF
--- a/lib/sudo-cli/src/lib.rs
+++ b/lib/sudo-cli/src/lib.rs
@@ -42,7 +42,7 @@ pub struct SudoOptions {
     help: bool,
     list: bool,
     remove_timestamp: bool,
-    reset_timestamp: bool,
+    pub reset_timestamp: bool,
     validate: bool,
     version: bool,
     // arguments passed straight through, either seperated by -- or just trailing.
@@ -171,7 +171,7 @@ impl SudoOptions {
             self.action = SudoAction::Version;
         } else if self.remove_timestamp {
             self.action = SudoAction::RemoveTimestamp;
-        } else if self.reset_timestamp {
+        } else if self.reset_timestamp && self.external_args.is_empty() {
             self.action = SudoAction::ResetTimestamp;
         } else if self.validate {
             self.action = SudoAction::Validate;

--- a/lib/sudo-common/src/context.rs
+++ b/lib/sudo-common/src/context.rs
@@ -19,6 +19,7 @@ pub struct Context {
     pub target_user: User,
     pub target_group: Group,
     pub stdin: bool,
+    pub use_session_records: bool,
     // system
     pub hostname: String,
     pub path: String,
@@ -56,6 +57,7 @@ impl Context {
             target_group,
             set_home: sudo_options.set_home,
             preserve_env: sudo_options.preserve_env,
+            use_session_records: !sudo_options.reset_timestamp,
             launch,
             chdir: sudo_options.directory,
             stdin: sudo_options.stdin,

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -104,7 +104,14 @@ fn sudo_process() -> Result<(), Error> {
             SudoAction::Validate => {
                 unimplemented!();
             }
-            SudoAction::Run(_) => options,
+            SudoAction::Run(ref cmd) => {
+                if cmd.is_empty() && !options.shell && !options.login {
+                    eprintln!("{}", help::USAGE_MSG);
+                    std::process::exit(1);
+                } else {
+                    options
+                }
+            }
             SudoAction::List(_) => {
                 unimplemented!();
             }

--- a/sudo/src/pam.rs
+++ b/sudo/src/pam.rs
@@ -48,7 +48,7 @@ fn determine_auth_status(
     record_for: Option<RecordScope>,
     context: &Context,
 ) -> (bool, Option<SessionRecordFile<File>>) {
-    if let Some(record_for) = record_for {
+    if let (true, Some(record_for)) = (context.use_session_records, record_for) {
         match SessionRecordFile::open_for_user(&context.current_user.name, Duration::minutes(15)) {
             Ok(mut sr) => {
                 match sr.touch(record_for, context.target_user.uid) {


### PR DESCRIPTION
This changes two things: first commit enables using `-k` with a command, effectively ignoring the session record file when specified. The second commit makes it so that sudo gives usage output if nothing else was specified.