### PR TITLE
Use `fork` and `exec` for the command

### DIFF
--- a/sudo/lib/exec/event.rs
+++ b/sudo/lib/exec/event.rs
@@ -1,4 +1,4 @@
-use std::{io, ops::ControlFlow, os::fd::AsRawFd};
+use std::{io, os::fd::AsRawFd};
 
 use crate::log::dev_error;
 use crate::system::{
@@ -9,8 +9,14 @@ use crate::system::{
 use signal_hook::consts::*;
 
 pub(super) trait EventClosure: Sized {
-    /// Reason why the event loop should break. This is the return type of [`EventDispatcher::event_loop`].
+    /// Reason why the event loop should break.
+    ///
+    /// See [`EventDispatcher::set_break`] for more information.
     type Break;
+    /// Reason why the event loop should exit.
+    ///
+    /// See [`EventDispatcher::set_exit`] for more information.
+    type Exit;
     /// Operation that the closure must do when a signal arrives.
     fn on_signal(&mut self, info: SignalInfo, dispatcher: &mut EventDispatcher<Self>);
 }
@@ -38,7 +44,7 @@ macro_rules! define_signals {
                     })?,)*],
                     poll_set: PollSet::new(),
                     callbacks: Vec::with_capacity(SIGNALS.len()),
