### PR TITLE
Some pseudoterminal updates

### DIFF
--- a/sudo/lib/exec/parent.rs
+++ b/sudo/lib/exec/parent.rs
@@ -6,7 +6,6 @@ use std::process::{exit, Command};
 use signal_hook::consts::*;
 
 use crate::log::user_error;
-use crate::system::interface::GroupId;
 use crate::system::signal::{SignalAction, SignalHandler};
 use crate::system::term::Pty;
 use crate::system::{chown, fork, Group, User};
@@ -81,11 +80,7 @@ pub(super) fn exec_pty(
 }
 
 fn get_pty() -> io::Result<Pty> {
-    let mut tty_gid = GroupId::MAX;
-
-    if let Some(group) = Group::from_name("tty")? {
-        tty_gid = group.gid;
-    }
+    let tty_gid = Group::from_name("tty")?.map(|group| group.gid);
 
     let pty = Pty::open()?;
     // FIXME: Test this

--- a/sudo/lib/system/mod.rs
+++ b/sudo/lib/system/mod.rs
@@ -144,8 +144,16 @@ pub fn chdir<S: AsRef<CStr>>(path: &S) -> io::Result<()> {
     cerr(unsafe { libc::chdir(path.as_ref().as_ptr()) }).map(|_| ())
 }
 
-pub fn chown<S: AsRef<CStr>>(path: &S, uid: UserId, gid: GroupId) -> io::Result<()> {
-    cerr(unsafe { libc::chown(path.as_ref().as_ptr(), uid, gid) }).map(|_| ())
+pub fn chown<S: AsRef<CStr>>(
+    path: &S,
+    uid: impl Into<Option<UserId>>,
+    gid: impl Into<Option<GroupId>>,
+) -> io::Result<()> {
+    let path = path.as_ref().as_ptr();
+    let uid = uid.into().unwrap_or(UserId::MAX);
+    let gid = gid.into().unwrap_or(GroupId::MAX);
+
+    cerr(unsafe { libc::chown(path, uid, gid) }).map(|_| ())
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/sudo/lib/system/mod.rs
+++ b/sudo/lib/system/mod.rs
@@ -144,6 +144,10 @@ pub fn chdir<S: AsRef<CStr>>(path: &S) -> io::Result<()> {
     cerr(unsafe { libc::chdir(path.as_ref().as_ptr()) }).map(|_| ())
 }
 
+pub fn chown<S: AsRef<CStr>>(path: &S, uid: UserId, gid: GroupId) -> io::Result<()> {
+    cerr(unsafe { libc::chown(path.as_ref().as_ptr(), uid, gid) }).map(|_| ())
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct User {
     pub uid: UserId,

--- a/sudo/lib/system/term.rs
+++ b/sudo/lib/system/term.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::{c_uchar, CString},
     io,
     os::fd::{AsRawFd, FromRawFd, OwnedFd},
     ptr::null_mut,
@@ -9,24 +10,44 @@ use crate::cutils::cerr;
 use super::interface::ProcessId;
 
 pub struct Pty {
+    pub path: CString,
     pub leader: OwnedFd,
     pub follower: OwnedFd,
 }
 
 impl Pty {
     pub fn open() -> io::Result<Self> {
+        const PATH_MAX: usize = libc::PATH_MAX as _;
+        // Allocate a buffer to hold the path to the pty.
+        let mut path = vec![0 as c_uchar; PATH_MAX];
+        // Create two integers to hold the file descriptors for each side of the pty.
         let (mut leader, mut follower) = (0, 0);
+
         cerr(unsafe {
             libc::openpty(
                 &mut leader,
                 &mut follower,
-                null_mut::<libc::c_char>(),
+                path.as_mut_ptr().cast(),
                 null_mut::<libc::termios>(),
                 null_mut::<libc::winsize>(),
             )
         })?;
 
+        // Get the index of the first null byte and truncate `path` so it doesn't have any null
+        // bytes. If there are no null bytes the path is left as it is.
+        if let Some(index) = path
+            .iter()
+            .enumerate()
+            .find_map(|(index, &byte)| (byte == 0).then_some(index))
+        {
+            path.truncate(index);
+        }
+
+        // This will not panic because `path` was truncated to not have any null bytes.
+        let path = CString::new(path).unwrap();
+
         Ok(Self {
+            path,
             leader: unsafe { OwnedFd::from_raw_fd(leader) },
             follower: unsafe { OwnedFd::from_raw_fd(follower) },
         })
@@ -51,11 +72,24 @@ pub fn tcgetpgrp<F: AsRawFd>(fd: &F) -> io::Result<ProcessId> {
 #[cfg(test)]
 mod tests {
     use std::{
-        io::{Read, Write},
-        os::unix::net::UnixStream,
+        ffi::OsString,
+        io::{IsTerminal, Read, Write},
+        os::unix::{net::UnixStream, prelude::OsStringExt},
+        path::PathBuf,
     };
 
     use crate::system::{fork, getpgid, setsid, term::*};
+
+    #[test]
+    fn open_pty() {
+        let pty = Pty::open().unwrap();
+        assert!(pty.leader.is_terminal());
+        assert!(pty.follower.is_terminal());
+
+        let path = PathBuf::from(OsString::from_vec(pty.path.into_bytes()));
+        assert!(path.try_exists().unwrap());
+        assert!(path.starts_with("/dev/pts/"));
+    }
 
     #[test]
     fn tcsetpgrp_and_tcgetpgrp_are_consistent() {

--- a/sudo/lib/system/term.rs
+++ b/sudo/lib/system/term.rs
@@ -10,8 +10,11 @@ use crate::cutils::cerr;
 use super::interface::ProcessId;
 
 pub struct Pty {
+    /// The file path of the leader side of the pty.
     pub path: CString,
+    /// The file descriptor of the leader side of the pty.
     pub leader: OwnedFd,
+    /// The file descriptor of the follower side of the pty.
     pub follower: OwnedFd,
 }
 


### PR DESCRIPTION
- Replace `ptyopen` by `Pty::open`
- Get the path of the pty
- Document the fields of `Pty`
- Add the `chown` syscall
- Set the owner of the pty leader
- Avoid using `-1` in `chown`

**Describe the changes done on this pull request**
This PR introduces the new `Pty` type to avoid returning a tuple when opening a new pseudoterminal. I also added `Pty::open` which replaces `openpty` and obtains the path to the leader side of the pseudoterminal.

The `chown` syscall was added to the `system` module and it is used to set the owner of the leader side of the pseudoterminal. This should be an interesting test for @BriocheBerlin and @japaric.

This is another chunk of #363

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will help fix issue https://github.com/memorysafety/sudo-rs/issues/325 where a proper discussion about a solution has taken place.
