### PR TITLE
Add signal handlers and a polling API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,6 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
- "cc",
  "libc",
  "signal-hook-registry",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,8 @@ name = "sudo-system"
 version = "0.1.0-alpha.1"
 dependencies = [
  "libc",
+ "signal-hook",
+ "signal-hook-registry",
  "sudo-cutils",
  "sudo-log",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ publish = true
 libc = "0.2.139"
 glob = "0.3.1"
 signal-hook = "0.3.15"
+signal-hook-registry = "1.4.1"
 log = "0.4.17"
 syslog = "6.0.1"
 env_logger = { version = "0.9.3", default-features = false }

--- a/lib/sudo-exec/Cargo.toml
+++ b/lib/sudo-exec/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 publish.workspace = true
 
 [dependencies]
-signal-hook = { workspace = true, features = [ "extended-siginfo" ] }
+signal-hook.workspace = true
 sudo-common.workspace = true
 sudo-system.workspace = true
 sudo-log.workspace = true

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -8,10 +8,8 @@ use std::{
 use signal_hook::consts::*;
 use sudo_log::user_error;
 use sudo_system::{
-    getpgid,
-    interface::ProcessId,
-    kill, set_controlling_terminal, setpgid, setsid,
-    signal::{SignalAction, SignalInfo},
+    getpgid, interface::ProcessId, kill, set_controlling_terminal, setpgid, setsid,
+    signal::SignalInfo,
 };
 
 use crate::{signal::SignalHandlers, ExitReason};

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -80,10 +80,6 @@ impl MonitorRelay {
             if let Some(status) = self.wait_command()? {
                 ExitReason::from_status(status).send(&self.tx)?;
 
-                // Given that we overwrote the default handlers for all the signals, we must
-                // emulate them to handle the signal we just sent correctly.
-                drop(self.signal_handlers);
-
                 exit(0);
             }
 

--- a/lib/sudo-exec/src/pty.rs
+++ b/lib/sudo-exec/src/pty.rs
@@ -2,12 +2,7 @@ use std::{io, os::fd::OwnedFd};
 
 use signal_hook::consts::*;
 use sudo_log::user_error;
-use sudo_system::{
-    getpgid,
-    interface::ProcessId,
-    kill,
-    signal::{SignalAction, SignalInfo},
-};
+use sudo_system::{getpgid, interface::ProcessId, kill, signal::SignalInfo};
 
 use crate::{signal::SignalHandlers, ExitReason};
 

--- a/lib/sudo-exec/src/pty.rs
+++ b/lib/sudo-exec/src/pty.rs
@@ -1,18 +1,18 @@
 use std::{io, os::fd::OwnedFd};
 
-use signal_hook::{
-    consts::*,
-    flag::register_conditional_default,
-    iterator::{exfiltrator::WithOrigin, SignalsInfo},
-    low_level::siginfo::{Cause, Origin, Process, Sent},
-};
+use signal_hook::consts::*;
 use sudo_log::user_error;
-use sudo_system::{getpgid, interface::ProcessId, kill};
+use sudo_system::{
+    getpgid,
+    interface::ProcessId,
+    kill,
+    signal::{SignalAction, SignalInfo},
+};
 
-use crate::{EmulateDefaultHandler, ExitReason};
+use crate::{signal::SignalHandlers, ExitReason};
 
 pub(super) struct PtyRelay {
-    signals: SignalsInfo<WithOrigin>,
+    signal_handlers: SignalHandlers,
     monitor_pid: ProcessId,
     sudo_pid: ProcessId,
     command_pid: ProcessId,
@@ -30,7 +30,7 @@ impl PtyRelay {
         rx: OwnedFd,
     ) -> io::Result<Self> {
         Ok(Self {
-            signals: SignalsInfo::<WithOrigin>::new(super::SIGNALS)?,
+            signal_handlers: SignalHandlers::new()?,
             monitor_pid,
             sudo_pid,
             // FIXME: is this ok? Check ogsudo's code.
@@ -40,25 +40,18 @@ impl PtyRelay {
         })
     }
 
-    pub(super) fn run(mut self) -> io::Result<(ExitReason, EmulateDefaultHandler)> {
-        let emulate_default_handler = EmulateDefaultHandler::default();
-
-        for &signal in super::SIGNALS {
-            register_conditional_default(
-                signal,
-                EmulateDefaultHandler::clone(&emulate_default_handler),
-            )?;
-        }
-
+    pub(super) fn run(mut self) -> io::Result<(ExitReason, impl FnOnce())> {
         loop {
             // First we check if the monitor sent us the exit status of the command.
             if let Ok(reason) = self.wait_monitor() {
-                return Ok((reason, emulate_default_handler));
+                return Ok((reason, move || drop(self.signal_handlers)));
             }
 
             // Then we check any pending signals that we received. Based on `signal_cb_pty`
-            for info in self.signals.wait() {
-                self.relay_signal(info);
+            if let Ok(infos) = self.signal_handlers.poll() {
+                for info in infos {
+                    self.relay_signal(info);
+                }
             }
         }
     }
@@ -67,9 +60,8 @@ impl PtyRelay {
         ExitReason::recv(&self.rx)
     }
 
-    fn relay_signal(&self, info: Origin) {
-        let user_signaled = info.cause == Cause::Sent(Sent::User);
-        match info.signal {
+    fn relay_signal(&self, info: SignalInfo) {
+        match info.signal() {
             // FIXME: check `handle_sigchld_pty`
             SIGCHLD => {}
             // FIXME: check `resume_terminal`
@@ -77,7 +69,7 @@ impl PtyRelay {
             // FIXME: check `sync_ttysize`
             SIGWINCH => {}
             // Skip the signal if it was sent by the user and it is self-terminating.
-            _ if user_signaled && self.is_self_terminating(info.process) => {}
+            _ if info.is_user_signaled() && self.is_self_terminating(info.pid()) => {}
             // FIXME: check `send_command_status`
             signal => {
                 kill(self.monitor_pid, signal).ok();
@@ -85,25 +77,23 @@ impl PtyRelay {
         }
     }
 
-    /// Decides if the signal sent by the `signaler` process is self-terminating.
+    /// Decides if the signal sent by the process with `signaler_pid` PID is self-terminating.
     ///
-    /// A signal is self-terminating if the PID of the `process`:
+    /// A signal is self-terminating if `signaler_pid`:
     /// - is the same PID of the command, or
     /// - is in the process group of the command and either sudo or the command is the leader.
-    fn is_self_terminating(&self, signaler: Option<Process>) -> bool {
-        if let Some(signaler) = signaler {
-            if signaler.pid != 0 {
-                if signaler.pid == self.command_pid {
+    fn is_self_terminating(&self, signaler_pid: ProcessId) -> bool {
+        if signaler_pid != 0 {
+            if signaler_pid == self.command_pid {
+                return true;
+            }
+
+            if let Ok(signaler_pgrp) = getpgid(signaler_pid) {
+                if signaler_pgrp == self.command_pid || signaler_pgrp == self.sudo_pid {
                     return true;
                 }
-
-                if let Ok(signaler_pgrp) = getpgid(signaler.pid) {
-                    if signaler_pgrp == self.command_pid || signaler_pgrp == self.sudo_pid {
-                        return true;
-                    }
-                } else {
-                    user_error!("Could not fetch process group ID");
-                }
+            } else {
+                user_error!("Could not fetch process group ID");
             }
         }
 

--- a/lib/sudo-exec/src/signal.rs
+++ b/lib/sudo-exec/src/signal.rs
@@ -1,0 +1,58 @@
+use std::{collections::HashMap, ffi::c_int, io};
+
+use signal_hook::consts::*;
+use sudo_system::{
+    poll::PollSet,
+    signal::{SignalHandler, SignalInfo},
+};
+
+pub(crate) const SIGNALS: &[c_int] = &[
+    SIGINT, SIGQUIT, SIGTSTP, SIGTERM, SIGHUP, SIGALRM, SIGPIPE, SIGUSR1, SIGUSR2, SIGCHLD,
+    SIGCONT, SIGWINCH,
+];
+
+pub(crate) struct SignalHandlers {
+    handlers: HashMap<c_int, SignalHandler>,
+    poll_set: PollSet<c_int>,
+}
+
+impl SignalHandlers {
+    pub(crate) fn new() -> io::Result<Self> {
+        let mut handlers = HashMap::with_capacity(SIGNALS.len());
+        let mut poll_set = PollSet::new();
+        for &signal in SIGNALS {
+            let handler = SignalHandler::new(signal)?;
+            poll_set.add_fd_read(signal, &handler);
+            handlers.insert(signal, handler);
+        }
+
+        Ok(Self { handlers, poll_set })
+    }
+
+    pub(crate) fn get(&self, signal: c_int) -> Option<&SignalHandler> {
+        self.handlers.get(&signal)
+    }
+
+    pub(crate) fn get_mut(&mut self, signal: c_int) -> Option<&mut SignalHandler> {
+        self.handlers.get_mut(&signal)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &SignalHandler> {
+        self.handlers.values()
+    }
+
+    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut SignalHandler> {
+        self.handlers.values_mut()
+    }
+
+    pub(crate) fn poll(&mut self) -> io::Result<Vec<SignalInfo>> {
+        let signals = self.poll_set.poll()?;
+        let mut infos = Vec::with_capacity(signals.len());
+
+        for signal in signals {
+            infos.push(self.get_mut(signal).unwrap().recv()?);
+        }
+
+        Ok(infos)
+    }
+}

--- a/lib/sudo-exec/src/signal.rs
+++ b/lib/sudo-exec/src/signal.rs
@@ -29,20 +29,8 @@ impl SignalHandlers {
         Ok(Self { handlers, poll_set })
     }
 
-    pub(crate) fn get(&self, signal: c_int) -> Option<&SignalHandler> {
-        self.handlers.get(&signal)
-    }
-
     pub(crate) fn get_mut(&mut self, signal: c_int) -> Option<&mut SignalHandler> {
         self.handlers.get_mut(&signal)
-    }
-
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &SignalHandler> {
-        self.handlers.values()
-    }
-
-    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut SignalHandler> {
-        self.handlers.values_mut()
     }
 
     pub(crate) fn poll(&mut self) -> io::Result<Vec<SignalInfo>> {

--- a/lib/sudo-system/Cargo.toml
+++ b/lib/sudo-system/Cargo.toml
@@ -11,6 +11,8 @@ publish.workspace = true
 libc.workspace = true
 sudo-cutils.workspace = true
 sudo-log.workspace = true
+signal-hook.workspace = true
+signal-hook-registry.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -28,6 +28,8 @@ pub mod timestamp;
 
 pub mod signal;
 
+pub mod poll;
+
 pub fn write<F: AsRawFd>(fd: &F, buf: &[u8]) -> io::Result<libc::ssize_t> {
     cerr(unsafe { libc::write(fd.as_raw_fd(), buf.as_ptr().cast(), buf.len()) })
 }

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -26,6 +26,8 @@ pub mod time;
 
 pub mod timestamp;
 
+pub mod signal;
+
 pub fn write<F: AsRawFd>(fd: &F, buf: &[u8]) -> io::Result<libc::ssize_t> {
     cerr(unsafe { libc::write(fd.as_raw_fd(), buf.as_ptr().cast(), buf.len()) })
 }

--- a/lib/sudo-system/src/poll.rs
+++ b/lib/sudo-system/src/poll.rs
@@ -1,0 +1,76 @@
+use std::{
+    collections::HashMap,
+    hash::Hash,
+    io,
+    os::fd::{AsRawFd, RawFd},
+};
+
+use libc::{c_short, pollfd, POLLIN, POLLOUT};
+use sudo_cutils::cerr;
+
+/// A set of indexed file descriptors to be polled using the [`poll`](https://manpage.me/?q=poll) system call.
+pub struct PollSet<K> {
+    fds: HashMap<K, (RawFd, c_short)>,
+}
+
+impl<K: Eq + PartialEq + Hash + Clone> PollSet<K> {
+    /// Create an empty set of file descriptors.
+    pub fn new() -> Self {
+        Self {
+            fds: HashMap::new(),
+        }
+    }
+
+    /// Add a file descriptor under the provided key. This descriptor will be checked for read events and return a unique identifier
+    /// for the descriptor inside the set.
+    ///
+    /// If the provided key is already in the set, calling this function will overwrite the file
+    /// descriptor for that key. 
+    pub fn add_fd_read<F: AsRawFd>(&mut self, key: K, fd: &F) {
+        self.add_fd(key, fd, POLLIN)
+    }
+
+    /// Add a file descriptor under the provided key. This descriptor will be checked for write events and return a unique identifier
+    /// for the descriptor inside the set.
+    ///
+    /// If the provided key is already in the set, calling this function will overwrite the file
+    /// descriptor for that key. 
+    pub fn add_fd_write<F: AsRawFd>(&mut self, key: K, fd: &F) {
+        self.add_fd(key, fd, POLLOUT)
+    }
+
+    fn add_fd<F: AsRawFd>(&mut self, key: K, fd: &F, events: c_short) {
+        self.fds.insert(key, (fd.as_raw_fd(), events));
+    }
+
+    /// Poll the set of file descriptors and return the key of the descriptors that are ready to be
+    /// read or written.
+    ///
+    /// Calling this function will block until one of the file descriptors in the set is ready.
+    pub fn poll(&mut self) -> io::Result<Vec<K>> {
+        let mut fds: Vec<pollfd> = self
+            .fds
+            .values()
+            .map(|&(fd, events)| pollfd {
+                fd,
+                events,
+                revents: 0,
+            })
+            .collect();
+
+        // FIXME: we should set either a timeout or use ppoll when available.
+        let n = cerr(unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as _, -1) })?;
+
+        let mut keys = Vec::with_capacity(n as usize);
+
+        for (key, fd) in self.fds.keys().zip(fds) {
+            let events = fd.events & fd.revents;
+
+            if (events & POLLIN != 0) || (events & POLLOUT != 0) {
+                keys.push(key.clone());
+            }
+        }
+
+        Ok(keys)
+    }
+}

--- a/lib/sudo-system/src/poll.rs
+++ b/lib/sudo-system/src/poll.rs
@@ -13,6 +13,12 @@ pub struct PollSet<K> {
     fds: HashMap<K, (RawFd, c_short)>,
 }
 
+impl<K: Eq + PartialEq + Hash + Clone> Default for PollSet<K> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<K: Eq + PartialEq + Hash + Clone> PollSet<K> {
     /// Create an empty set of file descriptors.
     pub fn new() -> Self {
@@ -25,7 +31,7 @@ impl<K: Eq + PartialEq + Hash + Clone> PollSet<K> {
     /// for the descriptor inside the set.
     ///
     /// If the provided key is already in the set, calling this function will overwrite the file
-    /// descriptor for that key. 
+    /// descriptor for that key.
     pub fn add_fd_read<F: AsRawFd>(&mut self, key: K, fd: &F) {
         self.add_fd(key, fd, POLLIN)
     }
@@ -34,7 +40,7 @@ impl<K: Eq + PartialEq + Hash + Clone> PollSet<K> {
     /// for the descriptor inside the set.
     ///
     /// If the provided key is already in the set, calling this function will overwrite the file
-    /// descriptor for that key. 
+    /// descriptor for that key.
     pub fn add_fd_write<F: AsRawFd>(&mut self, key: K, fd: &F) {
         self.add_fd(key, fd, POLLOUT)
     }

--- a/lib/sudo-system/src/signal.rs
+++ b/lib/sudo-system/src/signal.rs
@@ -192,6 +192,9 @@ impl SignalHandler {
     ///
     /// Calling this function will block until a signal arrives if the action for this handler is
     /// set to [`SignalAction::Stream`]. Otherwise it will block indefinitely.
+    ///
+    /// Note that calling this function will only retrieve the information related to a single
+    /// signal arrival even if the same signal has been sent to the process more than once. 
     pub fn recv(&mut self) -> io::Result<SignalInfo> {
         let mut info = MaybeUninit::<siginfo_t>::uninit();
         let fd = self.rx.as_raw_fd();

--- a/lib/sudo-system/src/signal.rs
+++ b/lib/sudo-system/src/signal.rs
@@ -194,7 +194,7 @@ impl SignalHandler {
     /// set to [`SignalAction::Stream`]. Otherwise it will block indefinitely.
     ///
     /// Note that calling this function will only retrieve the information related to a single
-    /// signal arrival even if the same signal has been sent to the process more than once. 
+    /// signal arrival even if the same signal has been sent to the process more than once.
     pub fn recv(&mut self) -> io::Result<SignalInfo> {
         let mut info = MaybeUninit::<siginfo_t>::uninit();
         let fd = self.rx.as_raw_fd();

--- a/lib/sudo-system/src/signal.rs
+++ b/lib/sudo-system/src/signal.rs
@@ -96,11 +96,10 @@ pub struct SignalHandler {
     action: Arc<AtomicU8>,
 }
 
+/// Set the action to [`SignalAction::Default`] when dropping.
 impl Drop for SignalHandler {
     fn drop(&mut self) {
-        // We need to be sure that we unregister this action when the handler is dropped. If it was
-        // already unregistered for whatever reason this should be a no-op.
-        unregister(self.sig_id);
+        self.set_action(SignalAction::Default);
     }
 }
 
@@ -213,6 +212,16 @@ impl SignalHandler {
     /// Returns the number of the signal that is being handled.
     pub fn signal(&self) -> c_int {
         self.signal
+    }
+
+    /// Unregister the handler.
+    ///
+    /// This leaves the current process without a handler for the signal handled by this handler.
+    /// Meaning that the process will ignore the signal when receiving it.
+    pub fn unregister(&self) {
+        // We need to be sure that we unregister this action when the handler is dropped. If it was
+        // already unregistered for whatever reason this should be a no-op.
+        unregister(self.sig_id);
     }
 }
 

--- a/lib/sudo-system/src/signal.rs
+++ b/lib/sudo-system/src/signal.rs
@@ -1,0 +1,230 @@
+//! Utilities to handle signals.
+
+// FIXME: It should be possible to implement the same functionality without `signal_hook` and
+// `signal_hook_registry` without much effort. But given that async-signal-safety can be tricky we
+// should keep using those crates unless those dependencies become a concern.
+use std::{
+    io,
+    mem::MaybeUninit,
+    os::{
+        fd::{AsRawFd, RawFd},
+        unix::net::UnixStream,
+    },
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
+};
+
+use libc::{c_int, siginfo_t, MSG_DONTWAIT};
+use signal_hook::low_level::{emulate_default_handler, signal_name};
+use signal_hook_registry::{register_sigaction, unregister, SigId, FORBIDDEN};
+use sudo_cutils::cerr;
+
+use crate::interface::ProcessId;
+
+const SIGINFO_SIZE: usize = std::mem::size_of::<siginfo_t>();
+
+/// Information related to the arrival of a signal.
+pub struct SignalInfo {
+    info: siginfo_t,
+}
+
+impl SignalInfo {
+    /// Returns whether the signal was sent by the user or not.
+    pub fn is_user_signaled(&self) -> bool {
+        // FIXME: we should check if si_code is equal to SI_USER but for some reason the latter it
+        // is not available in libc.
+        self.info.si_code <= 0
+    }
+
+    /// Gets the PID that sent the signal.
+    pub fn pid(&self) -> ProcessId {
+        // FIXME: some signals don't set si_pid.
+        unsafe { self.info.si_pid() }
+    }
+
+    /// Gets the signal number.
+    pub fn signal(&self) -> c_int {
+        self.info.si_signo
+    }
+}
+
+/// The action to be executed by a [`SignalHandler`] when a signal arrives.
+#[repr(u8)]
+pub enum SignalAction {
+    /// Stream the signal information so it can be received using [`SignalHandler::recv`].
+    Stream = 0,
+    /// Emulate the default handler for the signal (e.g. terminating the process when receiving `SIGTERM` or
+    /// stopping the process when receiving `SIGTSTP`).
+    Default = 1,
+    /// Ignore the incoming signal.
+    Ignore = 2,
+}
+
+impl SignalAction {
+    fn try_new(val: u8) -> Option<Self> {
+        if val == Self::Stream as u8 {
+            Some(Self::Stream)
+        } else if val == Self::Default as u8 {
+            Some(Self::Default)
+        } else if val == Self::Ignore as u8 {
+            Some(Self::Ignore)
+        } else {
+            None
+        }
+    }
+}
+
+/// A type that handles the received signals according to different actions that can be configured
+/// using [`SignalHandler::set_action`] and [`SignalHandler::with_action`].
+pub struct SignalHandler {
+    /// The number of the signal being handled.
+    signal: c_int,
+    /// The identifier under which the action of this handler was registered.
+    ///
+    /// It can be used to unregister or re-register the action if needed.
+    sig_id: SigId,
+    /// The reading side of the self-pipe.
+    ///
+    /// It is used to communicate that a signal was received if the set action is
+    /// [`SignalAction::Stream`].
+    rx: UnixStream,
+    /// The current action to be executed when a signal arrives.
+    ///
+    /// The atomic integer used here must match the representation type of [`SignalAction`].
+    action: Arc<AtomicU8>,
+}
+
+impl Drop for SignalHandler {
+    fn drop(&mut self) {
+        // We need to be sure that we unregister this action when the handler is dropped. If it was
+        // already unregistered for whatever reason this should be a no-op.
+        unregister(self.sig_id);
+    }
+}
+
+impl AsRawFd for SignalHandler {
+    fn as_raw_fd(&self) -> RawFd {
+        self.rx.as_raw_fd()
+    }
+}
+
+impl SignalHandler {
+    /// Creates a new signal handler that executes the [`SignalAction::Stream`] action.
+    ///
+    /// # Panics
+    ///
+    /// When `signal` is one of:
+    ///
+    /// * `SIGKILL`
+    /// * `SIGSTOP`
+    /// * `SIGILL`
+    /// * `SIGFPE`
+    /// * `SIGSEGV`
+    pub fn new(signal: c_int) -> io::Result<Self> {
+        Self::with_action(signal, SignalAction::Stream)
+    }
+
+    /// Creates a new signal handler that executes the provided action.
+    ///
+    /// # Panics
+    ///
+    /// When `signal` is one of:
+    ///
+    /// * `SIGKILL`
+    /// * `SIGSTOP`
+    /// * `SIGILL`
+    /// * `SIGFPE`
+    /// * `SIGSEGV`
+    pub fn with_action(signal: c_int, action: SignalAction) -> io::Result<Self> {
+        if FORBIDDEN.contains(&signal) {
+            panic!(
+                "SignalHandler cannot be used to handle the forbidden {} signal",
+                signal_name(signal).unwrap()
+            );
+        }
+
+        let (rx, tx) = UnixStream::pair()?;
+
+        let action = Arc::new(AtomicU8::from(action as u8));
+
+        let sig_id = {
+            let action = Arc::clone(&action);
+            // SAFETY: The closure passed to `register_sigaction` is run inside a signal handler,
+            // meaning that all the functions called inside it must be async-signal-safe as defined
+            // by POSIX. This code should be sound because:
+            //
+            // - This function does not panic.
+            // - The `action` atomic value is lock-free.
+            // - The `send` function only calls the `send` syscall which is async-signal-safe.
+            // - The `emulate_default_handler` function is async-signal-safe according to
+            // `signal_hook`.
+            unsafe {
+                register_sigaction(signal, move |info| {
+                    if let Some(action) = SignalAction::try_new(action.load(Ordering::SeqCst)) {
+                        match action {
+                            SignalAction::Stream => send(&tx, info),
+                            SignalAction::Default => {
+                                emulate_default_handler(signal).ok();
+                            }
+                            SignalAction::Ignore => {}
+                        }
+                    }
+                })
+            }?
+        };
+
+        Ok(Self {
+            signal,
+            sig_id,
+            rx,
+            action,
+        })
+    }
+
+    /// Changes the action for this handler and returns the previously set action.
+    pub fn set_action(&self, action: SignalAction) -> SignalAction {
+        SignalAction::try_new(self.action.swap(action as u8, Ordering::SeqCst))
+            .unwrap_or(SignalAction::Ignore)
+    }
+
+    /// Receives the information related to the arrival of a signal.
+    ///
+    /// Calling this function will block until a signal arrives if the action for this handler is
+    /// set to [`SignalAction::Stream`]. Otherwise it will block indefinitely.
+    pub fn recv(&mut self) -> io::Result<SignalInfo> {
+        let mut info = MaybeUninit::<siginfo_t>::uninit();
+        let fd = self.rx.as_raw_fd();
+        let bytes = cerr(unsafe { libc::recv(fd, info.as_mut_ptr().cast(), SIGINFO_SIZE, 0) })?;
+
+        if bytes as usize != SIGINFO_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Not enough bytes when receiving `siginfo_t`",
+            ));
+        }
+        // SAFETY: we can assume `info` is initialized because `recv` wrote enough bytes to fill
+        // the value and `siginfo_t` is POD.
+        let info = unsafe { info.assume_init() };
+        Ok(SignalInfo { info })
+    }
+
+    /// Returns the number of the signal that is being handled.
+    pub fn signal(&self) -> c_int {
+        self.signal
+    }
+}
+
+fn send(tx: &UnixStream, info: &siginfo_t) {
+    let fd = tx.as_raw_fd();
+
+    unsafe {
+        libc::send(
+            fd,
+            (info as *const siginfo_t).cast(),
+            SIGINFO_SIZE,
+            MSG_DONTWAIT,
+        );
+    }
+}

--- a/sudo/src/pipeline.rs
+++ b/sudo/src/pipeline.rs
@@ -1,4 +1,4 @@
-use std::{process::exit, sync::atomic::Ordering};
+use std::process::exit;
 
 use sudo_cli::SudoOptions;
 use sudo_common::{Context, Error};
@@ -71,7 +71,7 @@ impl<Policy: PolicyPlugin, Auth: AuthPlugin> Pipeline<Policy, Auth> {
         self.authenticator.cleanup();
 
         // Run any clean-up code before this line.
-        emulate_default_handler.store(true, Ordering::SeqCst);
+        emulate_default_handler();
 
         match reason {
             ExitReason::Code(code) => exit(code),


### PR DESCRIPTION
**Describe the changes done on this pull request**

This PR introduces a new API to handle signals using the self-pipe trick and a new polling API to be able to poll the pipes until one of them is ready.

This is done so we can eventually poll every single event happening for the two sudo processes running (the parent sudo process and the monitor process) using the same API so we don't have to write code to manually "select" which event to handle first. This makes bugs related to logic locks less likely.

This PR is the first attempt to dissect https://github.com/memorysafety/sudo-rs/pull/363 into more reviewable parts and it is better reviewed when checking the diff for each commit.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will help fix issue https://github.com/memorysafety/sudo-rs/issues/325 where a proper discussion about a solution has taken place.
