### PR TITLE
Add `waitpid` syscall to `sudo-system`

### DIFF
--- a/sudo/lib/system/mod.rs
+++ b/sudo/lib/system/mod.rs
@@ -30,6 +30,8 @@ pub mod poll;
 
 pub mod term;
 
+pub mod wait;
+
 #[cfg(target_os = "linux")]
 /// Create a new process.
 pub fn fork() -> io::Result<ProcessId> {

--- a/sudo/lib/system/mod.rs
+++ b/sudo/lib/system/mod.rs
@@ -3,7 +3,7 @@ use std::{
     fs::OpenOptions,
     io,
     mem::MaybeUninit,
-    os::fd::{AsRawFd, FromRawFd, OwnedFd},
+    os::fd::AsRawFd,
     path::PathBuf,
     str::FromStr,
 };
@@ -12,7 +12,6 @@ use crate::cutils::*;
 pub use audit::secure_open;
 use interface::{DeviceId, GroupId, ProcessId, UserId};
 pub use libc::PATH_MAX;
-use libc::{O_CLOEXEC, O_NONBLOCK};
 use time::SystemTime;
 
 mod audit;
@@ -30,20 +29,6 @@ pub mod signal;
 pub mod poll;
 
 pub mod term;
-
-pub fn write<F: AsRawFd>(fd: &F, buf: &[u8]) -> io::Result<libc::ssize_t> {
-    cerr(unsafe { libc::write(fd.as_raw_fd(), buf.as_ptr().cast(), buf.len()) })
-}
-
-pub fn read<F: AsRawFd>(fd: &F, buf: &mut [u8]) -> io::Result<libc::ssize_t> {
-    cerr(unsafe { libc::read(fd.as_raw_fd(), buf.as_mut_ptr().cast(), buf.len()) })
-}
-
-pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
-    let mut fds = [0; 2];
-    cerr(unsafe { libc::pipe2(fds.as_mut_ptr(), O_CLOEXEC | O_NONBLOCK) })?;
-    Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
-}
 
 #[cfg(target_os = "linux")]
 /// Create a new process.

