### PR TITLE
Add logger and macros for development

### DIFF
--- a/sudo/Cargo.toml
+++ b/sudo/Cargo.toml
@@ -27,3 +27,7 @@ glob.workspace = true
 [dev-dependencies]
 pretty_assertions.workspace = true
 tempfile.workspace = true
+
+[features]
+default = []
+dev = []

--- a/sudo/lib/exec/backchannel.rs
+++ b/sudo/lib/exec/backchannel.rs
@@ -11,6 +11,8 @@ use std::{
 
 use crate::system::{interface::ProcessId, signal::SignalNumber};
 
+use super::signal_fmt;
+
 type Prefix = u8;
 type ParentData = c_int;
 type MonitorData = c_int;
@@ -143,7 +145,7 @@ impl AsRawFd for ParentBackchannel {
 }
 
 /// Different messages exchanged between the monitor and the parent process using a [`ParentBackchannel`].
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub(super) enum MonitorMessage {
     ExecCommand,
     Signal(c_int),
@@ -174,6 +176,15 @@ impl MonitorMessage {
         };
 
         (prefix, data)
+    }
+}
+
+impl std::fmt::Debug for MonitorMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExecCommand => "ExecCommand".fmt(f),
+            &Self::Signal(signal) => write!(f, "Signal({})", signal_fmt(signal)),
+        }
     }
 }
 

--- a/sudo/lib/exec/event.rs
+++ b/sudo/lib/exec/event.rs
@@ -7,8 +7,6 @@ use crate::system::{
 };
 
 use signal_hook::consts::*;
-#[cfg(feature = "dev")]
-use signal_hook::low_level::signal_name;
 
 pub(super) trait EventClosure: Sized {
     /// Reason why the event loop should break. This is the return type of [`EventDispatcher::event_loop`].
@@ -34,7 +32,7 @@ macro_rules! define_signals {
                     signal_handlers: [$(SignalHandler::new($signal).map_err(|err| {
                         dev_error!(
                             "unable to set handler for {}",
-                            signal_name($signal).unwrap(),
+                            super::signal_fmt($signal)
                         );
                         err
                     })?,)*],

--- a/sudo/lib/exec/mod.rs
+++ b/sudo/lib/exec/mod.rs
@@ -91,7 +91,6 @@ pub enum ExitReason {
     Signal(i32),
 }
 
-#[cfg(feature = "dev")]
 fn signal_fmt(signal: crate::system::signal::SignalNumber) -> std::borrow::Cow<'static, str> {
     signal_hook::low_level::signal_name(signal)
         .map(|name| name.into())

--- a/sudo/lib/exec/mod.rs
+++ b/sudo/lib/exec/mod.rs
@@ -90,3 +90,19 @@ pub enum ExitReason {
     Code(i32),
     Signal(i32),
 }
+
+#[cfg(feature = "dev")]
+fn signal_fmt(signal: crate::system::signal::SignalNumber) -> std::borrow::Cow<'static, str> {
+    signal_hook::low_level::signal_name(signal)
+        .map(|name| name.into())
+        .unwrap_or_else(|| format!("unknown signal #{}", signal).into())
+}
+
+#[cfg(feature = "dev")]
+const fn cond_fmt(s: &str, cond: bool) -> &str {
+    if cond {
+        s
+    } else {
+        ""
+    }
+}

--- a/sudo/lib/exec/mod.rs
+++ b/sudo/lib/exec/mod.rs
@@ -97,7 +97,6 @@ fn signal_fmt(signal: crate::system::signal::SignalNumber) -> std::borrow::Cow<'
         .unwrap_or_else(|| format!("unknown signal #{}", signal).into())
 }
 