-                    status: ControlFlow::Continue(()),
+                    status: Status::Continue,
                 };
 
                 $(
@@ -73,6 +79,53 @@ define_signals! {
     SIGWINCH = 11,
 }
 
+enum Status<T: EventClosure> {
+    Continue,
+    Stop(StopReason<T>),
+}
+
+impl<T: EventClosure> Status<T> {
+    fn is_break(&self) -> bool {
+        matches!(self, Self::Stop(StopReason::Break(_)))
+    }
+
+    fn take_stop(&mut self) -> Option<StopReason<T>> {
+        // If the status ends up to be `Continue`, we are replacing it by another `Continue`.
+        let status = std::mem::replace(self, Self::Continue);
+        match status {
+            Status::Continue => None,
+            Status::Stop(reason) => Some(reason),
+        }
+    }
+
+    fn take_break(&mut self) -> Option<T::Break> {
+        match self.take_stop()? {
+            StopReason::Break(break_reason) => Some(break_reason),
+            reason @ StopReason::Exit(_) => {
+                // Replace back the status because it was not a `Break`.
+                *self = Self::Stop(reason);
+                None
+            }
+        }
+    }
+
+    fn take_exit(&mut self) -> Option<T::Exit> {
+        match self.take_stop()? {
+            reason @ StopReason::Break(_) => {
+                // Replace back the status because it was not an `Exit`.
+                *self = Self::Stop(reason);
+                None
+            }
+            StopReason::Exit(exit_reason) => Some(exit_reason),
+        }
+    }
+}
+
+pub(super) enum StopReason<T: EventClosure> {
+    Break(T::Break),
+    Exit(T::Exit),
+}
+
 #[derive(PartialEq, Eq, Hash, Clone)]
 struct EventId(usize);
 
@@ -83,7 +136,7 @@ pub(super) struct EventDispatcher<T: EventClosure> {
     signal_handlers: [SignalHandler; SIGNALS.len()],
     poll_set: PollSet<EventId>,
     callbacks: Vec<Callback<T>>,
-    status: ControlFlow<T::Break>,
+    status: Status<T>,
 }
 
 impl<T: EventClosure> EventDispatcher<T> {
@@ -107,7 +160,13 @@ impl<T: EventClosure> EventDispatcher<T> {
     ///
     /// This means that the event loop will stop even if other events are ready.
     pub(super) fn set_break(&mut self, reason: T::Break) {
-        self.status = ControlFlow::Break(reason);
+        self.status = Status::Stop(StopReason::Break(reason));
+    }
+
+    /// Stop the event loop when the callbacks for the events that are ready by now have been
+    /// dispatched and set a reason for it.
+    pub(super) fn set_exit(&mut self, reason: T::Exit) {
+        self.status = Status::Stop(StopReason::Exit(reason));
     }
 
     /// Return whether a break reason has been set already. This function will return `false` after
@@ -118,31 +177,27 @@ impl<T: EventClosure> EventDispatcher<T> {
 
     /// Run the event loop for this handler.
     ///
-    /// The event loop will continue indefinitely unless [`EventDispatcher::set_break`] is called.
-    pub(super) fn event_loop(&mut self, state: &mut T) -> T::Break {
+    /// The event loop will continue indefinitely unless you call [`EventDispatcher::set_break`] or
+    /// [`EventDispatcher::set_exit`].
+    pub(super) fn event_loop(&mut self, state: &mut T) -> StopReason<T> {
         loop {
             if let Ok(ids) = self.poll_set.poll() {
                 for EventId(id) in ids {
                     self.callbacks[id](state, self);
 
-                    if let Some(break_reason) = self.check_break() {
-                        return break_reason;
+                    if let Some(reason) = self.status.take_break() {
+                        return StopReason::Break(reason);
                     }
                 }
+                if let Some(reason) = self.status.take_exit() {
+                    return StopReason::Exit(reason);
+                }
+            } else {
+                // FIXME: maybe we shout return the IO error instead.
+                if let Some(reason) = self.status.take_stop() {
+                    return reason;
+                }
             }
-
-            if let Some(break_reason) = self.check_break() {
-                return break_reason;
-            }
-        }
-    }
-
-    pub(super) fn check_break(&mut self) -> Option<T::Break> {
-        // This is OK as we are swapping `Continue(())` by other `Continue(())` if the status is
-        // not `Break`.
-        match std::mem::replace(&mut self.status, ControlFlow::Continue(())) {
-            ControlFlow::Continue(()) => None,
-            ControlFlow::Break(reason) => Some(reason),
         }
     }
 }

--- a/sudo/lib/exec/event.rs
+++ b/sudo/lib/exec/event.rs
@@ -200,4 +200,11 @@ impl<T: EventClosure> EventDispatcher<T> {
             }
         }
     }
+
+    /// Unregister all the handlers created by the dispatcher.
+    pub(super) fn unregister_handlers(self) {
+        for handler in self.signal_handlers {
+            handler.unregister();
+        }
+    }
 }

--- a/sudo/lib/exec/monitor.rs
+++ b/sudo/lib/exec/monitor.rs
@@ -308,6 +308,7 @@ fn is_self_terminating(
 
 impl<'a> EventClosure for MonitorClosure<'a> {
     type Break = ();
+    type Exit = ();
 
     fn on_signal(&mut self, info: SignalInfo, dispatcher: &mut EventDispatcher<Self>) {
         dev_info!(
@@ -327,9 +328,7 @@ impl<'a> EventClosure for MonitorClosure<'a> {
             SIGCHLD => {
                 self.handle_sigchld(command_pid);
                 if self.command_pid.is_none() {
-                    // FIXME: This is what ogsudo calls a `loopexit`. Meaning that we should still
-                    // dispatch the remaining events to their callbacks and exit nicely.
-                    dispatcher.set_break(());
+                    dispatcher.set_exit(());
                 }
             }
             // Skip the signal if it was sent by the user and it is self-terminating.

--- a/sudo/lib/exec/monitor.rs
+++ b/sudo/lib/exec/monitor.rs
@@ -1,15 +1,22 @@
 use std::{
     ffi::c_int,
-    io,
-    os::fd::OwnedFd,
-    process::{exit, Child, Command},
+    io::{self, Read, Write},
+    os::{
+        fd::OwnedFd,
+        unix::{net::UnixStream, process::CommandExt},
+    },
+    process::{exit, Command},
     time::Duration,
 };
 
 use crate::log::{dev_info, dev_warn};
 use crate::system::{
-    getpgid, interface::ProcessId, kill, setpgid, setsid, signal::SignalInfo,
-    term::set_controlling_terminal,
+    fork, getpgid,
+    interface::ProcessId,
+    kill, setpgid, setsid,
+    signal::SignalInfo,
+    term::{set_controlling_terminal, tcgetpgrp, tcsetpgrp},
+    wait::{waitpid, WaitError, WaitOptions},
 };
 
 use signal_hook::consts::*;
@@ -24,7 +31,7 @@ use super::{cond_fmt, signal_fmt};
 // FIXME: This should return `io::Result<!>` but `!` is not stable yet.
 pub(super) fn exec_monitor(
     pty_follower: OwnedFd,
-    mut command: Command,
+    command: Command,
     backchannel: &mut MonitorBackchannel,
 ) -> io::Result<()> {
     let mut dispatcher = EventDispatcher::<MonitorClosure>::new()?;
@@ -46,6 +53,9 @@ pub(super) fn exec_monitor(
         err
     })?;
 
+    // Use a pipe to get the IO error if `exec_command` fails.
+    let (mut errpipe_tx, errpipe_rx) = UnixStream::pair()?;
+
     // Wait for the parent to give us green light before spawning the command. This avoids race
     // conditions when the command exits quickly.
     let event = retry_while_interrupted(|| backchannel.recv()).map_err(|err| {
@@ -58,22 +68,35 @@ pub(super) fn exec_monitor(
 
     // FIXME (ogsudo): Some extra config happens here if selinux is available.
 
-    // FIXME (ogsudo): Do any additional configuration that needs to be run after `fork` but before `exec`.
-
-    // spawn the command.
-    let command = command.spawn().map_err(|err| {
-        dev_warn!("cannot spawn command: {err}");
+    let command_pid = fork().map_err(|err| {
+        dev_warn!("unable to fork command process: {err}");
         err
     })?;
 
-    let command_pid = command.id() as ProcessId;
+    if command_pid == 0 {
+        drop(errpipe_rx);
+
+        let err = exec_command(command, pty_follower);
+        dev_warn!("failed to execute command: {err}");
+        // If `exec_command` returns, it means that executing the command failed. Send the error to
+        // the monitor using the pipe.
+        if let Some(error_code) = err.raw_os_error() {
+            errpipe_tx.write_all(&error_code.to_ne_bytes()).ok();
+        }
+        drop(errpipe_tx);
+        // FIXME: Calling `exit` doesn't run any destructors, clean everything up.
+        exit(1)
+    }
 
     // Send the command's PID to the parent.
     if let Err(err) = backchannel.send(&ParentMessage::CommandPid(command_pid)) {
         dev_warn!("cannot send command PID to parent: {err}");
     }
 
-    let mut closure = MonitorClosure::new(command, command_pid, backchannel, &mut dispatcher);
+    let mut closure = MonitorClosure::new(command_pid, errpipe_rx, backchannel, &mut dispatcher);
+
+    // Set the foreground group for the pty follower.
+    tcsetpgrp(&pty_follower, closure.command_pgrp).ok();
 
     // FIXME (ogsudo): Here's where the signal mask is removed because the handlers for the signals
     // have been setup after initializing the closure.
@@ -91,24 +114,44 @@ pub(super) fn exec_monitor(
     exit(1)
 }
 
+// FIXME: This should return `io::Result<!>` but `!` is not stable yet.
+fn exec_command(mut command: Command, pty_follower: OwnedFd) -> io::Error {
+    // FIXME (ogsudo): Do any additional configuration that needs to be run after `fork` but before `exec`
+    let command_pid = std::process::id() as ProcessId;
+
+    setpgid(0, command_pid).ok();
+
+    // Wait for the monitor to set us as the foreground group for the pty.
+    while !tcgetpgrp(&pty_follower).is_ok_and(|pid| pid == command_pid) {
+        std::thread::sleep(std::time::Duration::from_micros(1));
+    }
+
+    command.exec()
+}
+
 struct MonitorClosure<'a> {
-    command: Child,
     /// The command PID.
     ///
     /// This is `Some` iff the process is still running.
     command_pid: Option<ProcessId>,
     command_pgrp: ProcessId,
+    errpipe_rx: UnixStream,
     backchannel: &'a mut MonitorBackchannel,
 }
 
 impl<'a> MonitorClosure<'a> {
     fn new(
-        command: Child,
         command_pid: ProcessId,
+        errpipe_rx: UnixStream,
         backchannel: &'a mut MonitorBackchannel,
         dispatcher: &mut EventDispatcher<Self>,
     ) -> Self {
         // FIXME (ogsudo): Store the pgid of the monitor.
+
+        // Register the callback to receive the IO error if the command fails to execute.
+        dispatcher.set_read_callback(&errpipe_rx, |monitor, dispatcher| {
+            monitor.read_errpipe(dispatcher)
+        });
 
         // Register the callback to receive events from the backchannel
         dispatcher.set_read_callback(backchannel, |monitor, dispatcher| {
@@ -122,9 +165,9 @@ impl<'a> MonitorClosure<'a> {
         };
 
         Self {
-            command,
             command_pid: Some(command_pid),
             command_pgrp,
+            errpipe_rx,
             backchannel,
         }
     }
@@ -154,7 +197,67 @@ impl<'a> MonitorClosure<'a> {
             }
         }
     }
+
+    fn handle_sigchld(&mut self, command_pid: ProcessId) {
+        let status = loop {
+            match waitpid(command_pid, WaitOptions::new().untraced().no_hang()) {
+                Ok((_pid, status)) => break status,
+                Err(WaitError::Io(err)) if was_interrupted(&err) => {}
+                Err(_) => return,
+            }
+        };
+
+        if let Some(exit_code) = status.exit_status() {
+            dev_info!("command ({command_pid}) exited with status code {exit_code}");
+            // The command did exit, set it's PID to `None`.
+            self.command_pid = None;
+            self.backchannel
+                .send(&ParentMessage::CommandExit(exit_code))
+                .ok();
+        } else if let Some(signal) = status.term_signal() {
+            dev_info!(
+                "command ({command_pid}) was terminated by {}",
+                signal_fmt(signal),
+            );
+            // The command was terminated, set it's PID to `None`.
+            self.command_pid = None;
+            self.backchannel
+                .send(&ParentMessage::CommandSignal(signal))
+                .ok();
+        } else if let Some(_signal) = status.stop_signal() {
+            // FIXME: we should save the foreground process group ID so we can restore it later.
+            dev_info!(
+                "command ({command_pid}) was stopped by {}",
+                signal_fmt(_signal),
+            );
+        } else if status.did_continue() {
+            dev_info!("command ({command_pid}) continued execution");
+        } else {
+            dev_warn!("unexpected wait status for command ({command_pid})")
+        }
+    }
+
+    fn read_errpipe(&mut self, dispatcher: &mut EventDispatcher<Self>) {
+        let mut buf = 0i32.to_ne_bytes();
+        match self.errpipe_rx.read_exact(&mut buf) {
+            Err(err) if was_interrupted(&err) => { /* Retry later */ }
+            Err(err) => {
+                // Could not read from the pipe, report error to the parent.
+                // FIXME: Maybe we should have a different variant for this.
+                self.backchannel.send(&err.into()).ok();
+                dispatcher.set_break(());
+            }
+            Ok(_) => {
+                // Received error code from the command, forward it to the parent.
+                let error_code = i32::from_ne_bytes(buf);
+                self.backchannel
+                    .send(&ParentMessage::IoError(error_code))
+                    .ok();
+            }
+        }
+    }
 }
+
 /// Send a signal to the command.
 fn send_signal(signal: c_int, command_pid: ProcessId, from_parent: bool) {
     dev_info!(
@@ -221,17 +324,12 @@ impl<'a> EventClosure for MonitorClosure<'a> {
         };
 
         match info.signal() {
-            // FIXME: check `mon_handle_sigchld`
             SIGCHLD => {
-                if let Ok(Some(exit_status)) = self.command.try_wait() {
-                    dev_info!(
-                        "command ({command_pid}) exited with status: {}",
-                        exit_status
-                    );
-                    // The command has terminated, set it's PID to `None`.
-                    self.command_pid = None;
+                self.handle_sigchld(command_pid);
+                if self.command_pid.is_none() {
+                    // FIXME: This is what ogsudo calls a `loopexit`. Meaning that we should still
+                    // dispatch the remaining events to their callbacks and exit nicely.
                     dispatcher.set_break(());
-                    self.backchannel.send(&exit_status.into()).unwrap();
                 }
             }
             // Skip the signal if it was sent by the user and it is self-terminating.

--- a/sudo/lib/exec/parent.rs
+++ b/sudo/lib/exec/parent.rs
@@ -12,7 +12,7 @@ use crate::system::wait::{waitpid, WaitError, WaitOptions};
 use crate::system::{chown, fork, Group, User};
 use crate::system::{getpgid, interface::ProcessId, signal::SignalInfo};
 
-use super::event::{EventClosure, EventDispatcher};
+use super::event::{EventClosure, EventDispatcher, StopReason};
 use super::monitor::exec_monitor;
 use super::{
     backchannel::{BackchannelPair, MonitorMessage, ParentBackchannel, ParentMessage},
@@ -154,15 +154,10 @@ impl ParentClosure {
     }
 
     fn run(mut self, dispatcher: &mut EventDispatcher<Self>) -> io::Result<ExitReason> {
-        let exit_reason = match dispatcher.event_loop(&mut self) {
-            ParentMessage::IoError(code) => return Err(io::Error::from_raw_os_error(code)),
-            ParentMessage::CommandExit(code) => ExitReason::Code(code),
-            ParentMessage::CommandSignal(signal) => ExitReason::Signal(signal),
-            // We never set this event as the last event
-            ParentMessage::CommandPid(_) => unreachable!(),
-        };
-
-        Ok(exit_reason)
+        match dispatcher.event_loop(&mut self) {
+            StopReason::Break(err) | StopReason::Exit(ParentExit::Backchannel(err)) => Err(err),
+            StopReason::Exit(ParentExit::Command(exit_reason)) => Ok(exit_reason),
+        }
     }
 
     /// Read an event from the backchannel and return the event if it should break the event loop.
@@ -173,9 +168,15 @@ impl ParentClosure {
             // Failed to read command status. This means that something is wrong with the socket
             // and we should stop.
             Err(err) => {
-                dev_error!("could not receive message from monitor: {err}");
-                if !dispatcher.got_break() {
-                    dispatcher.set_break(err.into());
+                // If we get EOF the monitor exited or was killed
+                if err.kind() == io::ErrorKind::UnexpectedEof {
+                    dev_info!("parent received EOF from backchannel");
+                    dispatcher.set_exit(err.into());
+                } else {
+                    dev_error!("could not receive message from monitor: {err}");
+                    if !dispatcher.got_break() {
+                        dispatcher.set_break(err);
+                    }
                 }
             }
             Ok(event) => {
@@ -185,26 +186,24 @@ impl ParentClosure {
                     ParentMessage::CommandPid(pid) => {
                         dev_info!("received command PID ({pid}) from monitor");
                         self.command_pid = pid.into();
-                        // Do not set `CommandPid` as a break reason.
-                        return;
                     }
                     // The command terminated or the monitor was not able to spawn it. We should stop
                     // either way.
-                    ParentMessage::CommandExit(_code) => {
-                        dev_info!("command exited with status code {_code}");
+                    ParentMessage::CommandExit(code) => {
+                        dev_info!("command exited with status code {code}");
+                        dispatcher.set_exit(ExitReason::Code(code).into());
                     }
 
-                    ParentMessage::CommandSignal(_signal) => {
-                        dev_info!("command was terminated by {}", signal_fmt(_signal))
+                    ParentMessage::CommandSignal(signal) => {
+                        dev_info!("command was terminated by {}", signal_fmt(signal));
+                        dispatcher.set_exit(ExitReason::Signal(signal).into());
                     }
-                    ParentMessage::IoError(_code) => {
-                        dev_info!(
-                            "received error ({_code}) for monitor: {}",
-                            io::Error::from_raw_os_error(_code)
-                        )
+                    ParentMessage::IoError(code) => {
+                        let err = io::Error::from_raw_os_error(code);
+                        dev_info!("received error ({code}) for monitor: {err}",);
+                        dispatcher.set_break(err);
                     }
                 }
-                dispatcher.set_break(event);
             }
         }
     }
@@ -253,7 +252,7 @@ impl ParentClosure {
                 Err(err) if err.kind() == io::ErrorKind::BrokenPipe => {
                     dev_error!("broken pipe while writing to monitor over backchannel");
                     // FIXME: maybe we need a different event for backchannel errors.
-                    dispatcher.set_break(err.into());
+                    dispatcher.set_break(err);
                 }
                 // Non critical error, we can retry later.
                 Err(_) => {}
@@ -300,8 +299,28 @@ impl ParentClosure {
     }
 }
 
+enum ParentExit {
+    /// Error while reading from the backchannel.
+    Backchannel(io::Error),
+    /// The command exited.
+    Command(ExitReason),
+}
+
+impl From<io::Error> for ParentExit {
+    fn from(err: io::Error) -> Self {
+        Self::Backchannel(err)
+    }
+}
+
+impl From<ExitReason> for ParentExit {
+    fn from(reason: ExitReason) -> Self {
+        Self::Command(reason)
+    }
+}
+
 impl EventClosure for ParentClosure {
-    type Break = ParentMessage;
+    type Break = io::Error;
+    type Exit = ParentExit;
 
     fn on_signal(&mut self, info: SignalInfo, _dispatcher: &mut EventDispatcher<Self>) {
         dev_info!(

--- a/sudo/lib/exec/parent.rs
+++ b/sudo/lib/exec/parent.rs
@@ -199,8 +199,10 @@ impl ParentClosure {
                         dev_info!("command exited with status code {code}");
                         dispatcher.set_exit(ExitReason::Code(code).into());
                     }
-
                     ParentMessage::CommandSignal(signal) => {
+                        // FIXME: this isn't right as the command has not exited if the signal is
+                        // not a termination one. However, doing this makes us fail an ignored
+                        // compliance test instead of hanging forever.
                         dev_info!("command was terminated by {}", signal_fmt(signal));
                         dispatcher.set_exit(ExitReason::Signal(signal).into());
                     }


### PR DESCRIPTION
**Describe the changes done on this pull request**

This PR uses `fork` and `Command::exec` to run the command instead of using `Command::spawn`. This is done because we need to set the command's process group as the foreground process group for the terminal and we cannot execute the command until it is set. 

We cannot use `Command::pre_exec` to wait for the foreground process group to be set before executing the command because the monitor process will get stuck as `Command::spawn` will block until all the `Command::pre_exec` closures are executed. 

This PR also adds the new concept of "exit reason" for the event loop. The main difference between an exit and a break is that setting the loop to break will stop the loop after the current callback is done, meanwhile setting the loop to exit will stop the loop after all the callbacks for the events that have already been polled are done. Meaning that "exit" is the "nice" way to stop the event loop.

This is another chunk of #363 and it is blocked by #467.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will help fix issue https://github.com/memorysafety/sudo-rs/issues/325 where a proper discussion about a solution has taken place.       
