### PR TITLE
ci: parallelize compliance tests across 2 CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  compliance-tests-rs:
+  compliance-tests:
     runs-on: ubuntu-latest
     env:
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
       - main
 
 jobs:
-  compliance-tests:
+  compliance-tests-og:
     runs-on: ubuntu-latest
     env:
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
@@ -33,8 +33,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: docker-buildx-${{ github.sha }}
-          restore-keys: docker-buildx-
+          key: docker-buildx-og-${{ github.sha }}
+          restore-keys: docker-buildx-og-
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -50,6 +50,42 @@ jobs:
       - name: Run all compliance tests against original sudo
         working-directory: test-framework
         run: cargo test -p sudo-compliance-tests -- --include-ignored
+
+      - name: prevent the cache from growing too large
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  compliance-tests-rs:
+    runs-on: ubuntu-latest
+    env:
+      SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
+      CI: true
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: set up docker buildx
+        run: docker buildx create --name builder --use
+
+      - name: cache docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: docker-buildx-rs-${{ github.sha }}
+          restore-keys: docker-buildx-rs-
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: 'compliance-tests'
+          workspaces: |
+            test-framework
 
       - name: Run gated compliance tests against sudo-rs
         working-directory: test-framework


### PR DESCRIPTION
this splits the compliance-tests job in two to make better use of parallel CI runners

times before
![before](https://github.com/memorysafety/sudo-rs/assets/5018213/3941c975-d96c-42e9-a44c-6c27d7c68fe4)

times after
![after](https://github.com/memorysafety/sudo-rs/assets/5018213/21e7a400-43bd-461c-84bb-2386e065be87)

provided that there available runners this should let the entire CI pipeline finish 2-3 minutes earlier