### PR TITLE
Send signals to the monitor using the backchannel

### DIFF
--- a/lib/sudo-exec/src/backchannel.rs
+++ b/lib/sudo-exec/src/backchannel.rs
@@ -80,8 +80,8 @@ impl ParentEvent {
     }
 }
 
-impl<'a> From<&'a io::Error> for ParentEvent {
-    fn from(err: &'a io::Error) -> Self {
+impl From<io::Error> for ParentEvent {
+    fn from(err: io::Error) -> Self {
         // This only panics if an error is created using `io::Error::new`.
         Self::IoError(err.raw_os_error().unwrap())
     }

--- a/lib/sudo-exec/src/event.rs
+++ b/lib/sudo-exec/src/event.rs
@@ -30,7 +30,7 @@ macro_rules! define_signals {
                 let mut dispatcher = Self {
                     signal_handlers: [$(SignalHandler::new($signal)?,)*],
                     poll_set: PollSet::new(),
-                    callbacks: Vec::new(),
+                    callbacks: Vec::with_capacity(SIGNALS.len()),
                     status: ControlFlow::Continue(()),
                 };
 
@@ -85,6 +85,14 @@ impl<T: EventClosure> EventDispatcher<T> {
     pub(crate) fn set_read_callback<F: AsRawFd>(&mut self, fd: &F, callback: Callback<T>) {
         let id = EventId(self.callbacks.len());
         self.poll_set.add_fd_read(id, fd);
+        self.callbacks.push(callback);
+    }
+
+    /// Set the `fd` descriptor to be polled for write events and set `callback` to be called if
+    /// `fd` is ready.  
+    pub(crate) fn set_write_callback<F: AsRawFd>(&mut self, fd: &F, callback: Callback<T>) {
+        let id = EventId(self.callbacks.len());
+        self.poll_set.add_fd_write(id, fd);
         self.callbacks.push(callback);
     }
 

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -50,7 +50,7 @@ impl MonitorClosure {
             let event = retry_while_interrupted(|| backchannel.recv())?;
 
             // Given that `UnixStream` delivers messages in order it shouldn't be possible to
-            // receive an event different to `ExecCommand` at the beginning. 
+            // receive an event different to `ExecCommand` at the beginning.
             debug_assert_eq!(event, MonitorEvent::ExecCommand);
 
             // spawn the command

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -70,7 +70,7 @@ impl MonitorClosure {
 
         match result {
             Err(err) => {
-                backchannel.send(&(&err).into()).unwrap();
+                backchannel.send(&err.into()).unwrap();
                 exit(1);
             }
             Ok((dispatcher, command_pid, command_pgrp, command, pty_follower)) => (
@@ -123,7 +123,7 @@ impl MonitorClosure {
             // There's something wrong with the backchannel, break the event loop
             Err(err) => {
                 dispatcher.set_break(());
-                self.backchannel.send(&(&err).into()).unwrap();
+                self.backchannel.send(&err.into()).unwrap();
             }
             Ok(event) => {
                 match event {

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -56,7 +56,7 @@ impl MonitorClosure {
             let command_pid = command.id() as ProcessId;
 
             // Send the command's PID to the main sudo process.
-            backchannel.send(ParentEvent::CommandPid(command_pid)).ok();
+            backchannel.send(&ParentEvent::CommandPid(command_pid)).ok();
 
             // Register the callback to receive events from the backchannel
             dispatcher.set_read_callback(&backchannel, |mc, ev| mc.read_backchannel(ev));
@@ -70,7 +70,7 @@ impl MonitorClosure {
 
         match result {
             Err(err) => {
-                backchannel.send((&err).into()).unwrap();
+                backchannel.send(&(&err).into()).unwrap();
                 exit(1);
             }
             Ok((dispatcher, command_pid, command_pgrp, command, pty_follower)) => (
@@ -123,7 +123,7 @@ impl MonitorClosure {
             // There's something wrong with the backchannel, break the event loop
             Err(err) => {
                 dispatcher.set_break(());
-                self.backchannel.send((&err).into()).unwrap();
+                self.backchannel.send(&(&err).into()).unwrap();
             }
             Ok(event) => {
                 match event {
@@ -165,7 +165,7 @@ impl EventClosure for MonitorClosure {
             SIGCHLD => {
                 if let Ok(Some(exit_status)) = self.command.try_wait() {
                     dispatcher.set_break(());
-                    self.backchannel.send(exit_status.into()).unwrap();
+                    self.backchannel.send(&exit_status.into()).unwrap();
                 }
             }
             // Skip the signal if it was sent by the user and it is self-terminating.

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -49,9 +49,9 @@ impl MonitorClosure {
             // avoids race conditions when the command exits quickly.
             let event = retry_while_interrupted(|| backchannel.recv())?;
 
-            // FIXME: ogsudo doesn't check that this event is not a forwarded signal from the
-            // parent process. What should we do in that case?
-            assert_eq!(event, MonitorEvent::ExecCommand);
+            // Given that `UnixStream` delivers messages in order it shouldn't be possible to
+            // receive an event different to `ExecCommand` at the beginning. 
+            debug_assert_eq!(event, MonitorEvent::ExecCommand);
 
             // spawn the command
             let command = command.spawn()?;

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -42,7 +42,11 @@ impl MonitorClosure {
 
             // Wait for the main sudo process to give us green light before spawning the command. This
             // avoids race conditions when the command exits quickly.
-            let MonitorEvent::ExecCommand = retry_while_interrupted(|| backchannel.recv())?;
+            let event = retry_while_interrupted(|| backchannel.recv())?;
+
+            // FIXME: ogsudo doesn't check that this event is not a forwarded signal from the
+            // parent process. What should we do in that case?
+            assert_eq!(event, MonitorEvent::ExecCommand);
 
             // spawn the command
             let command = command.spawn()?;

--- a/lib/sudo-exec/src/parent.rs
+++ b/lib/sudo-exec/src/parent.rs
@@ -77,7 +77,7 @@ impl ParentClosure {
             // and we should stop.
             Err(err) => {
                 if !dispatcher.got_break() {
-                    dispatcher.set_break((&err).into());
+                    dispatcher.set_break(err.into());
                 }
             }
             Ok(event) => match event {
@@ -134,7 +134,7 @@ impl ParentClosure {
                 // The other end of the socket is gone, we should exit.
                 Err(err) if err.kind() == io::ErrorKind::BrokenPipe => {
                     // FIXME: maybe we need a different event for backchannel errors.
-                    dispatcher.set_break((&err).into());
+                    dispatcher.set_break(err.into());
                 }
                 // Non critical error, we can retry later.
                 Err(_) => {}


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR uses the backchannel to forward signals from the parent process to the monitor process instead of relying on `kill`. This is done because special signal numbers will be needed when forwarding `SIGCONT` to restore the terminal foreground status. 

Additionally, the parent process now can send messages using the backchannel without blocking by buffering the messages in a queue and adding a callback to the `EventDispatcher` so the messages are sent once the backchannel is ready to send a message.

This is another chunk of #363 and it is blocked by #433

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will help fix issue https://github.com/memorysafety/sudo-rs/issues/325 where a proper discussion about a solution has taken place.
