### PR TITLE
Lint removal

### DIFF
--- a/sudo/lib/env/environment.rs
+++ b/sudo/lib/env/environment.rs
@@ -242,7 +242,7 @@ mod tests {
 
         let check_should_keep = |key: &str, value: &str, expected: bool| {
             assert_eq!(
-                should_keep(&OsStr::new(key), &OsStr::new(value), &config),
+                should_keep(OsStr::new(key), OsStr::new(value), &config),
                 expected,
                 "{} should {}",
                 key,
@@ -259,6 +259,8 @@ mod tests {
         check_should_keep("MIES", "FOO%", false);
     }
 
+    #[allow(clippy::useless_format)]
+    #[allow(clippy::bool_assert_comparison)]
     #[test]
     fn test_tzinfo() {
         assert_eq!(is_safe_tz("Europe/Amsterdam".as_bytes()), true);

--- a/sudo/lib/env/environment.rs
+++ b/sudo/lib/env/environment.rs
@@ -109,7 +109,7 @@ fn add_extra_env(
     // target environment to the same value of SUDO_PS1 if the latter is set.
     if let Some(sudo_ps1_value) = sudo_ps1 {
         // set PS1 to the SUDO_PS1 value in the target environment
-        environment.insert("PS1".into(), sudo_ps1_value.clone());
+        environment.insert("PS1".into(), sudo_ps1_value);
     }
 }
 

--- a/sudo/tests/env_tests.rs
+++ b/sudo/tests/env_tests.rs
@@ -73,7 +73,7 @@ fn parse_env_commands(input: &str) -> Vec<(&str, Environment)> {
         .collect()
 }
 
-fn create_test_context<'a>(sudo_options: &'a SudoOptions) -> Context {
+fn create_test_context(sudo_options: &SudoOptions) -> Context {
     let path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string();
     let command =
         CommandAndArguments::try_from_args(None, sudo_options.clone().args(), &path).unwrap();


### PR DESCRIPTION
On my dev box, clippy had some remarks on recent changes; I also like running it on test cases without noise.

Note: I agree with the original author that the "redundant" `format` and `assert_eq!` makes the test-case more readable than the alternative, so the moral thing to do here is just to give this unit test a free pass.