### PR TITLE
Correctly handle directories in Cmnd_Spec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
       - name: Check that all ignored tests are linked to a GH issue
         working-directory: test-framework/sudo-compliance-tests
         run: |
-          grep -r '#\[ignore' ./src | grep -v '"gh' && echo 'found ignored tests not linked to a GitHub issue. please like them using the format #[ignore = "gh123"]' && exit 1; true
+          grep -r '#\[ignore' ./src | grep -v -e '"gh' -e '"wontfix"' && echo 'found ignored tests not linked to a GitHub issue. please like them using the format #[ignore = "gh123"]' && exit 1; true
 
 
   build-and-test:

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -280,8 +280,13 @@ fn match_token<T: basic_parser::Token + std::ops::Deref<Target = String>>(
 }
 
 fn match_command<'a>((cmd, args): (&'a Path, &'a [String])) -> (impl Fn(&Command) -> bool + 'a) {
+    let opts = glob::MatchOptions {
+        require_literal_separator: true,
+        ..glob::MatchOptions::new()
+    };
     move |(cmdpat, argpat)| {
-        cmdpat.matches_path(cmd) && argpat.as_ref().map_or(true, |vec| args == vec.as_ref())
+        cmdpat.matches_path_with(cmd, opts)
+            && argpat.as_ref().map_or(true, |vec| args == vec.as_ref())
     }
 }
 

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -145,7 +145,7 @@ impl Token for Command {
 
         // the tokenizer should not give us a token that consists of only whitespace
         let mut cmd_iter = s.split_whitespace();
-        let cmd = cmd_iter.next().unwrap();
+        let mut cmd = cmd_iter.next().unwrap().to_string();
         let mut args = cmd_iter.map(String::from).collect::<Vec<String>>();
 
         let argpat = if args.is_empty() {
@@ -159,7 +159,12 @@ impl Token for Command {
             Some(args.into_boxed_slice())
         };
 
-        Ok((cvt_err(glob::Pattern::new(cmd))?, argpat))
+        // if the cmd ends with a slash, any command in that directory is allowed
+        if cmd.ends_with('/') {
+            cmd.push('*');
+        }
+
+        Ok((cvt_err(glob::Pattern::new(&cmd))?, argpat))
     }
 
     // all commands start with "/" except "sudoedit"

--- a/test-framework/sudo-compliance-tests/src/sudoers/cmnd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/cmnd.rs
@@ -222,9 +222,7 @@ fn given_directory_then_commands_in_it_are_allowed() -> Result<()> {
 fn given_directory_then_commands_in_its_subdirectories_are_not_allowed() -> Result<()> {
     let env = Env("ALL ALL=(ALL:ALL) /usr/").build()?;
 
-    let output = Command::new("sudo")
-        .arg("/usr/bin/true")
-        .output(&env)?;
+    let output = Command::new("sudo").arg("/usr/bin/true").output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -240,15 +238,121 @@ fn given_directory_then_commands_in_its_subdirectories_are_not_allowed() -> Resu
 }
 
 #[test]
+fn wildcards_are_allowed_for_dir() -> Result<()> {
+    let env = Env("ALL ALL=(ALL:ALL) /usr/*/true").build()?;
+
+    Command::new("sudo")
+        .arg("/usr/bin/true")
+        .output(&env)?
+        .assert_success()?;
+
+    Ok(())
+}
+
+#[test]
+fn wildcards_are_allowed_for_file() -> Result<()> {
+    let env = Env("ALL ALL=(ALL:ALL) /usr/bin/*").build()?;
+
+    Command::new("sudo")
+        .arg("/usr/bin/true")
+        .output(&env)?
+        .assert_success()?;
+
+    Ok(())
+}
+
+// due to frequent misusage ("sudo: you are doing it wrong"), we explicitly don't support this
+#[test]
+#[ignore = "wontfix"]
+fn wildcards_are_allowed_for_args() -> Result<()> {
+    let env = Env("ALL ALL=(ALL:ALL) /usr/bin/true /root/*").build()?;
+
+    Command::new("sudo")
+        .arg("true")
+        .arg("/root/ hello world")
+        .output(&env)?
+        .assert_success()?;
+
+    Ok(())
+}
+
+#[test]
+fn arguments_can_be_supplied() -> Result<()> {
+    let env = Env("ALL ALL=(ALL:ALL) /usr/bin/true").build()?;
+
+    Command::new("sudo")
+        .arg("true")
+        .arg("/root/ hello world")
+        .output(&env)?
+        .assert_success()?;
+
+    Command::new("sudo")
+        .arg("true")
+        .arg("foo")
+        .output(&env)?
+        .assert_success()?;
+
+    Ok(())
+}
+
+#[test]
+fn arguments_can_be_forced() -> Result<()> {
+    let env = Env("ALL ALL=(ALL:ALL) /usr/bin/true hello").build()?;
+
+    Command::new("sudo")
+        .arg("true")
+        .arg("hello")
+        .output(&env)?
+        .assert_success()?;
+
+    let output = Command::new("sudo")
+        .arg("true")
+        .arg("/root/ hello world")
+        .output(&env)?;
+
+    assert!(!output.status().success());
+    assert_eq!(Some(1), output.status().code());
+
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "user root is not allowed to execute '/usr/bin/true /root/ hello world' as root"
+    } else {
+        "authentication failed: I'm sorry root. I'm afraid I can't do that"
+    };
+    assert_contains!(output.stderr(), diagnostic);
+
+    Ok(())
+}
+
+#[test]
+fn arguments_can_be_forbidded() -> Result<()> {
+    let env = Env("ALL ALL=(ALL:ALL) /usr/bin/true \"\"").build()?;
+
+    let output = Command::new("sudo")
+        .arg("true")
+        .arg("/root/ hello world")
+        .output(&env)?;
+
+    assert!(!output.status().success());
+    assert_eq!(Some(1), output.status().code());
+
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "user root is not allowed to execute '/usr/bin/true /root/ hello world' as root"
+    } else {
+        "authentication failed: I'm sorry root. I'm afraid I can't do that"
+    };
+    assert_contains!(output.stderr(), diagnostic);
+
+    Ok(())
+}
+
+#[test]
 fn wildcards_dont_cross_directory_boundaries() -> Result<()> {
     let env = Env("ALL ALL=(ALL:ALL) /usr/*/foo")
         .directory("/usr/bin/sub")
         .file("/usr/bin/sub/foo", TextFile("").chown("root").chmod("777"))
         .build()?;
 
-    let output = Command::new("sudo")
-        .arg("/usr/bin/sub/foo")
-        .output(&env)?;
+    let output = Command::new("sudo").arg("/usr/bin/sub/foo").output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());

