### PR TITLE
ignore flaky TTY test

### DIFF
--- a/test-framework/sudo-compliance-tests/src/pass_auth/tty.rs
+++ b/test-framework/sudo-compliance-tests/src/pass_auth/tty.rs
@@ -5,7 +5,12 @@ use crate::{Result, PASSWORD, USERNAME};
 use super::MAX_PAM_RESPONSE_SIZE;
 
 #[test]
+#[ignore = "gh414"]
 fn correct_password() -> Result<()> {
+    if !sudo_test::is_original_sudo() {
+        return Err("FIXME flaky test".into());
+    }
+
     let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
         .user(User(USERNAME).password(PASSWORD))
         .build()?;


### PR DESCRIPTION
this test has been making CI fail several times today. let's ignore it for now until we figure out how to make it more reliable

cc #414 