-#[cfg(feature = "dev")]
 const fn cond_fmt(s: &str, cond: bool) -> &str {
     if cond {
         s

--- a/sudo/lib/exec/monitor.rs
+++ b/sudo/lib/exec/monitor.rs
@@ -19,7 +19,6 @@ use super::{
     event::{EventClosure, EventDispatcher},
     io_util::{retry_while_interrupted, was_interrupted},
 };
-#[cfg(feature = "dev")]
 use super::{cond_fmt, signal_fmt};
 
 // FIXME: This should return `io::Result<!>` but `!` is not stable yet.
@@ -70,8 +69,8 @@ pub(super) fn exec_monitor(
     let command_pid = command.id() as ProcessId;
 
     // Send the command's PID to the parent.
-    if let Err(_err) = backchannel.send(&ParentMessage::CommandPid(command_pid)) {
-        dev_warn!("cannot send command PID to parent: {_err}");
+    if let Err(err) = backchannel.send(&ParentMessage::CommandPid(command_pid)) {
+        dev_warn!("cannot send command PID to parent: {err}");
     }
 
     let mut closure = MonitorClosure::new(command, command_pid, backchannel, &mut dispatcher);
@@ -118,8 +117,8 @@ impl<'a> MonitorClosure<'a> {
 
         // Put the command in its own process group.
         let command_pgrp = command_pid;
-        if let Err(_err) = setpgid(command_pid, command_pgrp) {
-            dev_warn!("cannot set process group ID for process: {_err}");
+        if let Err(err) = setpgid(command_pid, command_pgrp) {
+            dev_warn!("cannot set process group ID for process: {err}");
         };
 
         Self {

--- a/sudo/lib/exec/monitor.rs
+++ b/sudo/lib/exec/monitor.rs
@@ -147,7 +147,7 @@ impl<'a> MonitorClosure<'a> {
                     // Forward signal to the command.
                     MonitorMessage::Signal(signal) => {
                         if let Some(command_pid) = self.command_pid {
-                            send_signal::<true>(signal, command_pid)
+                            send_signal(signal, command_pid, true)
                         }
                     }
                 }
@@ -156,11 +156,11 @@ impl<'a> MonitorClosure<'a> {
     }
 }
 /// Send a signal to the command.
-fn send_signal<const FROM_PARENT: bool>(signal: c_int, command_pid: ProcessId) {
+fn send_signal(signal: c_int, command_pid: ProcessId, from_parent: bool) {
     dev_info!(
         "sending {}{} to command",
         signal_fmt(signal),
-        cond_fmt(" from parent", FROM_PARENT),
+        cond_fmt(" from parent", from_parent),
     );
     // FIXME: We should call `killpg` instead of `kill`.
     match signal {
@@ -237,7 +237,7 @@ impl<'a> EventClosure for MonitorClosure<'a> {
             // Skip the signal if it was sent by the user and it is self-terminating.
             _ if info.is_user_signaled()
                 && is_self_terminating(info.pid(), command_pid, self.command_pgrp) => {}
-            signal => send_signal::<false>(signal, command_pid),
+            signal => send_signal(signal, command_pid, false),
         }
     }
 }

--- a/sudo/lib/exec/monitor.rs
+++ b/sudo/lib/exec/monitor.rs
@@ -209,7 +209,7 @@ impl<'a> EventClosure for MonitorClosure<'a> {
 
     fn on_signal(&mut self, info: SignalInfo, dispatcher: &mut EventDispatcher<Self>) {
         dev_info!(
-            "monitor received {}{} from {}",
+            "monitor received{} {} from {}",
             cond_fmt(" user signaled", info.is_user_signaled()),
             signal_fmt(info.signal()),
             info.pid()

--- a/sudo/lib/exec/parent.rs
+++ b/sudo/lib/exec/parent.rs
@@ -235,7 +235,7 @@ impl ParentClosure {
     ///
     /// The signal message will be sent once the backchannel is ready to be written.
     fn schedule_signal(&mut self, signal: c_int) {
-        dev_error!("scheduling {} for command", signal_fmt(signal));
+        dev_info!("scheduling message with {} for monitor", signal_fmt(signal));
         self.message_queue.push_back(MonitorMessage::Signal(signal));
     }
 

--- a/sudo/lib/exec/parent.rs
+++ b/sudo/lib/exec/parent.rs
@@ -4,8 +4,10 @@ use std::io;
 use std::process::{exit, Command};
 
 use signal_hook::consts::*;
+#[cfg(feature = "dev")]
+use signal_hook::low_level::signal_name;
 
-use crate::log::user_error;
+use crate::log::{dev_error, dev_info, dev_warn};
 use crate::system::signal::{SignalAction, SignalHandler};
 use crate::system::term::Pty;
 use crate::system::wait::{waitpid, WaitError, WaitOptions};
@@ -29,12 +31,19 @@ pub(super) fn exec_pty(
     let pty = get_pty()?;
 
     // Create backchannels to communicate with the monitor.
-    let mut backchannels = BackchannelPair::new()?;
+    let mut backchannels = BackchannelPair::new().map_err(|err| {
+        dev_error!("unable to create backchannel: {err}");
+        err
+    })?;
 
     // We don't want to receive SIGTTIN/SIGTTOU
     // FIXME: why?
-    SignalHandler::with_action(SIGTTIN, SignalAction::Ignore).ok();
-    SignalHandler::with_action(SIGTTOU, SignalAction::Ignore).ok();
+    if let Err(_err) = SignalHandler::with_action(SIGTTIN, SignalAction::Ignore) {
+        dev_error!("unable to set handler for SIGTTIN: {_err}");
+    }
+    if let Err(_err) = SignalHandler::with_action(SIGTTOU, SignalAction::Ignore) {
+        dev_error!("unable to set handler for SIGTTOU: {_err}");
+    }
 
     // FIXME (ogsudo): Initialize the policy plugin's session here by calling
     // `policy_init_session`.
@@ -48,7 +57,10 @@ pub(super) fn exec_pty(
     // FIXME (ogsudo): Start in raw mode unless we're part of a pipeline
     let mut dispatcher = EventDispatcher::<ParentClosure>::new()?;
 
-    let monitor_pid = fork()?;
+    let monitor_pid = fork().map_err(|err| {
+        dev_error!("unable to fork monitor process: {err}");
+        err
+    })?;
 
     if monitor_pid == 0 {
         // Close the file descriptors that we don't access
@@ -57,7 +69,9 @@ pub(super) fn exec_pty(
 
         // If `exec_monitor` returns, it means we failed to execute the command somehow.
         if let Err(err) = exec_monitor(pty.follower, command, &mut backchannels.monitor) {
-            backchannels.monitor.send(&err.into()).ok();
+            if let Err(_err) = backchannels.monitor.send(&err.into()) {
+                dev_error!("unable to send status to parent: {_err}");
+            }
         }
         // FIXME: drop everything before calling `exit`.
         exit(1)
@@ -68,7 +82,12 @@ pub(super) fn exec_pty(
     drop(backchannels.monitor);
 
     // Send green light to the monitor after closing the follower.
-    retry_while_interrupted(|| backchannels.parent.send(&MonitorMessage::ExecCommand))?;
+    retry_while_interrupted(|| backchannels.parent.send(&MonitorMessage::ExecCommand)).map_err(
+        |err| {
+            dev_error!("unable to send green light to monitor: {err}");
+            err
+        },
+    )?;
 
     let closure = ParentClosure::new(monitor_pid, sudo_pid, backchannels.parent, &mut dispatcher);
 
@@ -81,11 +100,19 @@ pub(super) fn exec_pty(
 }
 
 fn get_pty() -> io::Result<Pty> {
-    let tty_gid = Group::from_name("tty")?.map(|group| group.gid);
+    let tty_gid = Group::from_name("tty")
+        .unwrap_or(None)
+        .map(|group| group.gid);
 
-    let pty = Pty::open()?;
+    let pty = Pty::open().map_err(|err| {
+        dev_error!("unable to allocate pty: {err}");
+        err
+    })?;
     // FIXME: Test this
-    chown(&pty.path, User::effective_uid(), tty_gid)?;
+    chown(&pty.path, User::effective_uid(), tty_gid).map_err(|err| {
+        dev_error!("unable to change owner for pty: {err}");
+        err
+    })?;
 
     Ok(pty)
 }
@@ -147,22 +174,42 @@ impl ParentClosure {
             // Failed to read command status. This means that something is wrong with the socket
             // and we should stop.
             Err(err) => {
+                dev_error!("could not receive message from monitor: {err}");
                 if !dispatcher.got_break() {
                     dispatcher.set_break(err.into());
                 }
             }
-            Ok(event) => match event {
-                // Received the PID of the command. This means that the command is already
-                // executing.
-                ParentMessage::CommandPid(pid) => self.command_pid = pid.into(),
-                // The command terminated or the monitor was not able to spawn it. We should stop
-                // either way.
-                ParentMessage::CommandExit(_)
-                | ParentMessage::CommandSignal(_)
-                | ParentMessage::IoError(_) => {
-                    dispatcher.set_break(event);
+            Ok(event) => {
+                match event {
+                    // Received the PID of the command. This means that the command is already
+                    // executing.
+                    ParentMessage::CommandPid(pid) => {
+                        dev_info!("received command PID ({pid}) from monitor");
+                        self.command_pid = pid.into();
+                        // Do not set `CommandPid` as a break reason.
+                        return;
+                    }
+                    // The command terminated or the monitor was not able to spawn it. We should stop
+                    // either way.
+                    ParentMessage::CommandExit(_code) => {
+                        dev_info!("command exited with status code {_code}");
+                    }
+
+                    ParentMessage::CommandSignal(_signal) => {
+                        dev_info!(
+                            "command was terminated by {}",
+                            signal_name(_signal).unwrap_or("unknown signal")
+                        )
+                    }
+                    ParentMessage::IoError(_code) => {
+                        dev_info!(
+                            "received error ({_code}) for monitor: {}",
+                            io::Error::from_raw_os_error(_code)
+                        )
+                    }
                 }
-            },
+                dispatcher.set_break(event);
+            }
         }
     }
 
@@ -181,8 +228,6 @@ impl ParentClosure {
                 if Some(signaler_pgrp) == self.command_pid || signaler_pgrp == self.sudo_pid {
                     return true;
                 }
-            } else {
-                user_error!("Could not fetch process group ID");
             }
         }
 
@@ -193,6 +238,10 @@ impl ParentClosure {
     ///
     /// The signal message will be sent once the backchannel is ready to be written.
     fn schedule_signal(&mut self, signal: c_int) {
+        dev_error!(
+            "scheduling {} for command",
+            signal_name(signal).unwrap_or("unknown signal")
+        );
         self.message_queue.push_back(MonitorMessage::Signal(signal));
     }
 
@@ -200,14 +249,16 @@ impl ParentClosure {
     ///
     /// Calling this function will block until the backchannel can be written.
     fn check_message_queue(&mut self, dispatcher: &mut EventDispatcher<Self>) {
-        if let Some(event) = self.message_queue.front() {
-            match self.backchannel.send(event) {
+        if let Some(msg) = self.message_queue.front() {
+            dev_info!("sending message {msg:?} to monitor over backchannel");
+            match self.backchannel.send(msg) {
                 // The event was sent, remove it from the queue
                 Ok(()) => {
                     self.message_queue.pop_front().unwrap();
                 }
                 // The other end of the socket is gone, we should exit.
                 Err(err) if err.kind() == io::ErrorKind::BrokenPipe => {
+                    dev_error!("broken pipe while writing to monitor over backchannel");
                     // FIXME: maybe we need a different event for backchannel errors.
                     dispatcher.set_break(err.into());
                 }
@@ -225,16 +276,33 @@ impl ParentClosure {
             match waitpid(monitor_pid, OPTS) {
                 Err(WaitError::Io(err)) if was_interrupted(&err) => {}
                 // This only happens if we receive `SIGCHLD` but there's no status update from the
-                // monitor or if the monitor exited and any process already waited for the monitor.
-                Err(_) => return,
+                // monitor.
+                Err(WaitError::Io(_err)) => dev_info!("parent could not wait for monitor: {_err}"),
+                // This only happens if the monitor exited and any process already waited for the monitor.
+                Err(WaitError::NotReady) => dev_info!("monitor process without status update"),
                 Ok((_pid, status)) => break status,
             }
         };
 
-        if status.did_exit() || status.was_signaled() {
+        if let Some(_code) = status.exit_status() {
+            dev_info!("monitor ({monitor_pid}) exited with status code {_code}");
             self.monitor_pid = None;
-        } else if status.was_stopped() {
+        } else if let Some(_signal) = status.term_signal() {
+            dev_info!(
+                "monitor ({monitor_pid}) was terminated by {}",
+                signal_name(_signal).unwrap_or("unknown signal")
+            );
+            self.monitor_pid = None;
+        } else if let Some(_signal) = status.stop_signal() {
             // FIXME: we should stop too.
+            dev_info!(
+                "monitor ({monitor_pid}) was stopped by {}",
+                signal_name(_signal).unwrap_or("unknown signal")
+            );
+        } else if status.did_continue() {
+            dev_info!("monitor ({monitor_pid}) continued execution");
+        } else {
+            dev_warn!("unexpected wait status for monitor ({monitor_pid})")
         }
     }
 }
@@ -243,7 +311,19 @@ impl EventClosure for ParentClosure {
     type Break = ParentMessage;
 
     fn on_signal(&mut self, info: SignalInfo, _dispatcher: &mut EventDispatcher<Self>) {
+        dev_info!(
+            "parent received {}{} from {}",
+            if info.is_user_signaled() {
+                " user signaled"
+            } else {
+                ""
+            },
+            signal_name(info.signal()).unwrap_or("unknown signal"),
+            info.pid()
+        );
+
         let Some(monitor_pid) = self.monitor_pid else {
+            dev_info!("monitor was terminated, ignoring signal");
             return;
         };
 

--- a/sudo/lib/exec/parent.rs
+++ b/sudo/lib/exec/parent.rs
@@ -306,7 +306,7 @@ impl EventClosure for ParentClosure {
 
     fn on_signal(&mut self, info: SignalInfo, _dispatcher: &mut EventDispatcher<Self>) {
         dev_info!(
-            "parent received {}{} from {}",
+            "parent received{} {} from {}",
             cond_fmt(" user signaled", info.is_user_signaled()),
             signal_fmt(info.signal()),
             info.pid()

--- a/sudo/lib/exec/parent.rs
+++ b/sudo/lib/exec/parent.rs
@@ -19,7 +19,6 @@ use super::{
     io_util::{retry_while_interrupted, was_interrupted},
     ExitReason,
 };
-#[cfg(feature = "dev")]
 use super::{cond_fmt, signal_fmt};
 
 pub(super) fn exec_pty(
@@ -38,11 +37,11 @@ pub(super) fn exec_pty(
 
     // We don't want to receive SIGTTIN/SIGTTOU
     // FIXME: why?
-    if let Err(_err) = SignalHandler::with_action(SIGTTIN, SignalAction::Ignore) {
-        dev_error!("unable to set handler for SIGTTIN: {_err}");
+    if let Err(err) = SignalHandler::with_action(SIGTTIN, SignalAction::Ignore) {
+        dev_error!("unable to set handler for SIGTTIN: {err}");
     }
-    if let Err(_err) = SignalHandler::with_action(SIGTTOU, SignalAction::Ignore) {
-        dev_error!("unable to set handler for SIGTTOU: {_err}");
+    if let Err(err) = SignalHandler::with_action(SIGTTOU, SignalAction::Ignore) {
+        dev_error!("unable to set handler for SIGTTOU: {err}");
     }
 
     // FIXME (ogsudo): Initialize the policy plugin's session here by calling
@@ -69,8 +68,8 @@ pub(super) fn exec_pty(
 
         // If `exec_monitor` returns, it means we failed to execute the command somehow.
         if let Err(err) = exec_monitor(pty.follower, command, &mut backchannels.monitor) {
-            if let Err(_err) = backchannels.monitor.send(&err.into()) {
-                dev_error!("unable to send status to parent: {_err}");
+            if let Err(err) = backchannels.monitor.send(&err.into()) {
+                dev_error!("unable to send status to parent: {err}");
             }
         }
         // FIXME: drop everything before calling `exit`.

--- a/sudo/lib/log/mod.rs
+++ b/sudo/lib/log/mod.rs
@@ -68,11 +68,14 @@ impl SudoLogger {
             .build();
 
         logger.add_logger("sudo::user", stderr_logger);
+
         #[cfg(feature = "dev")]
         {
             let path = option_env!("SUDO_DEV_LOGS")
                 .map(|s| s.into())
-                .unwrap_or_else(|| std::env::temp_dir().join("sudo-dev.log"));
+                .unwrap_or_else(|| {
+                    std::env::temp_dir().join(format!("sudo-dev-{}.log", std::process::id()))
+                });
 
             let dev_logger = env_logger::Builder::new()
                 .filter_level(log::LevelFilter::Trace)

--- a/sudo/lib/log/mod.rs
+++ b/sudo/lib/log/mod.rs
@@ -35,7 +35,7 @@ macro_rules! fake_logger {
     ($name:ident is $rule_level:ident to $target:expr, $d:tt) => {
         #[macro_export(local_inner_macros)]
         macro_rules! $name {
-            ($d($d arg:tt)+) => ();
+            ($d($d arg:tt)+) => {{}};
         }
         pub use $name;
     };

--- a/sudo/lib/log/mod.rs
+++ b/sudo/lib/log/mod.rs
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn can_construct_logger() {
         let logger = SudoLogger::new();
-
-        assert_eq!(logger.0.len(), 2);
+        let len = if cfg!(feature = "dev") { 3 } else { 2 };
+        assert_eq!(logger.0.len(), len);
     }
 }

--- a/sudo/src/main.rs
+++ b/sudo/src/main.rs
@@ -5,6 +5,7 @@ use pipeline::{Pipeline, PolicyPlugin};
 use std::env;
 use sudo::cli::{help, SudoAction, SudoOptions};
 use sudo::common::{resolve::resolve_current_user, Context, Error};
+use sudo::dev_info;
 use sudo::system::{time::Duration, timestamp::SessionRecordFile, Process};
 
 mod diagnostic;
@@ -73,6 +74,8 @@ impl PolicyPlugin for SudoersPolicy {
 
 fn sudo_process() -> Result<(), Error> {
     sudo::log::SudoLogger::new().into_global_logger();
+
+    dev_info!("development logs are enabled");
 
     // parse cli options
     let sudo_options = match SudoOptions::from_env() {

--- a/test-framework/sudo-test/src/ours.Dockerfile
+++ b/test-framework/sudo-test/src/ours.Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
 RUN cargo search sudo
 WORKDIR /usr/src/sudo
 COPY . .
-RUN --mount=type=cache,target=/usr/src/sudo/target RUSTFLAGS="-C instrument-coverage" cargo build --locked -p sudo && mkdir -p build && cp target/debug/sudo build/sudo
+RUN --mount=type=cache,target=/usr/src/sudo/target RUSTFLAGS="-C instrument-coverage" cargo build --locked --features="dev" -p sudo && mkdir -p build && cp target/debug/sudo build/sudo
 # discard code coverage data created during `cargo build`
 RUN find / -name '*.profraw' -exec rm {} \;
 # set setuid on install


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR adds a new feature `"dev"` that can be used to emit logs for development purposes to the file specified by the `SUDO_DEV_LOGS` environment variable (or to `/tmp/sudo-dev.log` if the variable is not defined). It also adds logging macros that are no-ops when `"dev"` is disabled.

It also adds some logging for the `exec` crate.

This can be used to debug sudo while running tests in docker by running `docker exec <HASH> cat /tmp/sudo-dev.log`.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
