### PR TITLE
Reorganize `sudo-exec`

### DIFF
--- a/sudo/lib/exec/mod.rs
+++ b/sudo/lib/exec/mod.rs
@@ -11,14 +11,13 @@ use std::{
     io,
     os::unix::ffi::OsStrExt,
     os::unix::process::CommandExt,
-    process::{exit, Command},
+    process::Command,
 };
 
 use crate::common::{context::LaunchType::Login, Context, Environment};
 use crate::log::user_error;
-use crate::system::{fork, set_target_user, term::openpty};
-use backchannel::BackchannelPair;
-use parent::ParentClosure;
+use crate::system::set_target_user;
+use parent::exec_pty;
 
 /// Based on `ogsudo`s `exec_pty` function.
 ///
@@ -71,31 +70,7 @@ pub fn run_command(ctx: Context, env: Environment) -> io::Result<(ExitReason, im
     // set target user and groups
     set_target_user(&mut command, ctx.target_user, ctx.target_group);
 
-    let (pty_leader, pty_follower) = openpty()?;
-
-    let mut backchannels = BackchannelPair::new()?;
-
-    // FIXME: We should block all the incoming signals before forking and unblock them just after
-    // initializing the signal handlers.
-    let monitor_pid = fork()?;
-    // Monitor logic. Based on `exec_monitor`.
-    if monitor_pid == 0 {
-        // If `exec_monitor` returns, it means we failed to execute the command somehow.
-        if let Err(err) = monitor::exec_monitor(pty_follower, command, &mut backchannels.monitor) {
-            backchannels.monitor.send(&err.into()).ok();
-            exit(1)
-        }
-    }
-
-    let (parent, mut dispatcher) = ParentClosure::new(
-        monitor_pid,
-        ctx.process.pid,
-        pty_leader,
-        backchannels.parent,
-    )?;
-    parent
-        .run(&mut dispatcher)
-        .map(|exit_reason| (exit_reason, move || drop(dispatcher)))
+    exec_pty(ctx.process.pid, command)
 }
 
 /// Exit reason for the command executed by sudo.

