### PR TITLE
sudo-test/refactor: `Command::exec` -> `Command::output`

### DIFF
--- a/test-framework/sudo-compliance-tests/src/child_process.rs
+++ b/test-framework/sudo-compliance-tests/src/child_process.rs
@@ -13,7 +13,7 @@ fn sudo_forwards_childs_exit_code() -> Result<()> {
     let output = Command::new("sudo")
         .args(["sh", "-c"])
         .arg(format!("exit {expected}"))
-        .exec(&env)?;
+        .output(&env)?;
     assert_eq!(Some(expected), output.status().code());
 
     Ok(())
@@ -24,7 +24,7 @@ fn sudo_forwards_childs_stdout() -> Result<()> {
     let env = Env(SUDOERS_ROOT_ALL_NOPASSWD).build()?;
 
     let expected = "hello";
-    let output = Command::new("sudo").args(["echo", expected]).exec(&env)?;
+    let output = Command::new("sudo").args(["echo", expected]).output(&env)?;
     assert!(output.stderr().is_empty());
     assert_eq!(expected, output.stdout()?);
 
@@ -39,7 +39,7 @@ fn sudo_forwards_childs_stderr() -> Result<()> {
     let output = Command::new("sudo")
         .args(["sh", "-c"])
         .arg(format!(">&2 echo {expected}"))
-        .exec(&env)?;
+        .output(&env)?;
     assert_eq!(expected, output.stderr());
     assert!(output.stdout()?.is_empty());
 
@@ -55,10 +55,10 @@ fn sudo_forwards_stdin_to_child() -> Result<()> {
     Command::new("sudo")
         .args(["tee", path])
         .stdin(expected)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
-    let actual = Command::new("cat").arg(path).exec(&env)?.stdout()?;
+    let actual = Command::new("cat").arg(path).output(&env)?.stdout()?;
 
     assert_eq!(expected, actual);
 

--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/mod.rs
@@ -21,7 +21,7 @@ fn signal_sent_by_child_process_is_ignored() -> Result<()> {
         .args(["sh", kill_sudo_parent])
         .as_user(USERNAME)
         .tty(true)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -44,7 +44,7 @@ fn signal_is_forwarded_to_child() -> Result<()> {
     Command::new("sh")
         .arg(kill_sudo)
         .tty(true)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let actual = child.wait()?.stdout()?;
@@ -67,7 +67,7 @@ fn child_terminated_by_signal() -> Result<()> {
         .args(["sh", "-c", "kill $$"])
         .as_user(USERNAME)
         .tty(true)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert_eq!(Some(143), output.status().code());
     assert!(output.stderr().is_empty());
@@ -89,7 +89,7 @@ fn sigtstp_works() -> Result<()> {
     let output = Command::new("bash")
         .arg(script_path)
         .tty(true)
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let timestamps = output

--- a/test-framework/sudo-compliance-tests/src/cli.rs
+++ b/test-framework/sudo-compliance-tests/src/cli.rs
@@ -19,7 +19,7 @@ fn just_dash_dash_works() -> Result<()> {
 
     Command::new("sudo")
         .args(["--", "true"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -29,7 +29,7 @@ fn dash_dash_after_other_flag_works() -> Result<()> {
 
     Command::new("sudo")
         .args(["-u", "root", "--", "true"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -39,7 +39,7 @@ fn dash_dash_before_flag_is_an_error() -> Result<()> {
 
     let output = Command::new("sudo")
         .args(["--", "-u", "root", "true"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -61,7 +61,7 @@ fn dash_flag_space_value_syntax() -> Result<()> {
 
     let actual = Command::new("sudo")
         .args(["-u", "root", "id", "-u"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?
         .parse::<u16>()?;
 
@@ -77,7 +77,7 @@ fn dash_flag_no_space_value_syntax() -> Result<()> {
 
     let actual = Command::new("sudo")
         .args(["-uroot", "id", "-u"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?
         .parse::<u16>()?;
 
@@ -92,7 +92,7 @@ fn dash_flag_equal_value_invalid_syntax() -> Result<()> {
 
     let output = Command::new("sudo")
         .args(["-u=root", "id", "-u"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -114,7 +114,7 @@ fn dash_dash_flag_space_value_syntax() -> Result<()> {
 
     let actual = Command::new("sudo")
         .args(["--user", "root", "id", "-u"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?
         .parse::<u16>()?;
 
@@ -130,7 +130,7 @@ fn dash_dash_flag_equal_value_syntax() -> Result<()> {
 
     let actual = Command::new("sudo")
         .args(["--user=root", "id", "-u"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?
         .parse::<u16>()?;
 

--- a/test-framework/sudo-compliance-tests/src/env_reset.rs
+++ b/test-framework/sudo-compliance-tests/src/env_reset.rs
@@ -16,16 +16,16 @@ use crate::{
 fn some_vars_are_set() -> Result<()> {
     let env = Env(SUDOERS_ROOT_ALL_NOPASSWD).build()?;
 
-    let stdout = Command::new("env").exec(&env)?.stdout()?;
+    let stdout = Command::new("env").output(&env)?.stdout()?;
     let normal_env = helpers::parse_env_output(&stdout)?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     // run sudo in an empty environment
     let stdout = Command::new("env")
         .args(["-i", SUDO_RS_IS_UNSTABLE, &sudo_abs_path, &env_abs_path])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let mut sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -85,7 +85,7 @@ fn most_vars_are_removed() -> Result<()> {
     let stdout = Command::new("sh")
         .arg("-c")
         .arg(format!("{set_env_var}; env"))
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let env_vars = helpers::parse_env_output(&stdout)?;
     assert!(env_vars.contains_key(varname));
@@ -93,7 +93,7 @@ fn most_vars_are_removed() -> Result<()> {
     let stdout = Command::new("sh")
         .arg("-c")
         .arg(format!("{set_env_var}; sudo env"))
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let env_vars = helpers::parse_env_output(&stdout)?;
     assert!(!env_vars.contains_key(varname));
@@ -110,8 +110,8 @@ fn user_dependent_vars() -> Result<()> {
         .user(User(USERNAME).shell(shell_path))
         .build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     // run sudo in an empty environment
     let stdout = Command::new("env")
@@ -123,7 +123,7 @@ fn user_dependent_vars() -> Result<()> {
             USERNAME,
             &env_abs_path,
         ])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let mut sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -158,8 +158,8 @@ fn user_dependent_vars() -> Result<()> {
 fn some_vars_are_preserved() -> Result<()> {
     let env = Env(SUDOERS_ROOT_ALL_NOPASSWD).build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     let home = "some-home";
     let mail = "some-mail";
@@ -192,7 +192,7 @@ fn some_vars_are_preserved() -> Result<()> {
             &sudo_abs_path,
             &env_abs_path,
         ])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let mut sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -225,8 +225,8 @@ fn some_vars_are_preserved() -> Result<()> {
 fn vars_whose_values_start_with_parentheses_are_removed() -> Result<()> {
     let env = Env(SUDOERS_ROOT_ALL_NOPASSWD).build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     let stdout = Command::new("env")
         .args([
@@ -238,7 +238,7 @@ fn vars_whose_values_start_with_parentheses_are_removed() -> Result<()> {
             &sudo_abs_path,
             &env_abs_path,
         ])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 

--- a/test-framework/sudo-compliance-tests/src/flag_chdir.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_chdir.rs
@@ -7,7 +7,7 @@ fn cwd_not_set_cannot_change_dir() -> Result<()> {
 
     let output = Command::new("sudo")
         .args(["--chdir", "/root", "pwd"])
-        .exec(&env)?;
+        .output(&env)?;
     assert_eq!(Some(1), output.status().code());
     assert!(!output.status().success());
     let diagnostic = if sudo_test::is_original_sudo() {
@@ -25,7 +25,7 @@ fn cwd_set_to_glob_change_dir() -> Result<()> {
     let env = Env(TextFile("ALL ALL=(ALL:ALL) CWD=* NOPASSWD: ALL")).build()?;
     let output = Command::new("sh")
         .args(["-c", "cd /; sudo --chdir /root pwd"])
-        .exec(&env)?;
+        .output(&env)?;
     assert_eq!(Some(0), output.status().code());
     assert!(output.status().success());
     assert_contains!(output.stdout()?, "/root");
@@ -44,7 +44,7 @@ fn cwd_fails_for_non_existent_dirs() -> Result<()> {
             "-c",
             "echo >&2 'avocado'",
         ])
-        .exec(&env)?;
+        .output(&env)?;
     assert_eq!(Some(1), output.status().code());
     assert!(!output.status().success());
     let stderr = output.stderr();
@@ -73,7 +73,7 @@ fn cwd_with_login_fails_for_non_existent_dirs() -> Result<()> {
             "-c",
             "echo >&2 'avocado'",
         ])
-        .exec(&env)?;
+        .output(&env)?;
     assert_eq!(Some(1), output.status().code());
     assert!(!output.status().success());
     let stderr = output.stderr();
@@ -91,7 +91,7 @@ fn cwd_set_to_non_glob_value_then_cannot_use_chdir_flag() -> Result<()> {
     let env = Env(TextFile("ALL ALL=(ALL:ALL) CWD=/root NOPASSWD: ALL")).build()?;
     let output = Command::new("sh")
         .args(["-c", "cd /; sudo --chdir /tmp pwd"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -113,7 +113,7 @@ fn cwd_set_to_non_glob_value_then_cannot_use_that_path_with_chdir_flag() -> Resu
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!("cd /; sudo --chdir {path} pwd"))
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -136,7 +136,7 @@ fn any_chdir_value_is_accepted_if_it_matches_pwd_cwd_unset() -> Result<()> {
     let stdout = Command::new("sh")
         .arg("-c")
         .arg(format!("cd {path}; sudo --chdir {path} pwd"))
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(path, stdout);
@@ -156,7 +156,7 @@ fn any_chdir_value_is_accepted_if_it_matches_pwd_cwd_set() -> Result<()> {
         .arg(format!(
             "cd {another_path}; sudo --chdir {another_path} pwd"
         ))
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(cwd_path, stdout);
@@ -175,7 +175,7 @@ fn target_user_has_insufficient_perms() -> Result<()> {
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!("cd /; sudo -u {USERNAME} --chdir {path} pwd"))
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/flag_login.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_login.rs
@@ -23,7 +23,7 @@ fn if_home_directory_does_not_exist_executes_program_without_changing_the_workin
         let output = Command::new("sh")
             .arg("-c")
             .arg(format!("cd {expected}; sudo -u {USERNAME} -i pwd"))
-            .exec(&env)?;
+            .output(&env)?;
 
         assert!(output.status().success());
 
@@ -51,7 +51,7 @@ fn sets_home_directory_as_working_directory() -> Result<()> {
     let actual = Command::new("sh")
         .arg("-c")
         .arg(format!("cd /; sudo -u {USERNAME} -i pwd"))
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(expected, actual);
@@ -74,7 +74,7 @@ echo $0";
 
     let actual = Command::new("sudo")
         .args(["-u", USERNAME, "-i"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let expected = shell_path;
 
@@ -95,7 +95,7 @@ echo $@";
 
     let output = Command::new("sudo")
         .args(["-u", USERNAME, "-i", "argument"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!("-c argument", output);
@@ -115,7 +115,7 @@ echo $@";
 
     let output = Command::new("sudo")
         .args(["-u", USERNAME, "-i", "a", "b"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!("-c a b", output);
@@ -135,7 +135,7 @@ for arg in \"$@\"; do echo -n \"{$arg}\"; done";
 
     let output = Command::new("sudo")
         .args(["-u", USERNAME, "-i", "a b", "c d"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!("{-c}{a\\ b c\\ d}", output);
@@ -155,7 +155,7 @@ echo $@";
 
     let output = Command::new("sudo")
         .args(["-u", USERNAME, "-i", "'", "\"", "a b"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(r#"-c \' \" a\ b"#, output);
@@ -177,7 +177,7 @@ echo $@";
         .args([
             "-u", USERNAME, "-i", "a", "1", "_", "-", "$", "$VAR", "${VAR}",
         ])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(r#"-c a 1 _ - $ $VAR $\{VAR\}"#, output);
@@ -194,7 +194,7 @@ fn shell_is_invoked_as_a_login_shell() -> Result<()> {
     let expected = "-bash";
     let actual = Command::new("sudo")
         .args(["-u", "ferris", "-i", "echo", "$0"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     // man bash says "A login shell is one whose first character of argument zero is a -"
@@ -212,7 +212,7 @@ fn shell_does_not_exist() -> Result<()> {
 
     let output = Command::new("sudo")
         .args(["-u", USERNAME, "-i"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -237,7 +237,7 @@ fn insufficient_permissions_to_execute_shell() -> Result<()> {
 
     let output = Command::new("sudo")
         .args(["-u", USERNAME, "-i"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -262,6 +262,6 @@ fn shell_with_open_permissions_is_accepted() -> Result<()> {
 
     Command::new("sudo")
         .args(["-u", USERNAME, "-i"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }

--- a/test-framework/sudo-compliance-tests/src/flag_non_interactive.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_non_interactive.rs
@@ -14,7 +14,7 @@ fn fails_if_password_needed() -> Result<()> {
     let output = Command::new("sudo")
         .args(["-n", "true"])
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -44,7 +44,7 @@ fn flag_remove_timestamp_plus_command_fails() -> Result<()> {
             "echo {PASSWORD} | sudo -S true 2>/dev/null; sudo -n -k true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -70,7 +70,7 @@ fn root() -> Result<()> {
 
     Command::new("sudo")
         .args(["-n", "true"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -81,7 +81,7 @@ fn nopasswd() -> Result<()> {
     Command::new("sudo")
         .args(["-n", "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -95,7 +95,7 @@ fn cached_credential() -> Result<()> {
         .arg("-c")
         .arg(format!("echo {PASSWORD} | sudo -S true; sudo -n true"))
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -107,7 +107,7 @@ fn lecture_is_not_shown() -> Result<()> {
     let output = Command::new("sudo")
         .args(["-n", "true"])
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/flag_user.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_user.rs
@@ -24,10 +24,13 @@ fn root_can_become_another_user_by_name() -> Result<()> {
     // NOTE `id` without flags prints the *real* user/group id if it's different from the
     // *effective* user/group id so here we are checking that both the real *and* effective UID has
     // changed to match the target user's
-    let expected = Command::new("id").as_user(USERNAME).exec(&env)?.stdout()?;
+    let expected = Command::new("id")
+        .as_user(USERNAME)
+        .output(&env)?
+        .stdout()?;
     let actual = Command::new("sudo")
         .args(["-u", USERNAME, "id"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(expected, actual);
@@ -42,15 +45,18 @@ fn root_can_become_another_user_by_uid() -> Result<()> {
     let uid = Command::new("id")
         .arg("-u")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .stdout()?
         .parse::<u32>()?;
-    let expected = Command::new("id").as_user(USERNAME).exec(&env)?.stdout()?;
+    let expected = Command::new("id")
+        .as_user(USERNAME)
+        .output(&env)?
+        .stdout()?;
     let actual = Command::new("sudo")
         .arg("-u")
         .arg(format!("#{uid}"))
         .arg("id")
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(expected, actual);
@@ -69,12 +75,12 @@ fn user_can_become_another_user() -> Result<()> {
 
     let expected = Command::new("id")
         .as_user(another_user)
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let actual = Command::new("sudo")
         .args(["-u", another_user, "id"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(expected, actual);
@@ -95,12 +101,12 @@ fn invoking_user_groups_are_lost_when_becoming_another_user() -> Result<()> {
 
     let expected = Command::new("id")
         .as_user(another_user)
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let actual = Command::new("sudo")
         .args(["-u", another_user, "id"])
         .as_user(invoking_user)
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(expected, actual);
@@ -119,7 +125,7 @@ fn unassigned_user_id_is_rejected() -> Result<()> {
             .arg(format!("#{expected_uid}"))
             .arg("true")
             .as_user(user)
-            .exec(&env)?;
+            .output(&env)?;
 
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());
@@ -141,7 +147,7 @@ fn user_does_not_exist() -> Result<()> {
 
     let output = Command::new("sudo")
         .args(["-u", "ghost", "true"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/lecture.rs
+++ b/test-framework/sudo-compliance-tests/src/lecture.rs
@@ -16,7 +16,7 @@ fn default_lecture_shown_once() -> Result<()> {
         .args(["-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
     assert!(output.status().success());
 
     assert_contains!(output.stderr(), OG_SUDO_STANDARD_LECTURE);
@@ -25,7 +25,7 @@ fn default_lecture_shown_once() -> Result<()> {
         .as_user(USERNAME)
         .stdin(PASSWORD)
         .args(["-S", "echo", "Yeah!"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(second_sudo.status().success());
     assert_not_contains!(second_sudo.stderr(), OG_SUDO_STANDARD_LECTURE);
@@ -43,7 +43,7 @@ fn lecture_in_stderr() -> Result<()> {
         .args(["-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
     assert!(output.status().success());
 
     assert_contains!(output.stderr(), OG_SUDO_STANDARD_LECTURE);
@@ -67,7 +67,7 @@ fn lecture_always_shown() -> Result<()> {
         .as_user(USERNAME)
         .stdin(PASSWORD)
         .args(["-S", "true"])
-        .exec(&env)?;
+        .output(&env)?;
     assert!(!output.status().success());
 
     assert_contains!(output.stderr(), OG_SUDO_STANDARD_LECTURE);
@@ -76,7 +76,7 @@ fn lecture_always_shown() -> Result<()> {
         .as_user(USERNAME)
         .stdin(PASSWORD)
         .args(["-S", "ls"])
-        .exec(&env)?;
+        .output(&env)?;
     assert!(!output.status().success());
 
     assert_contains!(second_sudo.stderr(), OG_SUDO_STANDARD_LECTURE);
@@ -93,7 +93,7 @@ fn lecture_never_shown() -> Result<()> {
         .as_user(USERNAME)
         .stdin(PASSWORD)
         .args(["-S", "echo", "Yeah!"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(output.status().success());
     assert_not_contains!(output.stderr(), OG_SUDO_STANDARD_LECTURE);
@@ -110,7 +110,7 @@ fn negation_equals_never() -> Result<()> {
         .as_user(USERNAME)
         .stdin(PASSWORD)
         .args(["-S", "echo", "Yeah!"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(output.status().success());
     assert_not_contains!(output.stderr(), OG_SUDO_STANDARD_LECTURE);
@@ -131,7 +131,7 @@ fn double_negation_also_equals_never() -> Result<()> {
         .args(["-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(output.status().success());
     assert_not_contains!(output.stderr(), OG_SUDO_STANDARD_LECTURE);
@@ -148,7 +148,7 @@ fn root_user_lecture_not_shown() -> Result<()> {
         .as_user("root")
         .stdin(PASSWORD)
         .args(["-S", "true"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(output.status().success());
     assert_not_contains!(output.stderr(), OG_SUDO_STANDARD_LECTURE);
@@ -166,7 +166,7 @@ fn nopasswd_lecture_not_shown() -> Result<()> {
         .as_user(USERNAME)
         .stdin(PASSWORD)
         .args(["-S", "true"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(output.status().success());
     assert_not_contains!(output.stderr(), OG_SUDO_STANDARD_LECTURE);

--- a/test-framework/sudo-compliance-tests/src/lecture_file.rs
+++ b/test-framework/sudo-compliance-tests/src/lecture_file.rs
@@ -15,7 +15,7 @@ fn default_lecture_message() -> Result<()> {
         .args(["-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert_contains!(output.stderr(), OG_SUDO_STANDARD_LECTURE);
     Ok(())
@@ -34,7 +34,7 @@ fn new_lecture_message() -> Result<()> {
         .as_user(USERNAME)
         .stdin(PASSWORD)
         .args(["-S", "true"])
-        .exec(&env)?;
+        .output(&env)?;
     assert!(!output.status().success());
     assert_contains!(output.stderr(), "I <3 sudo");
     Ok(())
@@ -57,7 +57,7 @@ fn new_lecture_for_specific_user() -> Result<()> {
         .as_user(USERNAME)
         .stdin(PASSWORD)
         .args(["-S", "true"])
-        .exec(&env)?;
+        .output(&env)?;
     assert!(!output.status().success());
     assert_contains!(output.stderr(), "I <3 sudo");
     Ok(())
@@ -81,7 +81,7 @@ fn default_lecture_for_unspecified_user() -> Result<()> {
         .as_user("other_user")
         .stdin("other_password")
         .args(["-S", "true"])
-        .exec(&env)?;
+        .output(&env)?;
     assert!(!output.status().success());
     assert_contains!(output.stderr(), OG_SUDO_STANDARD_LECTURE);
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/misc.rs
@@ -20,7 +20,7 @@ fn user_not_in_passwd_database_cannot_use_sudo() -> Result<()> {
     let output = Command::new("sudo")
         .arg("true")
         .as_user_id(1000)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -46,7 +46,7 @@ fn closes_open_file_descriptors() -> Result<()> {
         )
         .build()?;
 
-    let output = Command::new("bash").arg(script_path).exec(&env)?;
+    let output = Command::new("bash").arg(script_path).output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -63,13 +63,13 @@ fn sudo_binary_lacks_setuid_flag() -> Result<()> {
 
     Command::new("chmod")
         .args(["0755", "/usr/bin/sudo"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -89,13 +89,13 @@ fn sudo_binary_is_not_owned_by_root() -> Result<()> {
 
     Command::new("chown")
         .args([USERNAME, "/usr/bin/sudo"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/nopasswd.rs
+++ b/test-framework/sudo-compliance-tests/src/nopasswd.rs
@@ -14,7 +14,7 @@ fn user_is_root() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -29,7 +29,7 @@ fn user_as_themselves() -> Result<()> {
     Command::new("sudo")
         .args(["-u", USERNAME, "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -43,7 +43,7 @@ fn user_as_their_own_group() -> Result<()> {
     Command::new("sudo")
         .args(["-g", GROUPNAME, "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -56,6 +56,6 @@ fn nopasswd_tag() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }

--- a/test-framework/sudo-compliance-tests/src/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/pam.rs
@@ -16,7 +16,7 @@ fn given_pam_permit_then_no_password_auth_required() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -31,7 +31,7 @@ fn given_pam_deny_then_password_auth_always_fails() -> Result<()> {
         .args(["-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -54,7 +54,7 @@ fn being_root_has_precedence_over_pam() -> Result<()> {
 
     Command::new("sudo")
         .args(["true"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -68,6 +68,6 @@ fn nopasswd_in_sudoers_has_precedence_over_pam() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }

--- a/test-framework/sudo-compliance-tests/src/pam/env.rs
+++ b/test-framework/sudo-compliance-tests/src/pam/env.rs
@@ -34,7 +34,7 @@ fn stock_pam_d_sudo() -> Result<()> {
     if sudo_test::is_original_sudo() {
         let pam_d_sudo = Command::new("cat")
             .arg(PAM_D_SUDO_PATH)
-            .exec(&env)?
+            .output(&env)?
             .stdout()?;
 
         assert_eq!(
@@ -50,13 +50,13 @@ fn stock_pam_d_sudo() -> Result<()> {
             .arg(format!(
                 "if [ -f {PAM_D_SUDO_PATH} ]; then exit 1; else exit 0; fi"
             ))
-            .exec(&env)?
+            .output(&env)?
             .stdout()?;
     }
 
     let security_pam_env = Command::new("cat")
         .arg(SECURITY_PAM_ENV_PATH)
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(
@@ -91,7 +91,7 @@ fn preserves_pam_env() -> Result<()> {
         )
         .build()?;
 
-    let stdout = Command::new("sudo").arg("env").exec(&env)?.stdout()?;
+    let stdout = Command::new("sudo").arg("env").output(&env)?.stdout()?;
     let env = helpers::parse_env_output(&stdout)?;
 
     assert_eq!(Some(set_value), env.get(set_name).copied());
@@ -128,7 +128,7 @@ fn pam_env_has_precedence_over_callers_env() -> Result<()> {
         .arg(format!("{default_name}=1"))
         .arg(format!("{override_name}=2"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let env = helpers::parse_env_output(&stdout)?;
 
@@ -170,7 +170,7 @@ fn env_list_has_precendece_over_pam_env(env_list: EnvList) -> Result<()> {
         .arg(format!("{default_name}={new_default_value}"))
         .arg(format!("{override_name}={new_override_value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let env = helpers::parse_env_output(&stdout)?;
 
@@ -224,7 +224,7 @@ fn var_rejected_by_env_check_falls_back_to_pam_env_value() -> Result<()> {
         .arg(format!("{default_name}={new_default_value}"))
         .arg(format!("{override_name}={new_override_value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let env = helpers::parse_env_output(&stdout)?;
 
@@ -257,7 +257,7 @@ fn default_and_override_pam_env_vars_are_parentheses_checked_but_set_vars_are_no
         )
         .build()?;
 
-    let stdout = Command::new("sudo").arg("env").exec(&env)?.stdout()?;
+    let stdout = Command::new("sudo").arg("env").output(&env)?.stdout()?;
     let env = helpers::parse_env_output(&stdout)?;
 
     assert_eq!(Some(set_value), env.get(set_name).copied());
@@ -292,7 +292,7 @@ fn pam_env_vars_are_not_env_checked() -> Result<()> {
     )
     .build()?;
 
-    let stdout = Command::new("sudo").arg("env").exec(&env)?.stdout()?;
+    let stdout = Command::new("sudo").arg("env").output(&env)?.stdout()?;
     let env = helpers::parse_env_output(&stdout)?;
 
     assert_eq!(Some(set_value), env.get(set_name).copied());

--- a/test-framework/sudo-compliance-tests/src/pass_auth/stdin.rs
+++ b/test-framework/sudo-compliance-tests/src/pass_auth/stdin.rs
@@ -15,7 +15,7 @@ fn correct_password() -> Result<()> {
         .args(["-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -29,7 +29,7 @@ fn incorrect_password() -> Result<()> {
         .args(["-S", "true"])
         .as_user(USERNAME)
         .stdin("incorrect-password")
-        .exec(&env)?;
+        .output(&env)?;
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
@@ -52,7 +52,7 @@ fn no_password() -> Result<()> {
     let output = Command::new("sudo")
         .args(["-S", "true"])
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
     assert_eq!(Some(1), output.status().code());
 
     let diagnostic = if sudo_test::is_original_sudo() {
@@ -77,7 +77,7 @@ fn longest_possible_password_works() -> Result<()> {
         .args(["-S", "true"])
         .stdin(password)
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -90,7 +90,7 @@ fn input_longer_than_max_pam_response_size_is_handled_gracefully() -> Result<()>
         .args(["-S", "true"])
         .stdin(input)
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -121,7 +121,7 @@ fn input_longer_than_password_should_not_be_accepted_as_correct_password() -> Re
             .args(["-S", "true"])
             .stdin(input)
             .as_user(USERNAME)
-            .exec(&env)?;
+            .output(&env)?;
 
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/pass_auth/tty.rs
+++ b/test-framework/sudo-compliance-tests/src/pass_auth/tty.rs
@@ -18,7 +18,7 @@ fn correct_password() -> Result<()> {
     Command::new("sshpass")
         .args(["-p", PASSWORD, "sudo", "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -31,7 +31,7 @@ fn incorrect_password() -> Result<()> {
     let output = Command::new("sshpass")
         .args(["-p", "incorrect-password", "sudo", "true"])
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
     assert!(!output.status().success());
 
     // `sshpass` will override sudo's exit code with the value 5 so we can't check this
@@ -53,7 +53,7 @@ fn no_tty() -> Result<()> {
     let output = Command::new("sudo")
         .args(["true"])
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
     assert_eq!(Some(1), output.status().code());
 
     let diagnostic = if sudo_test::is_original_sudo() {
@@ -77,7 +77,7 @@ fn longest_possible_password_works() -> Result<()> {
     Command::new("sshpass")
         .args(["-p", &password, "sudo", "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -95,7 +95,7 @@ fn input_longer_than_password_should_not_be_accepted_as_correct_password() -> Re
         let output = Command::new("sshpass")
             .args(["-p", &input, "sudo", "true"])
             .as_user(USERNAME)
-            .exec(&env)?;
+            .output(&env)?;
 
         assert!(!output.status().success());
         // `sshpass` will override sudo's exit code with the value 5 so we can't check this

--- a/test-framework/sudo-compliance-tests/src/password_retry.rs
+++ b/test-framework/sudo-compliance-tests/src/password_retry.rs
@@ -14,7 +14,7 @@ fn can_retry_password() -> Result<()> {
             "(echo wrong-password; echo {PASSWORD}) | sudo -S true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -30,7 +30,7 @@ fn three_retries_allowed_by_default() -> Result<()> {
             "(for i in $(seq 1 3); do echo wrong-password; done; echo {PASSWORD}) | sudo -S true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -76,7 +76,7 @@ Defaults passwd_tries=2"
             "(for i in $(seq 1 2); do echo wrong-password; done; echo {PASSWORD}) | sudo -S true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -130,7 +130,7 @@ fn time_password_retry(script_path: &str, env: Env) -> Result<u64> {
     let stdout = Command::new("sh")
         .arg(script_path)
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let timestamps = stdout
         .lines()
@@ -156,7 +156,7 @@ fn can_control_retry_delay_using_pam() -> Result<()> {
         .build()?;
     let common_auth = Command::new("cat")
         .arg("/etc/pam.d/common-auth")
-        .exec(&check_env)?
+        .output(&check_env)?
         .stdout()?;
     let common_auth = common_auth
         .lines()

--- a/test-framework/sudo-compliance-tests/src/path_search.rs
+++ b/test-framework/sudo-compliance-tests/src/path_search.rs
@@ -24,7 +24,7 @@ fn can_find_command_not_visible_to_regular_user() -> Result<()> {
     Command::new("sh")
         .args(["-c", "export PATH=/root; cd /; /usr/bin/sudo my-script"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())
@@ -39,7 +39,7 @@ fn when_path_is_unset_does_not_search_in_default_path_set_for_command_execution(
 
     let default_path = Command::new("sh")
         .args(["-c", "unset PATH; /usr/bin/sudo /usr/bin/printenv PATH"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     // sanity check that `/usr/bin` is in sudo's default PATH
@@ -48,7 +48,7 @@ fn when_path_is_unset_does_not_search_in_default_path_set_for_command_execution(
 
     let output = Command::new("sh")
         .args(["-c", "unset PATH; /usr/bin/sudo my-script"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -74,7 +74,7 @@ fn ignores_path_for_qualified_commands() -> Result<()> {
         Command::new("sh")
             .args(["-c", &format!("cd /root; sudo {param}")])
             .as_user("root")
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 

--- a/test-framework/sudo-compliance-tests/src/perms.rs
+++ b/test-framework/sudo-compliance-tests/src/perms.rs
@@ -15,7 +15,7 @@ fn user_can_read_file_owned_by_root() -> Result<()> {
     let actual = Command::new("sudo")
         .args(["cat", path])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     assert_eq!(expected, actual);
 
@@ -33,7 +33,7 @@ fn user_can_write_file_owned_by_root() -> Result<()> {
     Command::new("sudo")
         .args(["rm", path])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -55,6 +55,6 @@ exit 0"#,
     Command::new("sudo")
         .arg(path)
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }

--- a/test-framework/sudo-compliance-tests/src/sudo_ps1.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo_ps1.rs
@@ -9,15 +9,15 @@ fn ps1_env_var_is_set_when_sudo_ps1_is_set() -> Result<()> {
     let ps1 = "abc";
     let env = Env(SUDOERS_ROOT_ALL_NOPASSWD).build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     // run sudo in an empty environment
     let stdout = Command::new("env")
         .args(["-i", SUDO_RS_IS_UNSTABLE])
         .arg(format!("SUDO_PS1={ps1}"))
         .args([&sudo_abs_path, &env_abs_path])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -31,15 +31,15 @@ fn ps1_env_var_is_set_when_sudo_ps1_is_set() -> Result<()> {
 fn ps1_env_var_is_not_set_when_sudo_ps1_is_set_and_flag_login_is_used() -> Result<()> {
     let env = Env(SUDOERS_ROOT_ALL_NOPASSWD).build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     // run sudo in an empty environment
     let stdout = Command::new("env")
         .args(["-i", SUDO_RS_IS_UNSTABLE])
         .arg("SUDO_PS1=abc")
         .args([&sudo_abs_path, "-i", &env_abs_path])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -55,15 +55,15 @@ fn can_start_with_parentheses() -> Result<()> {
     let ps1 = "() abc";
     let env = Env(SUDOERS_ROOT_ALL_NOPASSWD).build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     // run sudo in an empty environment
     let stdout = Command::new("env")
         .args(["-i", SUDO_RS_IS_UNSTABLE])
         .arg(format!("SUDO_PS1={ps1}"))
         .args([&sudo_abs_path, &env_abs_path])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -84,7 +84,7 @@ fn preserved_when_in_env_list(env_list: &EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("SUDO_PS1={ps1}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -117,7 +117,7 @@ fn sudo_ps1_has_precedence_over_env_list_ps1(env_list: &EnvList) -> Result<()> {
         .arg(format!("PS1={ps1}"))
         .arg(format!("SUDO_PS1={sudo_ps1}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -145,7 +145,7 @@ fn ps1_is_set_even_if_sudo_ps1_fails_the_env_check_check() -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("SUDO_PS1={sudo_ps1}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -163,7 +163,7 @@ fn ps1_is_set_even_if_sudo_ps1_fails_the_env_keep_check() -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("SUDO_PS1={sudo_ps1}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 

--- a/test-framework/sudo-compliance-tests/src/sudoers.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers.rs
@@ -18,7 +18,7 @@ mod user_list;
 fn cannot_sudo_if_sudoers_file_is_world_writable() -> Result<()> {
     let env = Env(TextFile(SUDOERS_ROOT_ALL_NOPASSWD).chmod("446")).build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
     assert_eq!(Some(1), output.status().code());
 
     let diagnostic = if sudo_test::is_original_sudo() {
@@ -39,7 +39,7 @@ fn cannot_sudo_if_sudoers_file_is_group_writable() -> Result<()> {
     .user(User(USERNAME).password(PASSWORD))
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
     assert_eq!(Some(1), output.status().code());
 
     let diagnostic = if sudo_test::is_original_sudo() {
@@ -56,7 +56,7 @@ fn cannot_sudo_if_sudoers_file_is_group_writable() -> Result<()> {
 fn can_sudo_if_sudoers_file_is_owner_writable() -> Result<()> {
     let env = Env(TextFile(SUDOERS_ROOT_ALL_NOPASSWD).chmod("644")).build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
     assert_eq!(Some(0), output.status().code());
 
     Ok(())
@@ -68,7 +68,7 @@ fn cannot_sudo_if_sudoers_file_is_not_owned_by_root() -> Result<()> {
         .user(User(USERNAME).password(PASSWORD))
         .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
     assert_eq!(Some(1), output.status().code());
 
     let diagnostic = if sudo_test::is_original_sudo() {
@@ -93,7 +93,7 @@ fn user_specifications_evaluated_bottom_to_top() -> Result<()> {
     let output = Command::new("sudo")
         .args(["-S", "true"])
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
@@ -108,7 +108,7 @@ fn user_specifications_evaluated_bottom_to_top() -> Result<()> {
         .args(["-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -120,6 +120,6 @@ fn accepts_sudoers_file_that_has_no_trailing_newline() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }

--- a/test-framework/sudo-compliance-tests/src/sudoers/cmnd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/cmnd.rs
@@ -23,7 +23,7 @@ fn given_specific_command_then_that_command_is_allowed() -> Result<()> {
 
     Command::new("sudo")
         .arg("/bin/true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -31,7 +31,7 @@ fn given_specific_command_then_that_command_is_allowed() -> Result<()> {
 fn given_specific_command_then_other_command_is_not_allowed() -> Result<()> {
     let env = Env("ALL ALL=(ALL:ALL) /bin/ls").build()?;
 
-    let output = Command::new("sudo").arg("/bin/true").exec(&env)?;
+    let output = Command::new("sudo").arg("/bin/true").output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -58,7 +58,7 @@ fn given_specific_command_with_nopasswd_tag_then_no_password_auth_is_required() 
     Command::new("sudo")
         .arg("/bin/true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -66,7 +66,7 @@ fn given_specific_command_with_nopasswd_tag_then_no_password_auth_is_required() 
 fn command_specified_not_by_absolute_path_is_rejected() -> Result<()> {
     let env = Env("ALL ALL=(ALL:ALL) true").build()?;
 
-    let output = Command::new("sudo").arg("/bin/true").exec(&env)?;
+    let output = Command::new("sudo").arg("/bin/true").output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -90,12 +90,12 @@ fn different() -> Result<()> {
 
     Command::new("sudo")
         .arg("/bin/true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = Command::new("sudo")
         .args(["/bin/ls", "/root"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!("", output);
@@ -113,7 +113,7 @@ fn nopasswd_is_sticky() -> Result<()> {
     Command::new("sudo")
         .arg("/bin/true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -123,7 +123,7 @@ fn repeated() -> Result<()> {
 
     Command::new("sudo")
         .arg("/bin/true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -136,7 +136,7 @@ fn nopasswd_override() -> Result<()> {
     Command::new("sudo")
         .arg("/bin/true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -148,14 +148,14 @@ fn runas_override() -> Result<()> {
 
     let stdout = Command::new("sudo")
         .args(["/bin/ls", "/root"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!("", stdout);
 
     let output = Command::new("sudo")
         .args(["-u", USERNAME, "/bin/ls"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -169,10 +169,10 @@ fn runas_override() -> Result<()> {
 
     Command::new("sudo")
         .args(["-u", "ferris", "/bin/true"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
-    let output = Command::new("sudo").args(["/bin/true"]).exec(&env)?;
+    let output = Command::new("sudo").args(["/bin/true"]).output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -197,12 +197,12 @@ fn runas_override_repeated_cmnd_means_runas_union() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Command::new("sudo")
         .args(["-u", USERNAME, "true"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/cmnd_alias.rs
@@ -24,7 +24,7 @@ fn cmnd_alias_works() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -40,7 +40,7 @@ fn cmnd_alias_nopasswd() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -54,7 +54,7 @@ fn cmnd_alias_can_contain_underscore_and_digits() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -69,7 +69,7 @@ fn cmnd_alias_cannot_start_with_underscore() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -81,7 +81,7 @@ fn unlisted_cmnd_fails() -> Result<()> {
     ])
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
 
@@ -106,7 +106,7 @@ fn command_specified_not_by_absolute_path_is_rejected() -> Result<()> {
     ])
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -132,7 +132,7 @@ fn command_alias_negation() -> Result<()> {
     ])
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
 
@@ -159,7 +159,7 @@ fn combined_cmnd_aliases() -> Result<()> {
     ])
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
     let stderr = output.stderr();
@@ -172,7 +172,7 @@ fn combined_cmnd_aliases() -> Result<()> {
         );
     }
 
-    let second_output = Command::new("sudo").arg("ls").exec(&env)?;
+    let second_output = Command::new("sudo").arg("ls").output(&env)?;
 
     assert!(second_output.status().success());
 
@@ -189,7 +189,7 @@ fn double_negation() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -205,10 +205,10 @@ fn negation_not_order_sensitive() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
-    let output = Command::new("sudo").arg("ls").exec(&env)?;
+    let output = Command::new("sudo").arg("ls").output(&env)?;
     assert!(!output.status().success());
 
     let stderr = output.stderr();
@@ -235,11 +235,11 @@ fn negation_combination() -> Result<()> {
     ])
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(output.status().success());
 
-    let second_output = Command::new("sudo").arg("ls").exec(&env)?;
+    let second_output = Command::new("sudo").arg("ls").output(&env)?;
 
     assert!(second_output.status().success());
 
@@ -257,7 +257,7 @@ fn another_negation_combination() -> Result<()> {
     ])
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
 
@@ -271,7 +271,7 @@ fn another_negation_combination() -> Result<()> {
         );
     }
 
-    let second_output = Command::new("sudo").arg("ls").exec(&env)?;
+    let second_output = Command::new("sudo").arg("ls").output(&env)?;
 
     assert!(second_output.status().success());
 
@@ -289,7 +289,7 @@ fn one_more_negation_combination() -> Result<()> {
     ])
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
 
@@ -303,7 +303,7 @@ fn one_more_negation_combination() -> Result<()> {
         );
     }
 
-    let second_output = Command::new("sudo").arg("ls").exec(&env)?;
+    let second_output = Command::new("sudo").arg("ls").output(&env)?;
 
     assert!(second_output.status().success());
 
@@ -320,7 +320,7 @@ fn tripple_negation_combination() -> Result<()> {
     ])
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
 
@@ -334,7 +334,7 @@ fn tripple_negation_combination() -> Result<()> {
         );
     }
 
-    let second_output = Command::new("sudo").arg("ls").exec(&env)?;
+    let second_output = Command::new("sudo").arg("ls").output(&env)?;
 
     assert!(!second_output.status().success());
 
@@ -360,11 +360,11 @@ fn comma_listing_works() -> Result<()> {
     ])
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(output.status().success());
 
-    let second_output = Command::new("sudo").arg("ls").exec(&env)?;
+    let second_output = Command::new("sudo").arg("ls").output(&env)?;
 
     assert!(second_output.status().success());
 
@@ -383,13 +383,13 @@ fn runas_override() -> Result<()> {
 
     let stdout = Command::new("sudo")
         .args(["/usr/bin/ls", "/root"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     assert_eq!("", stdout);
 
     let output = Command::new("sudo")
         .args(["-u", "ferris", "/usr/bin/ls"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -406,10 +406,10 @@ fn runas_override() -> Result<()> {
 
     Command::new("sudo")
         .args(["-u", "ferris", "/usr/bin/true"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
-    let second_output = Command::new("sudo").args(["/usr/bin/true"]).exec(&env)?;
+    let second_output = Command::new("sudo").args(["/usr/bin/true"]).output(&env)?;
 
     assert!(!second_output.status().success());
     assert_eq!(Some(1), second_output.status().code());
@@ -439,12 +439,12 @@ fn runas_override_repeated_cmnd_means_runas_union() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Command::new("sudo")
         .args(["-u", "ferris", "true"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/sudoers/cwd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/cwd.rs
@@ -9,7 +9,7 @@ fn sets_the_working_directory_of_the_executed_command() -> Result<()> {
 
     let stdout = Command::new("sh")
         .args(["-c", "cd /; sudo pwd"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(expected_path, stdout);
@@ -25,7 +25,7 @@ fn glob_has_no_effect_on_its_own() -> Result<()> {
     let stdout = Command::new("sh")
         .arg("-c")
         .arg(format!("cd {expected_path}; sudo pwd"))
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(expected_path, stdout);
@@ -39,7 +39,7 @@ fn non_absolute_path_is_rejected() -> Result<()> {
 
     let output = Command::new("sh")
         .args(["-c", "cd /; sudo pwd"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -60,7 +60,7 @@ fn dot_slash_is_rejected() -> Result<()> {
 
     let output = Command::new("sh")
         .args(["-c", "cd /; sudo pwd"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -82,7 +82,7 @@ fn tilde_when_target_user_is_root() -> Result<()> {
 
     let stdout = Command::new("sh")
         .args(["-c", "cd /; sudo pwd"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!("/root", stdout);
@@ -100,7 +100,7 @@ fn tilde_when_target_user_is_regular_user() -> Result<()> {
     let stdout = Command::new("sh")
         .arg("-c")
         .arg(format!("cd /; sudo -u {USERNAME} pwd"))
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     assert_eq!(format!("/home/{USERNAME}"), stdout);
@@ -119,7 +119,7 @@ fn tilde_username() -> Result<()> {
         let stdout = Command::new("sh")
             .arg("-c")
             .arg(format!("cd /; sudo -u {target_user} pwd"))
-            .exec(&env)?
+            .output(&env)?
             .stdout()?;
 
         assert_eq!(format!("/home/{USERNAME}"), stdout);
@@ -135,7 +135,7 @@ fn path_does_not_exist() -> Result<()> {
     let output = Command::new("sh")
         .arg("-c")
         .arg("cd /; sudo pwd")
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -155,7 +155,7 @@ fn path_is_file() -> Result<()> {
     let output = Command::new("sh")
         .arg("-c")
         .arg("cd /; sudo pwd")
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -178,7 +178,7 @@ fn target_user_has_insufficient_permissions() -> Result<()> {
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!("cd /; sudo -u {USERNAME} pwd"))
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/sudoers/env.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/env.rs
@@ -36,7 +36,7 @@ fn var_in_both_lists_is_preserved() -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{name}={value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -55,7 +55,7 @@ fn var_in_both_lists_is_preserved() -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{name}={value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -78,7 +78,7 @@ fn checks_applied_if_in_both_lists() -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{name}={value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -97,7 +97,7 @@ fn checks_applied_if_in_both_lists() -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{name}={value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -124,7 +124,7 @@ fn unchecked_tz() -> Result<()> {
         let stdout = Command::new("env")
             .arg(format!("{TZ}={value}"))
             .args(["sudo", "env"])
-            .exec(&env)?
+            .output(&env)?
             .stdout()?;
         let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -145,7 +145,7 @@ fn equal_single(env_list: EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{env_name}={env_val}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -169,7 +169,7 @@ fn equal_multiple(env_list: EnvList) -> Result<()> {
         .arg(format!("{env_name1}={env_val1}"))
         .arg(format!("{env_name2}={env_val2}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -191,7 +191,7 @@ fn equal_repeated(env_list: EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{env_name}={env_val}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -216,7 +216,7 @@ fn equal_overrides(env_list: EnvList) -> Result<()> {
         .arg(format!("{env_name1}={env_val1}"))
         .arg(format!("{env_name2}={env_val2}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -238,7 +238,7 @@ fn plus_equal_on_empty_set(env_list: EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{env_name}={env_value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -263,7 +263,7 @@ fn plus_equal_appends(env_list: EnvList) -> Result<()> {
         .arg(format!("{env_name1}={env_val1}"))
         .arg(format!("{env_name2}={env_val2}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -286,7 +286,7 @@ fn plus_equal_repeated(env_list: EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{env_name}={env_val}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -316,7 +316,7 @@ fn vars_with_target_user_specific_values(env_list: EnvList) -> Result<()> {
         .arg(format!("MAIL={mail}"))
         .arg(format!("USER={user}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -342,7 +342,7 @@ fn sudo_env_vars(env_list: EnvList) -> Result<()> {
         .arg("SUDO_UID=uid")
         .arg("SUDO_USER=user")
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -365,7 +365,7 @@ fn user_set_to_preserved_logname_value(env_list: EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("LOGNAME={value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -386,7 +386,7 @@ fn logname_set_to_preserved_user_value(env_list: EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("USER={value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -408,7 +408,7 @@ fn if_value_starts_with_parentheses_variable_is_removed(env_list: EnvList) -> Re
     let stdout = Command::new("env")
         .arg(format!("{env_name}={env_val}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -429,7 +429,7 @@ fn key_value_matches(env_list: EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{env_name}={env_val}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -450,7 +450,7 @@ fn key_value_no_match(env_list: EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{env_name}=different-value"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -473,7 +473,7 @@ fn key_value_syntax_needs_double_quotes(env_list: EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{env_name}={env_val}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -495,7 +495,7 @@ fn key_value_where_value_is_parentheses_glob(env_list: EnvList) -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{env_name}={env_val}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -520,7 +520,7 @@ fn minus_equal_removes(env_list: EnvList) -> Result<()> {
         .arg(format!("{env_name1}={env_val1}"))
         .arg(format!("{env_name2}={env_val2}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -542,7 +542,7 @@ fn minus_equal_an_element_not_in_the_list_is_not_an_error(env_list: EnvList) -> 
     let output = Command::new("env")
         .arg(format!("{env_name}={env_val}"))
         .args(["sudo", "env"])
-        .exec(&env)?;
+        .output(&env)?;
 
     // no diagnostics in this case
     assert!(output.stderr().is_empty());
@@ -571,7 +571,7 @@ fn bang_clears_the_whole_list(env_list: EnvList) -> Result<()> {
         .arg(format!("{env_name1}={env_val1}"))
         .arg(format!("{env_name2}={env_val2}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -599,7 +599,7 @@ fn can_append_after_bang(env_list: EnvList) -> Result<()> {
         .arg(format!("{env_name1}={env_val1}"))
         .arg(format!("{env_name2}={env_val2}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -627,7 +627,7 @@ fn can_override_after_bang(env_list: EnvList) -> Result<()> {
         .arg(format!("{env_name1}={env_val1}"))
         .arg(format!("{env_name2}={env_val2}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -657,7 +657,7 @@ fn wildcard_works(env_list: EnvList) -> Result<()> {
         .arg(format!("{kept_name2}={kept_value2}"))
         .arg(format!("{discarded_name}={discarded_value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -689,7 +689,7 @@ fn double_wildcard_is_ok(env_list: EnvList) -> Result<()> {
         .arg(format!("{kept_name2}={kept_value2}"))
         .arg(format!("{discarded_name}={discarded_value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -718,7 +718,7 @@ fn minus_equal_can_remove_wildcard(env_list: EnvList) -> Result<()> {
         .arg(format!("{name1}={value1}"))
         .arg(format!("{name2}={value2}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -748,7 +748,7 @@ fn accepts_uncommon_var_names(env_list: EnvList) -> Result<()> {
         .arg(format!("{name2}={value2}"))
         .arg(format!("{name3}={value3}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -779,7 +779,7 @@ fn skips_invalid_variable_names(env_list: EnvList) -> Result<()> {
         .arg(format!("{discarded_name1}={discarded_value1}"))
         .arg(format!("{discarded_name2}={discarded_value2}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;

--- a/test-framework/sudo-compliance-tests/src/sudoers/env/check.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/env/check.rs
@@ -146,8 +146,8 @@ fn skips_invalid_variable_names() -> Result<()> {
 fn equal_can_disable_preservation_of_vars_term_but_not_display_path() -> Result<()> {
     let env = Env([SUDOERS_ALL_ALL_NOPASSWD, "Defaults env_check = WHATEVER"]).build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     let display = "some-display";
     let path = "some-path";
@@ -156,7 +156,7 @@ fn equal_can_disable_preservation_of_vars_term_but_not_display_path() -> Result<
         .arg(format!("DISPLAY={display}"))
         .arg("TERM=some-term")
         .args([sudo_abs_path, env_abs_path])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -179,8 +179,8 @@ fn minus_equal_can_disable_preservation_of_vars_term_but_not_display_path() -> R
     ])
     .build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     let display = "some-display";
     let path = "some-path";
@@ -189,7 +189,7 @@ fn minus_equal_can_disable_preservation_of_vars_term_but_not_display_path() -> R
         .arg(format!("DISPLAY={display}"))
         .arg("TERM=some-term")
         .args([sudo_abs_path, env_abs_path])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -208,8 +208,8 @@ fn minus_equal_can_disable_preservation_of_vars_term_but_not_display_path() -> R
 fn bang_can_disable_preservation_of_vars_term_but_not_display_path() -> Result<()> {
     let env = Env([SUDOERS_ALL_ALL_NOPASSWD, "Defaults !env_check"]).build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     let display = "some-display";
     let path = "some-path";
@@ -218,7 +218,7 @@ fn bang_can_disable_preservation_of_vars_term_but_not_display_path() -> Result<(
         .arg(format!("DISPLAY={display}"))
         .arg("TERM=some-term")
         .args([sudo_abs_path, env_abs_path])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -249,7 +249,7 @@ fn vars_not_preserved_if_they_fail_checks() -> Result<()> {
         .arg(format!("{env_name1}={env_val1}"))
         .arg(format!("{env_name2}={env_val2}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -296,7 +296,7 @@ fn good_tz() -> Result<()> {
         let stdout = Command::new("env")
             .arg(format!("{TZ}={value}"))
             .args(["sudo", "env"])
-            .exec(&env)?
+            .output(&env)?
             .stdout()?;
         let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -331,7 +331,7 @@ fn bad_tz() -> Result<()> {
         let stdout = Command::new("env")
             .arg(format!("{TZ}={value}"))
             .args(["sudo", "env"])
-            .exec(&env)?
+            .output(&env)?
             .stdout()?;
         let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -349,7 +349,7 @@ fn tz_is_in_default_list() -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{TZ}={value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 
@@ -359,7 +359,7 @@ fn tz_is_in_default_list() -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{TZ}={value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 

--- a/test-framework/sudo-compliance-tests/src/sudoers/env/keep.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/env/keep.rs
@@ -144,8 +144,8 @@ fn skips_invalid_variable_names() -> Result<()> {
 fn equal_can_disable_preservation_of_vars_display_path_but_not_term() -> Result<()> {
     let env = Env([SUDOERS_ALL_ALL_NOPASSWD, "Defaults env_keep = WHATEVER"]).build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     let term = "some-term";
     let stdout = Command::new("env")
@@ -153,7 +153,7 @@ fn equal_can_disable_preservation_of_vars_display_path_but_not_term() -> Result<
         .arg("DISPLAY=some-display")
         .arg(format!("TERM={term}"))
         .args([sudo_abs_path, env_abs_path])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -176,8 +176,8 @@ fn minus_equal_can_disable_preservation_of_vars_display_path_but_not_term() -> R
     ])
     .build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     let term = "some-term";
     let stdout = Command::new("env")
@@ -185,7 +185,7 @@ fn minus_equal_can_disable_preservation_of_vars_display_path_but_not_term() -> R
         .arg("DISPLAY=some-display")
         .arg(format!("TERM={term}"))
         .args([sudo_abs_path, env_abs_path])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -204,8 +204,8 @@ fn minus_equal_can_disable_preservation_of_vars_display_path_but_not_term() -> R
 fn bang_can_disable_preservation_of_vars_display_path_but_not_term() -> Result<()> {
     let env = Env([SUDOERS_ALL_ALL_NOPASSWD, "Defaults !env_keep"]).build()?;
 
-    let sudo_abs_path = Command::new("which").arg("sudo").exec(&env)?.stdout()?;
-    let env_abs_path = Command::new("which").arg("env").exec(&env)?.stdout()?;
+    let sudo_abs_path = Command::new("which").arg("sudo").output(&env)?.stdout()?;
+    let env_abs_path = Command::new("which").arg("env").output(&env)?.stdout()?;
 
     let term = "some-term";
     let stdout = Command::new("env")
@@ -213,7 +213,7 @@ fn bang_can_disable_preservation_of_vars_display_path_but_not_term() -> Result<(
         .arg("DISPLAY=some-display")
         .arg(format!("TERM={term}"))
         .args([sudo_abs_path, env_abs_path])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let sudo_env = helpers::parse_env_output(&stdout)?;
@@ -241,7 +241,7 @@ fn checks_not_applied() -> Result<()> {
     let stdout = Command::new("env")
         .arg(format!("{name}={value}"))
         .args(["sudo", "env"])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
     let sudo_env = helpers::parse_env_output(&stdout)?;
 

--- a/test-framework/sudo-compliance-tests/src/sudoers/host_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/host_alias.rs
@@ -24,7 +24,7 @@ fn host_alias_works() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -38,7 +38,7 @@ fn host_alias_can_contain_underscore_and_digits() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())
@@ -55,7 +55,7 @@ fn host_alias_cannot_start_with_underscore() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())
@@ -70,7 +70,7 @@ fn host_alias_negation() -> Result<()> {
     .hostname("mail")
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
 
@@ -98,7 +98,7 @@ fn host_alias_double_negation() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -113,7 +113,7 @@ fn combined_host_aliases() -> Result<()> {
     .hostname("foo")
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
     assert!(output.status().success());
 
     let second_env = Env([
@@ -125,7 +125,7 @@ fn combined_host_aliases() -> Result<()> {
     .hostname("mail")
     .build()?;
 
-    let second_output = Command::new("sudo").arg("true").exec(&second_env)?;
+    let second_output = Command::new("sudo").arg("true").output(&second_env)?;
     assert!(!second_output.status().success());
     let stderr = second_output.stderr();
     if sudo_test::is_original_sudo() {
@@ -151,7 +151,7 @@ fn unlisted_host_fails() -> Result<()> {
     .hostname("not_listed")
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
 
@@ -179,7 +179,7 @@ fn negation_not_order_sensitive() -> Result<()> {
     .hostname("mail")
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
 
@@ -208,7 +208,7 @@ fn negation_combination() -> Result<()> {
     .hostname("mail")
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(output.status().success());
 
@@ -226,7 +226,7 @@ fn comma_listing_works() -> Result<()> {
     .hostname("foo")
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(output.status().success());
     let second_env = Env([
@@ -238,7 +238,7 @@ fn comma_listing_works() -> Result<()> {
     .hostname("mail")
     .build()?;
 
-    let second_output = Command::new("sudo").arg("true").exec(&second_env)?;
+    let second_output = Command::new("sudo").arg("true").output(&second_env)?;
 
     assert!(second_output.status().success());
 

--- a/test-framework/sudo-compliance-tests/src/sudoers/host_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/host_list.rs
@@ -22,7 +22,7 @@ fn given_specific_hostname_then_sudo_from_said_hostname_is_allowed() -> Result<(
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -32,7 +32,7 @@ fn given_specific_hostname_then_sudo_from_different_hostname_is_rejected() -> Re
         .hostname("container")
         .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -58,7 +58,7 @@ fn different() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -70,7 +70,7 @@ fn repeated() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -80,7 +80,7 @@ fn negation_rejects() -> Result<()> {
         .hostname("container")
         .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -106,7 +106,7 @@ fn double_negative_is_positive() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -118,6 +118,6 @@ fn longest_hostname() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }

--- a/test-framework/sudo-compliance-tests/src/sudoers/run_as.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/run_as.rs
@@ -28,7 +28,7 @@ fn when_empty_then_implicit_as_self_is_allowed() -> Result<()> {
         Command::new("sudo")
             .args(["true"])
             .as_user(user)
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 
@@ -43,7 +43,7 @@ fn when_empty_then_explicit_as_self_is_allowed() -> Result<()> {
         Command::new("sudo")
             .args(["-u", user, "true"])
             .as_user(user)
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 
@@ -56,7 +56,7 @@ fn when_empty_then_as_someone_else_is_not_allowed() -> Result<()> {
 
     let output = Command::new("sudo")
         .args(["-u", USERNAME, "true"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -85,7 +85,7 @@ fn when_empty_then_as_own_group_is_allowed() -> Result<()> {
         Command::new("sudo")
             .args(["-g", user, "true"])
             .as_user(user)
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 
@@ -102,7 +102,7 @@ fn when_specific_user_then_as_that_user_is_allowed() -> Result<()> {
         Command::new("sudo")
             .args(["-u", USERNAME, "true"])
             .as_user(user)
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 
@@ -118,7 +118,7 @@ fn when_specific_user_then_as_a_different_user_is_not_allowed() -> Result<()> {
 
     let output = Command::new("sudo")
         .args(["-u", "ghost", "true"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -140,7 +140,7 @@ fn when_specific_user_then_as_a_different_user_is_not_allowed() -> Result<()> {
 fn when_specific_user_then_as_self_is_not_allowed() -> Result<()> {
     let env = Env(format!("ALL ALL=({USERNAME}) NOPASSWD: ALL")).build()?;
 
-    let output = Command::new("sudo").args(["true"]).exec(&env)?;
+    let output = Command::new("sudo").args(["true"]).output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -176,7 +176,7 @@ fn when_only_user_is_specified_then_group_flag_is_not_allowed() -> Result<()> {
         let output = Command::new("sudo")
             .args(["-g", GROUPNAME, "true"])
             .as_user(user)
-            .exec(&env)?;
+            .output(&env)?;
 
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());
@@ -203,7 +203,7 @@ fn when_specific_group_then_as_that_group_is_allowed() -> Result<()> {
         Command::new("sudo")
             .args(["-g", GROUPNAME, "true"])
             .as_user(user)
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 
@@ -224,7 +224,7 @@ fn when_specific_group_then_as_a_different_group_is_not_allowed() -> Result<()> 
         let output = Command::new("sudo")
             .args(["-g", "ghosts", "true"])
             .as_user(user)
-            .exec(&env)?;
+            .output(&env)?;
 
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());
@@ -257,7 +257,7 @@ fn when_only_group_is_specified_then_as_some_user_is_not_allowed() -> Result<()>
         let output = Command::new("sudo")
             .args(["-u", "ghost", "true"])
             .as_user(user)
-            .exec(&env)?;
+            .output(&env)?;
 
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());
@@ -288,7 +288,7 @@ fn when_both_user_and_group_are_specified_then_as_that_user_is_allowed() -> Resu
         Command::new("sudo")
             .args(["-u", USERNAME, "true"])
             .as_user(user)
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 
@@ -307,7 +307,7 @@ fn when_both_user_and_group_are_specified_then_as_that_group_is_allowed() -> Res
         Command::new("sudo")
             .args(["-g", GROUPNAME, "true"])
             .as_user(user)
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 
@@ -323,7 +323,7 @@ fn when_no_run_as_spec_then_target_user_can_be_root() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -333,7 +333,7 @@ fn when_no_run_as_spec_then_target_user_cannot_be_a_regular_user() -> Result<()>
 
     let output = Command::new("sudo")
         .args(["-u", USERNAME, "true"])
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -360,7 +360,7 @@ fn when_no_run_as_spec_then_a_target_group_may_be_specified() -> Result<()> {
     let output = Command::new("sudo")
         .args(["-u", "root", "-g", GROUPNAME, "groups"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     let mut actual = output.split_ascii_whitespace().collect::<HashSet<_>>();
@@ -386,7 +386,7 @@ fn when_both_user_and_group_are_specified_then_as_that_user_with_that_group_is_a
     Command::new("sudo")
         .args(["-u", "otheruser", "-g", GROUPNAME, "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/sudoers/runas_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/runas_alias.rs
@@ -29,13 +29,13 @@ fn runas_alias_works() -> Result<()> {
             .args(["-u", "root", "-S", "true"])
             .as_user(user)
             .stdin(PASSWORD)
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
     Command::new("sudo")
         .args(["-S", "true"])
         .as_user("root")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())
@@ -56,7 +56,7 @@ fn underscore() -> Result<()> {
             .args(["-u", "root", "-S", "true"])
             .as_user(user)
             .stdin(PASSWORD)
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 
@@ -78,7 +78,7 @@ fn runas_alias_negation() -> Result<()> {
         .args(["-u", "root", "-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -110,7 +110,7 @@ fn negation_on_user() -> Result<()> {
         .args(["-u", "root", "-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -142,7 +142,7 @@ fn double_negation() -> Result<()> {
             .args(["-u", "root", "-S", "true"])
             .as_user(user)
             .stdin(PASSWORD)
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 
@@ -164,7 +164,7 @@ fn when_specific_user_then_as_a_different_user_is_not_allowed() -> Result<()> {
         .args(["-u", "ghost", "-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -202,7 +202,7 @@ fn alias_for_group() -> Result<()> {
     Command::new("sudo")
         .args(["-g", GROUPNAME, "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())
@@ -223,14 +223,14 @@ fn when_only_groupname_is_given_user_arg_fails() -> Result<()> {
     Command::new("sudo")
         .args(["-g", GROUPNAME, "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = Command::new("sudo")
         .args(["-u", "otheruser", "-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -263,14 +263,14 @@ fn when_only_username_is_given_group_arg_fails() -> Result<()> {
     Command::new("sudo")
         .args(["-u", "otheruser", "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = Command::new("sudo")
         .args(["-g", GROUPNAME, "-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -303,13 +303,13 @@ fn user_and_group_works_when_one_is_passed_as_arg() -> Result<()> {
     Command::new("sudo")
         .args(["-u", "otheruser", "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Command::new("sudo")
         .args(["-g", GROUPNAME, "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())
@@ -332,7 +332,7 @@ fn user_and_group_fails_when_both_are_passed() -> Result<()> {
         .args(["-u", "otheruser", "-g", GROUPNAME, "-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -366,13 +366,13 @@ fn different_aliases_user_and_group_works_when_one_is_passed_as_arg() -> Result<
     Command::new("sudo")
         .args(["-u", "otheruser", "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Command::new("sudo")
         .args(["-g", GROUPNAME, "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())
@@ -396,7 +396,7 @@ fn different_aliases_user_and_group_fails_when_both_are_passed() -> Result<()> {
         .args(["-u", "otheruser", "-g", GROUPNAME, "-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -428,13 +428,13 @@ fn aliases_given_on_one_line_divided_by_colon() -> Result<()> {
     Command::new("sudo")
         .args(["-u", "otheruser", "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Command::new("sudo")
         .args(["-g", "ghost", "true"])
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/sudoers/secure_path.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/secure_path.rs
@@ -22,7 +22,7 @@ fn if_unset_searches_program_in_invoking_users_path() -> Result<()> {
 
     Command::new("sh")
         .args(["-c", "export PATH=/root; cd /; /usr/bin/sudo my-script"])
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())
@@ -56,7 +56,7 @@ ALL ALL=(ALL:ALL) NOPASSWD: ALL")
 
         Command::new("sh")
             .args(["-c", script])
-            .exec(&env)?
+            .output(&env)?
             .assert_success()?;
     }
 
@@ -70,7 +70,7 @@ fn if_set_it_does_not_search_in_original_user_path() -> Result<()> {
 ALL ALL=(ALL:ALL) NOPASSWD: ALL")
     .build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -103,7 +103,7 @@ ALL ALL=(ALL:ALL) NOPASSWD: ALL"
 
         let path = Command::new("sh")
             .args(["-c", script])
-            .exec(&env)?
+            .output(&env)?
             .stdout()?;
 
         assert_eq!(secure_path, &path);

--- a/test-framework/sudo-compliance-tests/src/sudoers/timestamp_timeout.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/timestamp_timeout.rs
@@ -21,7 +21,7 @@ Defaults timestamp_timeout=0.1"
             "echo {PASSWORD} | sudo -S true; sleep 10; sudo true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -52,7 +52,7 @@ Defaults timestamp_timeout=0"
         .arg("-c")
         .arg(format!("echo {PASSWORD} | sudo -S true; sudo true"))
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
@@ -20,7 +20,7 @@ macro_rules! assert_snapshot {
 fn no_match() -> Result<()> {
     let env = Env("").build()?;
 
-    let output = Command::new("sudo").arg("true").exec(&env)?;
+    let output = Command::new("sudo").arg("true").output(&env)?;
     assert_eq!(Some(1), output.status().code());
 
     let stderr = output.stderr();
@@ -44,13 +44,13 @@ fn all() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -60,7 +60,7 @@ fn user_name() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -70,7 +70,7 @@ fn user_id() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -80,7 +80,7 @@ fn group_name() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -90,7 +90,7 @@ fn group_id() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -102,13 +102,13 @@ fn many_different() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -118,7 +118,7 @@ fn many_repeated() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -130,7 +130,7 @@ fn double_negative_is_positive() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -147,13 +147,13 @@ fn negation_excludes_group_members() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user("ferris")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = Command::new("sudo")
         .arg("true")
         .as_user("ghost")
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -183,13 +183,13 @@ fn negation_is_order_sensitive() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user("ferris")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Command::new("sudo")
         .arg("true")
         .as_user("ghost")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -210,13 +210,13 @@ fn user_alias_works() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user("ferris")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = Command::new("sudo")
         .arg("true")
         .as_user("ghost")
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -246,7 +246,7 @@ fn user_alias_can_contain_underscore_and_digits() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())
@@ -265,7 +265,7 @@ fn user_alias_cannot_start_with_underscore() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     Ok(())
@@ -287,13 +287,13 @@ User_Alias ADMINS = %users, !ghost
     Command::new("sudo")
         .arg("true")
         .as_user("ghost")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = Command::new("sudo")
         .arg("true")
         .as_user("ferris")
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -322,13 +322,13 @@ fn negated_subgroup() -> Result<()> {
     Command::new("sudo")
         .arg("true")
         .as_user("ghost")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = Command::new("sudo")
         .arg("true")
         .as_user("ferris")
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -352,7 +352,10 @@ fn negated_supergroup() -> Result<()> {
         .build()?;
 
     for user in ["ferris", "ghost"] {
-        let output = Command::new("sudo").arg("true").as_user(user).exec(&env)?;
+        let output = Command::new("sudo")
+            .arg("true")
+            .as_user(user)
+            .output(&env)?;
 
         assert!(!output.status().success());
         assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/syslog.rs
+++ b/test-framework/sudo-compliance-tests/src/syslog.rs
@@ -19,7 +19,7 @@ impl<'a> Rsyslogd<'a> {
         Command::new("sh")
             .arg("-c")
             .arg(format!("[ ! -f {path} ] || cat {path}"))
-            .exec(self.env)?
+            .output(self.env)?
             .stdout()
     }
 }
@@ -29,7 +29,7 @@ impl Drop for Rsyslogd<'_> {
         // need to kill the daemon or `Env::drop` won't properly `stop` the docker container
         let _ = Command::new("sh")
             .args(["-c", "kill -9 $(pidof rsyslogd)"])
-            .exec(self.env);
+            .output(self.env);
     }
 }
 
@@ -43,7 +43,7 @@ fn rsyslogd_works() -> Result<()> {
 
     Command::new("useradd")
         .arg("ferris")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let auth_log = rsyslog.auth_log()?;
@@ -63,7 +63,7 @@ fn sudo_logs_every_executed_command() -> Result<()> {
 
     Command::new("sudo")
         .arg("true")
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let auth_log = rsyslog.auth_log()?;
@@ -83,7 +83,7 @@ fn sudo_logs_every_failed_authentication_attempt() -> Result<()> {
     let output = Command::new("sudo")
         .args(["-S", "true"])
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
 

--- a/test-framework/sudo-compliance-tests/src/timestamp.rs
+++ b/test-framework/sudo-compliance-tests/src/timestamp.rs
@@ -18,7 +18,7 @@ fn credential_caching_works() -> Result<()> {
         .arg("-c")
         .arg(format!("set -e; echo {PASSWORD} | sudo -S true; sudo true"))
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -32,13 +32,13 @@ fn by_default_credential_caching_is_local() -> Result<()> {
         .arg("-c")
         .arg(format!("set -e; echo {PASSWORD} | sudo -S true"))
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = Command::new("sudo")
         .arg("true")
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -67,7 +67,7 @@ fn credential_cache_is_shared_with_child_shell() -> Result<()> {
         .as_user(USERNAME)
         // XXX unclear why this and the tests that follow need a pseudo-TTY allocation to pass
         .tty(true)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -84,7 +84,7 @@ fn credential_cache_is_shared_with_parent_shell() -> Result<()> {
         ))
         .as_user(USERNAME)
         .tty(true)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -101,7 +101,7 @@ fn credential_cache_is_shared_between_sibling_shells() -> Result<()> {
         ))
         .as_user(USERNAME)
         .tty(true)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -119,7 +119,7 @@ fn cached_credential_applies_to_all_target_users() -> Result<()> {
             "set -e; echo {PASSWORD} | sudo -S true; sudo -u {second_target_user} true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -137,7 +137,7 @@ fn cached_credential_not_shared_with_target_user_that_are_not_self() -> Result<(
             "echo {PASSWORD} | sudo -u {second_target_user} -S true; sudo -u {second_target_user} sh -c 'export \"{SUDO_RS_IS_UNSTABLE}\"; sudo -S true'"
         ))
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
 

--- a/test-framework/sudo-compliance-tests/src/timestamp/remove.rs
+++ b/test-framework/sudo-compliance-tests/src/timestamp/remove.rs
@@ -22,7 +22,7 @@ fn is_limited_to_a_single_user() -> Result<()> {
         .arg("-c")
         .arg("until [ -f /tmp/barrier1 ]; do sleep 1; done; sudo -K && touch /tmp/barrier2")
         .as_user(second_user)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     child.wait()?.assert_success()
@@ -46,7 +46,7 @@ fn has_a_user_global_effect() -> Result<()> {
         .arg("-c")
         .arg("until [ -f /tmp/barrier1 ]; do sleep 1; done; sudo -K && touch /tmp/barrier2")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     let output = child.wait()?;
@@ -79,7 +79,7 @@ fn also_works_locally() -> Result<()> {
             "echo {PASSWORD} | sudo -S true; sudo -K; sudo true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/timestamp/reset.rs
+++ b/test-framework/sudo-compliance-tests/src/timestamp/reset.rs
@@ -17,7 +17,7 @@ fn it_works() -> Result<()> {
             "echo {PASSWORD} | sudo -S true; sudo -k; sudo true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -50,7 +50,7 @@ fn has_a_local_effect() -> Result<()> {
         .arg("-c")
         .arg("until [ -f /tmp/barrier1 ]; do sleep 1; done; sudo -k; touch /tmp/barrier2")
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()?;
 
     child.wait()?.assert_success()
@@ -66,7 +66,7 @@ fn with_command_prompts_for_password() -> Result<()> {
         .arg("-c")
         .arg(format!("echo {PASSWORD} | sudo -S true; sudo -k true"))
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -103,7 +103,7 @@ fn with_command_failure_does_not_invalidate_credential_cache() -> Result<()> {
             "echo {PASSWORD} | sudo -S true; sudo -k true; [ $? -eq 1 ] || exit 2; sudo true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -125,7 +125,7 @@ fn with_command_success_does_not_invalidate_credential_cache() -> Result<()> {
             "echo {PASSWORD} | sudo -S true; echo {PASSWORD} | sudo -k -S true; sudo true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?
+        .output(&env)?
         .assert_success()
 }
 
@@ -141,7 +141,7 @@ fn with_command_does_not_cache_credentials() -> Result<()> {
             "echo {PASSWORD} | sudo -k -S true 2>/dev/null || exit 2; sudo true"
         ))
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/timestamp/validate.rs
+++ b/test-framework/sudo-compliance-tests/src/timestamp/validate.rs
@@ -21,7 +21,7 @@ Defaults timestamp_timeout=0.1"
         "set -e; echo {PASSWORD} | sudo -S true; for i in $(seq 1 5); do sleep 3; sudo -v; done; sudo true"
     ))
     .as_user(USERNAME)
-    .exec(&env)?
+    .output(&env)?
     .assert_success()
 }
 
@@ -35,7 +35,7 @@ fn prompts_for_password() -> Result<()> {
     let output = Command::new("sudo")
         .arg("-v")
         .as_user(USERNAME)
-        .exec(&env)?;
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/use_pty.rs
+++ b/test-framework/sudo-compliance-tests/src/use_pty.rs
@@ -15,7 +15,7 @@ fn fixture() -> Result<Vec<PsAuxEntry>> {
             "-c",
             "until [ -f /tmp/barrier ]; do sleep 0.1; done; ps aux",
         ])
-        .exec(&env)?
+        .output(&env)?
         .stdout()?;
 
     child.wait()?.assert_success()?;


### PR DESCRIPTION
this better matches the `std::process::Command` API