--- a/test-framework/sudo-compliance-tests/src/sudoers/cmnd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/cmnd.rs
@@ -1,7 +1,7 @@
 //! Test the Cmnd_Spec component of the user specification: <user> ALL=(ALL:ALL) <cmnd_spec>
 
 use pretty_assertions::assert_eq;
-use sudo_test::{Command, Env};
+use sudo_test::{Command, Env, TextFile};
 
 use crate::{Result, USERNAME};
 
@@ -204,6 +204,30 @@ fn runas_override_repeated_cmnd_means_runas_union() -> Result<()> {
         .args(["-u", USERNAME, "true"])
         .output(&env)?
         .assert_success()?;
+
+    Ok(())
+}
+
+#[test]
+fn wildcards_dont_cross_directory_boundaries() -> Result<()> {
+    let env = Env("ALL ALL=(ALL:ALL) /usr/*/foo")
+        .directory("/usr/bin/sub")
+        .file("/usr/bin/sub/foo", TextFile("").chown("root").chmod("777"))
+        .build()?;
+
+    let output = Command::new("sudo")
+        .arg("/usr/bin/sub/foo")
+        .output(&env)?;
+
+    assert!(!output.status().success());
+    assert_eq!(Some(1), output.status().code());
+
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "user root is not allowed to execute '/usr/bin/sub/foo' as root"
+    } else {
+        "authentication failed: I'm sorry root. I'm afraid I can't do that"
+    };
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }


### PR DESCRIPTION
This PR:
- Disallows the matching of forward slashes to '*' in the globbing module
- Adds the feature that a directory in the sudoers file matches all file in it
- Adds some compliance tests related to command arguments (while we're at it)
- Makes a change to the CI so `#[ignore]`'d tests can be marked as `wontfix` (for compliance issues where we are uncomplaint)