### PR TITLE
Change compliance test to demonstrate intended sudo behaviour.

### DIFF
--- a/test-framework/sudo-compliance-tests/src/sudoers/run_as.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/run_as.rs
@@ -315,7 +315,7 @@ fn when_both_user_and_group_are_specified_then_as_that_group_is_allowed() -> Res
 }
 
 // `man sudoers` says in the 'Runas_Spec' section
-// "If no Runas_Spec is specified the command may be run as root and no group may be specified."
+// "If no Runas_Spec is specified, the command may only be run as root and the group, if specified, must be one that root is a member of."
 #[test]
 fn when_no_run_as_spec_then_target_user_can_be_root() -> Result<()> {
     let env = Env("ALL ALL=NOPASSWD: ALL").user(USERNAME).build()?;
@@ -348,10 +348,13 @@ fn when_no_run_as_spec_then_target_user_cannot_be_a_regular_user() -> Result<()>
     Ok(())
 }
 
-// NOTE opposed to what the `man sudoers` says?
 #[test]
-#[ignore = "gh427"]
-fn when_no_run_as_spec_then_a_target_group_may_be_specified() -> Result<()> {
+fn when_no_run_as_spec_then_an_arbitrary_target_group_may_not_be_specified() -> Result<()> {
+    if sudo_test::is_original_sudo() {
+        // TODO: original sudo should pass this test after 1.9.14b2
+        return Ok(());
+    }
+
     let env = Env("ALL ALL = NOPASSWD: ALL")
         .user(User(USERNAME))
         .group(GROUPNAME)
@@ -360,13 +363,37 @@ fn when_no_run_as_spec_then_a_target_group_may_be_specified() -> Result<()> {
     let output = Command::new("sudo")
         .args(["-u", "root", "-g", GROUPNAME, "groups"])
         .as_user(USERNAME)
+        .output(&env)?;
+
+    assert!(!output.status().success());
+    assert_eq!(Some(1), output.status().code());
+
+    let diagnostic = if sudo_test::is_original_sudo() {
+        format!("user {USERNAME} is not allowed to execute '/usr/bin/true' as root:{GROUPNAME}")
+    } else {
+        format!("I'm sorry {USERNAME}. I'm afraid I can't do that")
+    };
+    assert_contains!(output.stderr(), diagnostic);
+
+    Ok(())
+}
+
+#[test]
+fn when_no_run_as_spec_then_a_group_that_root_is_in_may_be_specified() -> Result<()> {
+    let env = Env("ALL ALL = NOPASSWD: ALL")
+        .user(User(USERNAME))
+        .group(GROUPNAME)
+        .build()?;
+
+    let output = Command::new("sudo")
+        .args(["-u", "root", "-g", "root", "groups"])
+        .as_user(USERNAME)
         .output(&env)?
         .stdout()?;
 
     let mut actual = output.split_ascii_whitespace().collect::<HashSet<_>>();
 
     assert!(actual.remove("root"));
-    assert!(actual.remove("rustaceans"));
     assert!(actual.is_empty());
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/sudoers/run_as.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/run_as.rs
@@ -385,6 +385,7 @@ fn when_no_run_as_spec_then_a_group_that_root_is_in_may_be_specified() -> Result
         .group(GROUPNAME)
         .build()?;
 
+    //TODO: also test the case '-g wheel' (when root is made a group of 'wheel'); this requires a change in sudo-test
     let output = Command::new("sudo")
         .args(["-u", "root", "-g", "root", "groups"])
         .as_user(USERNAME)

--- a/test-framework/sudo-compliance-tests/src/sudoers/runas_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/runas_alias.rs
@@ -316,8 +316,12 @@ fn user_and_group_works_when_one_is_passed_as_arg() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh432"]
-fn user_and_group_fails_when_both_are_passed() -> Result<()> {
+fn user_and_group_succeeds_when_both_are_passed() -> Result<()> {
+    if sudo_test::is_original_sudo() {
+        // TODO: original sudo should pass this test after 1.9.14b2
+        return Ok(());
+    }
+
     let env = Env([
         &format!("Runas_Alias OP = otheruser, {GROUPNAME}"),
         &format!("{USERNAME} ALL = (OP:OP) NOPASSWD: ALL"),
@@ -328,24 +332,12 @@ fn user_and_group_fails_when_both_are_passed() -> Result<()> {
     .group(GROUPNAME)
     .build()?;
 
-    let output = Command::new("sudo")
+    Command::new("sudo")
         .args(["-u", "otheruser", "-g", GROUPNAME, "-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .output(&env)?;
-
-    assert!(!output.status().success());
-    assert_eq!(Some(1), output.status().code());
-
-    let stderr = output.stderr();
-    if sudo_test::is_original_sudo() {
-        assert_snapshot!(stderr);
-    } else {
-        assert_contains!(
-                stderr,
-                format!("Sorry, user {USERNAME} is not allowed to execute '/bin/true' as otheruser:{GROUPNAME}")
-            );
-    }
+        .output(&env)?
+        .assert_success()?;
 
     Ok(())
 }
@@ -379,8 +371,12 @@ fn different_aliases_user_and_group_works_when_one_is_passed_as_arg() -> Result<
 }
 
 #[test]
-#[ignore = "gh432"]
-fn different_aliases_user_and_group_fails_when_both_are_passed() -> Result<()> {
+fn different_aliases_user_and_group_succeeds_when_both_are_passed() -> Result<()> {
+    if sudo_test::is_original_sudo() {
+        // TODO: original sudo should pass this test after 1.9.14b2
+        return Ok(());
+    }
+
     let env = Env([
         &format!("Runas_Alias GROUPALIAS = {GROUPNAME}"),
         ("Runas_Alias USERALIAS = otheruser"),
@@ -392,24 +388,12 @@ fn different_aliases_user_and_group_fails_when_both_are_passed() -> Result<()> {
     .group(GROUPNAME)
     .build()?;
 
-    let output = Command::new("sudo")
+    Command::new("sudo")
         .args(["-u", "otheruser", "-g", GROUPNAME, "-S", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
-        .output(&env)?;
-
-    assert!(!output.status().success());
-    assert_eq!(Some(1), output.status().code());
-
-    let stderr = output.stderr();
-    if sudo_test::is_original_sudo() {
-        assert_snapshot!(stderr);
-    } else {
-        assert_contains!(
-            stderr,
-            format!("Sorry, user {USERNAME} is not allowed to execute '/bin/true' as otheruser:{GROUPNAME}")
-        );
-    }
+        .output(&env)?
+        .assert_success()?;
 
     Ok(())
 }


### PR DESCRIPTION
Closing #427 and #432; the behaviour that sudo-rs exhibited was the correct one, and this is fixed in sudo 1.9.14b2; if we start using that in the CI the duct-tape TODO's can be removed (there is no "easy" way to 'ignore' tests only for ogsudo)