--- a/sudo/lib/system/wait.rs
+++ b/sudo/lib/system/wait.rs
@@ -1,0 +1,158 @@
+use std::io;
+
+use libc::{
+    c_int, WCONTINUED, WEXITSTATUS, WIFCONTINUED, WIFEXITED, WIFSIGNALED, WIFSTOPPED, WNOHANG,
+    WSTOPSIG, WTERMSIG, WUNTRACED, __WALL,
+};
+use sudo_cutils::cerr;
+
+use crate::{interface::ProcessId, signal::SignalNumber};
+
+/// Wait for a process to change state.
+///
+/// Calling this function will block until a child specified by [`WaitPid`] has changed state. This
+/// can be configured further using [`WaitOptions`].
+pub fn waitpid<P: Into<WaitPid>>(
+    pid: P,
+    options: WaitOptions,
+) -> Result<(ProcessId, WaitStatus), WaitError> {
+    let pid = pid.into().into_pid();
+    let mut status: c_int = 0;
+
+    let pid =
+        cerr(unsafe { libc::waitpid(pid, &mut status, options.flags) }).map_err(WaitError::Io)?;
+
+    if pid == 0 && options.flags & WNOHANG != 0 {
+        return Err(WaitError::NotReady);
+    }
+
+    Ok((pid, WaitStatus { status }))
+}
+
+/// Error values returned when [`waitpid`] fails.
+#[derive(Debug)]
+pub enum WaitError {
+    // No children were in a waitable state.
+    //
+    // This is only returned if the [`WaitOptions::no_hang`] option is used.
+    NotReady,
+    // Regular I/O error.
+    Io(io::Error),
+}
+
+/// Which child process to wait for.
+pub enum WaitPid {
+    /// Wait for any child process.
+    Any,
+    /// Wait for the child process with the given ID.
+    One(ProcessId),
+}
+
+impl WaitPid {
+    fn into_pid(self) -> ProcessId {
+        match self {
+            Self::Any => -1,
+            Self::One(pid) => pid,
+        }
+    }
+}
+
+impl From<ProcessId> for WaitPid {
+    fn from(pid: ProcessId) -> Self {
+        debug_assert!(pid > 0);
+        Self::One(pid)
+    }
+}
+
+/// Options to configure how [`waitpid`] waits for children.
+pub struct WaitOptions {
+    flags: c_int,
+}
+
+impl WaitOptions {
+    /// Only wait for terminated children.
+    pub const fn new() -> Self {
+        Self { flags: 0 }
+    }
+
+    /// Return immediately if no child has exited.
+    pub const fn no_hang(mut self) -> Self {
+        self.flags |= WNOHANG;
+        self
+    }
+
+    /// Return immediately if a child has stopped.
+    pub const fn untraced(mut self) -> Self {
+        self.flags |= WUNTRACED;
+        self
+    }
+
+    /// Return immediately if a child has been resumed by `SIGCONT`.
+    pub const fn continued(mut self) -> Self {
+        self.flags |= WCONTINUED;
+        self
+    }
+
+    /// Wait for all children, regardless of being created using `clone` or not.
+    pub const fn all(mut self) -> Self {
+        self.flags |= __WALL;
+        self
+    }
+}
+
+/// The status of the waited child.
+#[derive(Clone, Copy)]
+pub struct WaitStatus {
+    status: c_int,
+}
+
+impl WaitStatus {
+    /// Return `true` if the child terminated normally, i.e., by calling `exit`.
+    pub const fn did_exit(&self) -> bool {
+        WIFEXITED(self.status)
+    }
+
+    /// Return the exit status of the child if the child terminated normally.
+    pub const fn exit_status(&self) -> Option<c_int> {
+        if self.did_exit() {
+            Some(WEXITSTATUS(self.status))
+        } else {
+            None
+        }
+    }
+
+    /// Return `true` if the child process was terminated by a signal.
+    pub const fn was_signaled(&self) -> bool {
+        WIFSIGNALED(self.status)
+    }
+
+    /// Return the signal number which caused the child to terminate if the child was terminated by
+    /// a signal.
+    pub const fn term_signal(&self) -> Option<SignalNumber> {
+        if self.was_signaled() {
+            Some(WTERMSIG(self.status))
+        } else {
+            None
+        }
+    }
+
+    /// Return `true` if the child process was stopped by a signal.
+    pub const fn was_stopped(&self) -> bool {
+        WIFSTOPPED(self.status)
+    }
+
+    /// Return the signal number which caused the child to stop if the child was stopped by a
+    /// signal.
+    pub const fn stop_signal(&self) -> Option<SignalNumber> {
+        if self.was_stopped() {
+            Some(WSTOPSIG(self.status))
+        } else {
+            None
+        }
+    }
+
+    /// Return `true` if the child process was resumed by receiving `SIGCONT`.
+    pub const fn did_continue(&self) -> bool {
+        WIFCONTINUED(self.status)
+    }
+}

