### PR TITLE
Add new syscalls to `sudo-system`

### DIFF
--- a/lib/sudo-exec/src/lib.rs
+++ b/lib/sudo-exec/src/lib.rs
@@ -17,7 +17,7 @@ use std::{
 use backchannel::BackchannelPair;
 use sudo_common::{context::LaunchType::Login, Context, Environment};
 use sudo_log::user_error;
-use sudo_system::{fork, openpty, set_target_user};
+use sudo_system::{fork, set_target_user, term::openpty};
 
 /// Based on `ogsudo`s `exec_pty` function.
 ///

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -8,8 +8,8 @@ use std::{
 use signal_hook::consts::*;
 use sudo_log::user_error;
 use sudo_system::{
-    getpgid, interface::ProcessId, kill, set_controlling_terminal, setpgid, setsid,
-    signal::SignalInfo,
+    getpgid, interface::ProcessId, kill, setpgid, setsid, signal::SignalInfo,
+    term::set_controlling_terminal,
 };
 
 use crate::{

--- a/lib/sudo-exec/src/monitor.rs
+++ b/lib/sudo-exec/src/monitor.rs
@@ -56,7 +56,7 @@ impl MonitorRelay {
 
             // set the process group ID of the command to the command PID.
             let command_pgrp = command_pid;
-            setpgid(command_pid, command_pgrp);
+            setpgid(command_pid, command_pgrp).ok();
 
             Ok((
                 signal_handlers,

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -154,8 +154,8 @@ pub fn getpgid(pid: ProcessId) -> io::Result<ProcessId> {
 }
 
 /// Set a process group ID.
-pub fn setpgid(pid: ProcessId, pgid: ProcessId) {
-    unsafe { libc::setpgid(pid, pgid) };
+pub fn setpgid(pid: ProcessId, pgid: ProcessId) -> io::Result<()> {
+    cerr(unsafe { libc::setpgid(pid, pgid) }).map(|_| ())
 }
 
 pub fn chdir<S: AsRef<CStr>>(path: &S) -> io::Result<()> {

--- a/lib/sudo-system/src/lib.rs
+++ b/lib/sudo-system/src/lib.rs
@@ -5,7 +5,6 @@ use std::{
     mem::MaybeUninit,
     os::fd::{AsRawFd, FromRawFd, OwnedFd},
     path::PathBuf,
-    ptr::null,
     str::FromStr,
 };
 
@@ -29,6 +28,8 @@ pub mod timestamp;
 pub mod signal;
 
 pub mod poll;
+
+pub mod term;
 
 pub fn write<F: AsRawFd>(fd: &F, buf: &[u8]) -> io::Result<libc::ssize_t> {
     cerr(unsafe { libc::write(fd.as_raw_fd(), buf.as_ptr().cast(), buf.len()) })
@@ -65,26 +66,6 @@ pub unsafe fn fork() -> io::Result<ProcessId> {
 
 pub fn setsid() -> io::Result<ProcessId> {
     cerr(unsafe { libc::setsid() })
-}
-
-pub fn openpty() -> io::Result<(OwnedFd, OwnedFd)> {
-    let (mut leader, mut follower) = (0, 0);
-    cerr(unsafe {
-        libc::openpty(
-            &mut leader,
-            &mut follower,
-            null::<libc::c_char>() as *mut _,
-            null::<libc::termios>() as *mut _,
-            null::<libc::winsize>() as *mut _,
-        )
-    })?;
-
-    Ok(unsafe { (OwnedFd::from_raw_fd(leader), OwnedFd::from_raw_fd(follower)) })
-}
-
-pub fn set_controlling_terminal<F: AsRawFd>(fd: &F) -> io::Result<()> {
-    cerr(unsafe { libc::ioctl(fd.as_raw_fd(), libc::TIOCSCTTY, 0) })?;
-    Ok(())
 }
 
 pub fn hostname() -> String {

--- a/lib/sudo-system/src/term.rs
+++ b/lib/sudo-system/src/term.rs
@@ -1,0 +1,27 @@
+use std::{
+    io,
+    os::fd::{AsRawFd, FromRawFd, OwnedFd},
+    ptr::null_mut,
+};
+
+use sudo_cutils::cerr;
+
+pub fn openpty() -> io::Result<(OwnedFd, OwnedFd)> {
+    let (mut leader, mut follower) = (0, 0);
+    cerr(unsafe {
+        libc::openpty(
+            &mut leader,
+            &mut follower,
+            null_mut::<libc::c_char>(),
+            null_mut::<libc::termios>(),
+            null_mut::<libc::winsize>(),
+        )
+    })?;
+
+    Ok(unsafe { (OwnedFd::from_raw_fd(leader), OwnedFd::from_raw_fd(follower)) })
+}
+
+pub fn set_controlling_terminal<F: AsRawFd>(fd: &F) -> io::Result<()> {
+    cerr(unsafe { libc::ioctl(fd.as_raw_fd(), libc::TIOCSCTTY, 0) })?;
+    Ok(())
+}

--- a/lib/sudo-system/src/term.rs
+++ b/lib/sudo-system/src/term.rs
@@ -6,6 +6,8 @@ use std::{
 
 use sudo_cutils::cerr;
 
+use crate::interface::ProcessId;
+
 pub fn openpty() -> io::Result<(OwnedFd, OwnedFd)> {
     let (mut leader, mut follower) = (0, 0);
     cerr(unsafe {
@@ -24,4 +26,14 @@ pub fn openpty() -> io::Result<(OwnedFd, OwnedFd)> {
 pub fn set_controlling_terminal<F: AsRawFd>(fd: &F) -> io::Result<()> {
     cerr(unsafe { libc::ioctl(fd.as_raw_fd(), libc::TIOCSCTTY, 0) })?;
     Ok(())
+}
+
+/// Set the foreground process group ID associated with the `fd` terminal device to `pgrp`.
+pub fn tcsetpgrp<F: AsRawFd>(fd: &F, pgrp: ProcessId) -> io::Result<()> {
+    cerr(unsafe { libc::tcsetpgrp(fd.as_raw_fd(), pgrp) }).map(|_| ())
+}
+
+/// Get the foreground process group ID associated with the `fd` terminal device.
+pub fn tcgetpgrp<F: AsRawFd>(fd: &F) -> io::Result<ProcessId> {
+    cerr(unsafe { libc::tcgetpgrp(fd.as_raw_fd()) })
 }

--- a/lib/sudo-system/src/term.rs
+++ b/lib/sudo-system/src/term.rs
@@ -45,17 +45,10 @@ mod tests {
         os::unix::net::UnixStream,
     };
 
-    use crate::{fork, getpgid, interface::ProcessId, setsid, term::*};
+    use crate::{fork, getpgid, setsid, term::*};
 
     #[test]
-    fn tcgetpgrp_works() {
-        let tty = std::fs::File::open("/dev/tty").unwrap();
-        let pgrp = getpgid(std::process::id() as ProcessId).unwrap();
-        assert_eq!(tcgetpgrp(&tty).unwrap(), pgrp);
-    }
-
-    #[test]
-    fn tcsetpgrp_works() {
+    fn tcsetpgrp_and_tcgetpgrp_are_consistent() {
         // Create a socket so the child can send us a byte if successful.
         let (mut rx, mut tx) = UnixStream::pair().unwrap();
 

--- a/lib/sudo-system/src/term.rs
+++ b/lib/sudo-system/src/term.rs
@@ -67,7 +67,7 @@ mod tests {
         assert_eq!(tcgetpgrp(&leader).unwrap(), 0);
         // Create a new session so we can change the controlling terminal.
         setsid().unwrap();
-        // Set the pty leader as the controlling terminal. 
+        // Set the pty leader as the controlling terminal.
         set_controlling_terminal(&leader).unwrap();
         // Set us as the foreground process group of the pty leader.
         let pgid = getpgid(0).unwrap();

--- a/lib/sudo-system/src/term.rs
+++ b/lib/sudo-system/src/term.rs
@@ -37,3 +37,15 @@ pub fn tcsetpgrp<F: AsRawFd>(fd: &F, pgrp: ProcessId) -> io::Result<()> {
 pub fn tcgetpgrp<F: AsRawFd>(fd: &F) -> io::Result<ProcessId> {
     cerr(unsafe { libc::tcgetpgrp(fd.as_raw_fd()) })
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{getpgid, interface::ProcessId, term::*};
+
+    #[test]
+    fn tcgetpgrp_matches_getpgid() {
+        let stdout = std::io::stdout();
+        let pgrp = getpgid(std::process::id() as ProcessId).unwrap();
+        assert_eq!(tcgetpgrp(&stdout).unwrap(), pgrp);
+    }
+}

--- a/lib/sudo-system/src/term.rs
+++ b/lib/sudo-system/src/term.rs
@@ -49,9 +49,9 @@ mod tests {
 
     #[test]
     fn tcgetpgrp_works() {
-        let stdout = std::io::stdout();
+        let tty = std::fs::File::open("/dev/tty").unwrap();
         let pgrp = getpgid(std::process::id() as ProcessId).unwrap();
-        assert_eq!(tcgetpgrp(&stdout).unwrap(), pgrp);
+        assert_eq!(tcgetpgrp(&tty).unwrap(), pgrp);
     }
 
     #[test]


### PR DESCRIPTION
This PR:
- Changes the return type of `setpgid` to `io::Result<()>` to properly report errors.
- Adds the `killpg` syscall (required by `sudo-exec` to terminate the command and all the processes in its process group).
- Adds a test for `setpgid`.
- Move terminal related functions to the `term` module.
- Add the `tcsetpgrp` and `tcgetpgrp` syscalls (required by `sudo-exec` to be able to handle `SIGTSTP` and `SIGCONT` correctly).
- Add tests for both `tcgetpgrp` and `tcsetpgrp`.
