### PR TITLE
ci: set a timeout for compliance-tests-rs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
 
   compliance-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
       CI: true


### PR DESCRIPTION
we have seen sudo-rs hang when running compliance tests due to e.g. bugs like #388 

this sets a timeout for the job that runs the compliance test suite using sudo-rs. that job usually takes ~7 minutes so the timeout is set to 15 minutes.

this PR builds on top of #406