### PR TITLE
Rename types inside `sudo-exec`

### DIFF
--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -4,7 +4,7 @@ mod backchannel;
 mod event;
 mod io_util;
 mod monitor;
-mod pty;
+mod parent;
 
 use std::{
     ffi::{CString, OsStr},
@@ -15,6 +15,8 @@ use std::{
 };
 
 use backchannel::BackchannelPair;
+use monitor::MonitorClosure;
+use parent::ParentClosure;
 use sudo_common::{context::LaunchType::Login, Context, Environment};
 use sudo_log::user_error;
 use sudo_system::{fork, set_target_user, term::openpty};
@@ -75,15 +77,15 @@ pub fn run_command(ctx: Context, env: Environment) -> io::Result<(ExitReason, im
     let backchannels = BackchannelPair::new()?;
 
     // FIXME: We should block all the incoming signals before forking and unblock them just after
-    // initializing the signal hadnlers.
+    // initializing the signal handlers.
     let monitor_pid = fork()?;
     // Monitor logic. Based on `exec_monitor`.
     if monitor_pid == 0 {
         let (monitor, mut dispatcher) =
-            monitor::MonitorRelay::new(command, pty_follower, backchannels.monitor);
+            MonitorClosure::new(command, pty_follower, backchannels.monitor);
         match monitor.run(&mut dispatcher) {}
     } else {
-        let (parent, mut dispatcher) = pty::PtyRelay::new(
+        let (parent, mut dispatcher) = ParentClosure::new(
             monitor_pid,
             ctx.process.pid,
             pty_leader,

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -18,7 +18,7 @@ use crate::{
     io_util::retry_while_interrupted,
 };
 
-pub(super) struct MonitorRelay {
+pub(super) struct MonitorClosure {
     command_pid: ProcessId,
     command_pgrp: ProcessId,
     command: Child,
@@ -26,7 +26,7 @@ pub(super) struct MonitorRelay {
     backchannel: MonitorBackchannel,
 }
 
-impl MonitorRelay {
+impl MonitorClosure {
     pub(super) fn new(
         mut command: Command,
         pty_follower: OwnedFd,
@@ -107,7 +107,7 @@ impl MonitorRelay {
     }
 }
 
-impl EventClosure for MonitorRelay {
+impl EventClosure for MonitorClosure {
     type Break = ();
 
     fn on_signal(&mut self, info: SignalInfo, dispatcher: &mut EventDispatcher<Self>) {

--- a/lib/sudo-exec/src/parent.rs
+++ b/lib/sudo-exec/src/parent.rs
@@ -11,7 +11,7 @@ use crate::{
     ExitReason,
 };
 
-pub(super) struct PtyRelay {
+pub(super) struct ParentClosure {
     monitor_pid: ProcessId,
     sudo_pid: ProcessId,
     command_pid: Option<ProcessId>,
@@ -21,7 +21,7 @@ pub(super) struct PtyRelay {
     backchannel: ParentBackchannel,
 }
 
-impl PtyRelay {
+impl ParentClosure {
     pub(super) fn new(
         monitor_pid: ProcessId,
         sudo_pid: ProcessId,
@@ -111,7 +111,7 @@ impl PtyRelay {
     }
 }
 
-impl EventClosure for PtyRelay {
+impl EventClosure for ParentClosure {
     type Break = ParentEvent;
 
     fn on_signal(&mut self, info: SignalInfo, dispatcher: &mut EventDispatcher<Self>) {


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR renames some types and modules inside `sudo-exec` to make the code clearer:
- The `pty` name has been replaced by `parent` to better reflect the fact that this is the main process.
- The `Relay` name has been replaced by `Closure` as both types are actually the state of the event loop so they are akin to the values captured by a closure (this is also the name that ogsudo uses)

Blocked by #433 

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