--- a/sudo/lib/exec/monitor.rs
+++ b/sudo/lib/exec/monitor.rs
@@ -97,7 +97,9 @@ impl<'a> MonitorClosure<'a> {
         // FIXME (ogsudo): Store the pgid of the monitor.
 
         // Register the callback to receive events from the backchannel
-        dispatcher.set_read_callback(backchannel, |mc, ev| mc.read_backchannel(ev));
+        dispatcher.set_read_callback(backchannel, |monitor, dispatcher| {
+            monitor.read_backchannel(dispatcher)
+        });
 
         // Put the command in its own process group.
         let command_pgrp = command_pid;

--- a/sudo/lib/exec/monitor.rs
+++ b/sudo/lib/exec/monitor.rs
@@ -19,82 +19,96 @@ use super::{
     io_util::{retry_while_interrupted, was_interrupted},
 };
 
-pub(super) struct MonitorClosure {
+// FIXME: This should return `io::Result<!>` but `!` is not stable yet.
+pub(crate) fn exec_monitor(
+    pty_follower: OwnedFd,
+    mut command: Command,
+    backchannel: &mut MonitorBackchannel,
+) -> io::Result<()> {
+    let mut dispatcher = EventDispatcher::<MonitorClosure>::new()?;
+
+    // FIXME (ogsudo): Any file descriptor not used by the monitor are closed here.
+
+    // FIXME (ogsudo): SIGTTIN and SIGTTOU are ignored here but the docs state that it shouldn't
+    // be possible to receive them in the first place. Investigate
+
+    // Start a new terminal session with the monitor as the leader.
+    setsid()?;
+
+    // Set the follower side of the pty as the controlling terminal for the session.
+    set_controlling_terminal(&pty_follower)?;
+
+    // Wait for the parent to give us green light before spawning the command. This avoids race
+    // conditions when the command exits quickly.
+    let event = retry_while_interrupted(|| backchannel.recv())?;
+    // Given that `UnixStream` delivers messages in order it shouldn't be possible to
+    // receive an event different to `ExecCommand` at the beginning.
+    debug_assert_eq!(event, MonitorMessage::ExecCommand);
+
+    // FIXME (ogsudo): Some extra config happens here if selinux is available.
+
+    // FIXME (ogsudo): Do any additional configuration that needs to be run after `fork` but before `exec`.
+
+    // spawn the command.
+    let command = command.spawn()?;
+
+    let command_pid = command.id() as ProcessId;
+
+    // Send the command's PID to the parent.
+    backchannel
+        .send(&ParentMessage::CommandPid(command_pid))
+        .ok();
+
+    let mut closure = MonitorClosure::new(command, command_pid, backchannel, &mut dispatcher);
+
+    // FIXME (ogsudo): Here's where the signal mask is removed because the handlers for the signals
+    // have been setup after initializing the closure.
+    // FIXME (ogsudo): Set the command as the foreground process for the follower.
+
+    // Start the event loop.
+    dispatcher.event_loop(&mut closure);
+    // FIXME (ogsudo): Terminate the command using `killpg` if it's not terminated.
+    // FIXME (ogsudo): Take the controlling tty so the command's children don't receive SIGHUP when we exit.
+    // FIXME (ogsudo): Send the command status back to the parent.
+    // FIXME (ogsudo): The tty is restored here if selinux is available.
+
+    drop(closure);
+
+    exit(1)
+}
+
+struct MonitorClosure<'a> {
     /// The command PID.
     ///
     /// This is `Some` iff the process is still running.
+    command: Child,
     command_pid: Option<ProcessId>,
     command_pgrp: ProcessId,
-    command: Child,
-    _pty_follower: OwnedFd,
-    backchannel: MonitorBackchannel,
+    backchannel: &'a mut MonitorBackchannel,
 }
 
-impl MonitorClosure {
-    pub(super) fn new(
-        mut command: Command,
-        pty_follower: OwnedFd,
-        mut backchannel: MonitorBackchannel,
-    ) -> (Self, EventDispatcher<Self>) {
-        let result = io::Result::Ok(()).and_then(|()| {
-            let mut dispatcher = EventDispatcher::<Self>::new()?;
+impl<'a> MonitorClosure<'a> {
+    fn new(
+        command: Child,
+        command_pid: ProcessId,
+        backchannel: &'a mut MonitorBackchannel,
+        dispatcher: &mut EventDispatcher<Self>,
+    ) -> Self {
+        // FIXME (ogsudo): Store the pgid of the monitor.
 
-            // Create new terminal session.
-            setsid()?;
+        // Register the callback to receive events from the backchannel
+        dispatcher.set_read_callback(backchannel, |mc, ev| mc.read_backchannel(ev));
 
-            // Set the pty as the controlling terminal.
-            set_controlling_terminal(&pty_follower)?;
+        // Put the command in its own process group.
+        let command_pgrp = command_pid;
+        setpgid(command_pid, command_pgrp).ok();
 
-            // Wait for the main sudo process to give us green light before spawning the command. This
-            // avoids race conditions when the command exits quickly.
-            let event = retry_while_interrupted(|| backchannel.recv())?;
-
-            // Given that `UnixStream` delivers messages in order it shouldn't be possible to
-            // receive an event different to `ExecCommand` at the beginning.
-            debug_assert_eq!(event, MonitorMessage::ExecCommand);
-
-            // spawn the command
-            let command = command.spawn()?;
-
-            let command_pid = command.id() as ProcessId;
-
-            // Send the command's PID to the main sudo process.
-            backchannel
-                .send(&ParentMessage::CommandPid(command_pid))
-                .ok();
-
-            // Register the callback to receive events from the backchannel
-            dispatcher.set_read_callback(&backchannel, |mc, ev| mc.read_backchannel(ev));
-
-            // set the process group ID of the command to the command PID.
-            let command_pgrp = command_pid;
-            setpgid(command_pid, command_pgrp).ok();
-
-            Ok((dispatcher, command_pid, command_pgrp, command, pty_follower))
-        });
-
-        match result {
-            Err(err) => {
-                backchannel.send(&err.into()).unwrap();
-                exit(1);
-            }
-            Ok((dispatcher, command_pid, command_pgrp, command, pty_follower)) => (
-                Self {
-                    command_pid: Some(command_pid),
-                    command_pgrp,
-                    command,
-                    _pty_follower: pty_follower,
-                    backchannel,
-                },
-                dispatcher,
-            ),
+        Self {
+            command,
+            command_pid: Some(command_pid),
+            command_pgrp,
+            backchannel,
         }
-    }
-
-    pub(super) fn run(mut self, dispatcher: &mut EventDispatcher<Self>) -> ! {
-        dispatcher.event_loop(&mut self);
-        drop(self);
-        exit(0);
     }
 
     /// Based on `mon_backchannel_cb`
@@ -168,7 +182,7 @@ fn is_self_terminating(
     false
 }
 
-impl EventClosure for MonitorClosure {
+impl<'a> EventClosure for MonitorClosure<'a> {
     type Break = ();
 
     fn on_signal(&mut self, info: SignalInfo, dispatcher: &mut EventDispatcher<Self>) {

--- a/sudo/lib/exec/monitor.rs
+++ b/sudo/lib/exec/monitor.rs
@@ -78,10 +78,10 @@ pub(super) fn exec_monitor(
 }
 
 struct MonitorClosure<'a> {
+    command: Child,
     /// The command PID.
     ///
     /// This is `Some` iff the process is still running.
-    command: Child,
     command_pid: Option<ProcessId>,
     command_pgrp: ProcessId,
     backchannel: &'a mut MonitorBackchannel,

--- a/sudo/lib/exec/monitor.rs
+++ b/sudo/lib/exec/monitor.rs
@@ -20,7 +20,7 @@ use super::{
 };
 
 // FIXME: This should return `io::Result<!>` but `!` is not stable yet.
-pub(crate) fn exec_monitor(
+pub(super) fn exec_monitor(
     pty_follower: OwnedFd,
     mut command: Command,
     backchannel: &mut MonitorBackchannel,


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR reorganizes the `sudo_exec` crate and adds a bunch of `FIXME` comments stating parts of the `use_pty` logic that we are missing.

This is another chunk of #363.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will help fix issue https://github.com/memorysafety/sudo-rs/issues/325 where a proper discussion about a solution has taken place.
