### PR TITLE
ci: collect code coverage data from compliance tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
+      SUDO_TEST_PROFRAW_DIR: /tmp/profraw
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
       CI: true
     steps:
@@ -93,6 +94,14 @@ jobs:
         env:
           SUDO_UNDER_TEST: ours
         run: cargo test -p sudo-compliance-tests
+
+      - name: Prepare code coverage data
+        run: ./make-lcov-info.bash
+
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
 
       - name: Check that we didn't forget to gate a passing compliance test
         working-directory: test-framework

--- a/make-lcov-info.bash
+++ b/make-lcov-info.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+rustup component add llvm-tools
+
+llvm_profdata=$(find "$(rustc --print sysroot)" -name llvm-profdata)
+profdata="$SUDO_TEST_PROFRAW_DIR"/sudo-rs.profdata
+$llvm_profdata merge \
+	-sparse \
+	"$SUDO_TEST_PROFRAW_DIR"/**/*.profraw \
+	-o "$profdata"
+
+binary="$SUDO_TEST_PROFRAW_DIR"/sudo-rs
+dockerid=$(docker create sudo-test-rs)
+docker cp "$dockerid":/usr/bin/sudo "$binary"
+docker rm "$dockerid"
+
+llvm_cov="$(dirname "$llvm_profdata")"/llvm-cov
+$llvm_cov export \
+	-format=lcov \
+	--ignore-filename-regex='/usr/local/cargo/registry' \
+	--ignore-filename-regex='/rustc' \
+	--instr-profile="$profdata" \
+	--object "$binary" \
+	-path-equivalence=/usr/src/sudo,"$(pwd)" >lcov.info

--- a/test-framework/sudo-test/src/ours.Dockerfile
+++ b/test-framework/sudo-test/src/ours.Dockerfile
@@ -5,7 +5,9 @@ RUN apt-get update && \
 RUN cargo search sudo
 WORKDIR /usr/src/sudo
 COPY . .
-RUN --mount=type=cache,target=/usr/src/sudo/target cargo build --locked -p sudo && mkdir -p build && cp target/debug/sudo build/sudo
+RUN --mount=type=cache,target=/usr/src/sudo/target RUSTFLAGS="-C instrument-coverage" cargo build --locked -p sudo && mkdir -p build && cp target/debug/sudo build/sudo
+# discard code coverage data created during `cargo build`
+RUN find / -name '*.profraw' -exec rm {} \;
 # set setuid on install
 RUN install --mode 4755 build/sudo /usr/bin/sudo
 # remove build dependencies


### PR DESCRIPTION
closes #411 
builds on top of #406 

[this bumps the reported coverage by ~15%](https://app.codecov.io/github/memorysafety/sudo-rs/commit/87044a3d98f0aac6302881e4885cc327c1aa0dea)