--- a/sudo/lib/system/wait.rs
+++ b/sudo/lib/system/wait.rs
@@ -200,7 +200,15 @@ mod tests {
 
         let (pid, status) = waitpid(command_pid, WaitOptions::new()).unwrap();
         assert_eq!(command_pid, pid);
+        assert!(status.did_exit());
         assert_eq!(status.exit_status(), Some(42));
+
+        assert!(!status.was_signaled());
+        assert!(status.term_signal().is_none());
+        assert!(!status.was_stopped());
+        assert!(status.stop_signal().is_none());
+        assert!(!status.did_continue());
+
         // Waiting when there are no children should fail.
         let WaitError::Io(err) = waitpid(command_pid, WaitOptions::new()).unwrap_err() else {
             panic!("`WaitError::NotReady` should not happens if `WaitOptions::no_hang` was not called.");
@@ -233,7 +241,14 @@ mod tests {
 
         let (pid, status) = waitpid(command_pid, WaitOptions::new()).unwrap();
         assert_eq!(command_pid, pid);
+        assert!(status.was_signaled());
         assert_eq!(status.term_signal(), Some(SIGKILL));
+
+        assert!(!status.did_exit());
+        assert!(status.exit_status().is_none());
+        assert!(!status.was_stopped());
+        assert!(status.stop_signal().is_none());
+        assert!(!status.did_continue());
     }
 
     #[test]
@@ -255,8 +270,15 @@ mod tests {
         };
 
         assert_eq!(command_pid, pid);
+        assert!(status.did_exit());
         assert_eq!(status.exit_status(), Some(42));
         assert!(count > 0);
+
+        assert!(!status.was_signaled());
+        assert!(status.term_signal().is_none());
+        assert!(!status.was_stopped());
+        assert!(status.stop_signal().is_none());
+        assert!(!status.did_continue());
     }
 
     #[test]
@@ -278,9 +300,21 @@ mod tests {
             assert_eq!(cmd1.id() as ProcessId, pid);
             assert_eq!(status.exit_status(), Some(42));
 
+            assert!(!status.was_signaled());
+            assert!(status.term_signal().is_none());
+            assert!(!status.was_stopped());
+            assert!(status.stop_signal().is_none());
+            assert!(!status.did_continue());
+
             let (pid, status) = waitpid(WaitPid::any(), WaitOptions::new()).unwrap();
             assert_eq!(cmd2.id() as ProcessId, pid);
             assert_eq!(status.exit_status(), Some(43));
+
+            assert!(!status.was_signaled());
+            assert!(status.term_signal().is_none());
+            assert!(!status.was_stopped());
+            assert!(status.stop_signal().is_none());
+            assert!(!status.did_continue());
             // Exit with a specific status code so we can check it from the parent.
             exit(44);
         }
@@ -288,5 +322,11 @@ mod tests {
         let (pid, status) = waitpid(child_pid, WaitOptions::new()).unwrap();
         assert_eq!(child_pid, pid);
         assert_eq!(status.exit_status(), Some(44));
+
+        assert!(!status.was_signaled());
+        assert!(status.term_signal().is_none());
+        assert!(!status.was_stopped());
+        assert!(status.stop_signal().is_none());
+        assert!(!status.did_continue());
     }
 }

--- a/sudo/lib/system/wait.rs
+++ b/sudo/lib/system/wait.rs
@@ -242,7 +242,7 @@ mod tests {
             .unwrap();
 
         let cmd2 = std::process::Command::new("sh")
-            .args(["-c", "sleep 0.2; exit 43"])
+            .args(["-c", "sleep 0.5; exit 43"])
             .spawn()
             .unwrap();
 

--- a/sudo/lib/system/wait.rs
+++ b/sudo/lib/system/wait.rs
@@ -4,9 +4,9 @@ use libc::{
     c_int, WCONTINUED, WEXITSTATUS, WIFCONTINUED, WIFEXITED, WIFSIGNALED, WIFSTOPPED, WNOHANG,
     WSTOPSIG, WTERMSIG, WUNTRACED, __WALL,
 };
-use sudo_cutils::cerr;
 
-use crate::{interface::ProcessId, signal::SignalNumber};
+use crate::cutils::cerr;
+use crate::{system::interface::ProcessId, system::signal::SignalNumber};
 
 /// Wait for a process to change state.
 ///
@@ -163,13 +163,12 @@ mod tests {
 
     use libc::{SIGCONT, SIGKILL, SIGSTOP};
 
-    use crate::{
+    use crate::system::{
+        fork,
         interface::ProcessId,
         kill,
-        wait::{WaitError, WaitPid},
+        wait::{waitpid, WaitError, WaitOptions, WaitPid},
     };
-
-    use super::{waitpid, WaitOptions};
 
     #[test]
     fn exit_status() {
@@ -239,7 +238,7 @@ mod tests {
     #[test]
     fn any() {
         // We fork so waiting for `WaitPid::Any` doesn't wait for other tests.
-        let child_pid = crate::fork().unwrap();
+        let child_pid = fork().unwrap();
         if child_pid == 0 {
             let cmd1 = std::process::Command::new("sh")
                 .args(["-c", "sleep 0.1; exit 42"])


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR adds the `waitpid` system call to `sudo-system` with a rust-like interface to it. This syscall is required so the parent process in `sudo-exec` can wait for the monitor process termination.

This PR also adds tests for the different `waitpid` options and removes the now unused `read`, `write` and `pipe` system calls.

This is another chunk of #363.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will help fix issue https://github.com/memorysafety/sudo-rs/issues/325 where a proper discussion about a solution has taken place.
