### PR TITLE
Cleanup of PAM module, some more PAM implementation work

### DIFF
--- a/src/env/environment.rs
+++ b/src/env/environment.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, HashSet},
+    collections::{hash_map::Entry, HashMap, HashSet},
     ffi::{OsStr, OsString},
     os::unix::prelude::OsStrExt,
 };
@@ -189,6 +189,7 @@ fn should_keep(key: &OsStr, value: &OsStr, cfg: &impl Policy) -> bool {
 /// Environment variables with a value beginning with ‘()’ are removed
 pub fn get_target_environment(
     current_env: Environment,
+    additional_env: HashMap<OsString, OsString>,
     context: &Context,
     settings: &impl Policy,
 ) -> Environment {
@@ -196,6 +197,8 @@ pub fn get_target_environment(
 
     // retrieve SUDO_PS1 value to set a PS1 value as additional environment
     let sudo_ps1 = current_env.get(OsStr::new("SUDO_PS1")).cloned();
+
+    environment.extend(additional_env);
 
     environment.extend(
         current_env

--- a/src/env/environment.rs
+++ b/src/env/environment.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{hash_map::Entry, HashSet},
     ffi::{OsStr, OsString},
     os::unix::prelude::OsStrExt,
 };
@@ -189,7 +189,7 @@ fn should_keep(key: &OsStr, value: &OsStr, cfg: &impl Policy) -> bool {
 /// Environment variables with a value beginning with ‘()’ are removed
 pub fn get_target_environment(
     current_env: Environment,
-    additional_env: HashMap<OsString, OsString>,
+    additional_env: Environment,
     context: &Context,
     settings: &impl Policy,
 ) -> Environment {
@@ -198,6 +198,8 @@ pub fn get_target_environment(
     // retrieve SUDO_PS1 value to set a PS1 value as additional environment
     let sudo_ps1 = current_env.get(OsStr::new("SUDO_PS1")).cloned();
 
+    // variables preserved from the invoking user's environment by the
+    // env_keep list take precedence over those in the PAM environment
     environment.extend(additional_env);
 
     environment.extend(

--- a/src/env/tests.rs
+++ b/src/env/tests.rs
@@ -2,7 +2,7 @@ use crate::cli::SudoOptions;
 use crate::common::{CommandAndArguments, Context, Environment};
 use crate::env::environment::get_target_environment;
 use crate::system::{Group, Process, User};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 const TESTS: &str = "
 > env
@@ -156,7 +156,8 @@ fn test_environment_variable_filtering() {
         let options = SudoOptions::try_parse_from(cmd.split_whitespace()).unwrap();
         let settings = crate::sudoers::Judgement::default();
         let context = create_test_context(&options);
-        let resulting_env = get_target_environment(initial_env.clone(), &context, &settings);
+        let resulting_env =
+            get_target_environment(initial_env.clone(), HashMap::new(), &context, &settings);
 
         let resulting_env = environment_to_set(resulting_env);
         let expected_env = environment_to_set(expected_env);

--- a/src/pam/converse.rs
+++ b/src/pam/converse.rs
@@ -48,11 +48,6 @@ impl PamMessage {
     pub fn set_response(&mut self, resp: PamBuffer) {
         self.response = Some(resp);
     }
-
-    /// Clear the response to the message.
-    pub fn clear_response(&mut self) {
-        self.response = None;
-    }
 }
 
 /// Contains the conversation messages and allows setting responses to
@@ -66,11 +61,6 @@ pub struct Conversation {
 }
 
 impl Conversation {
-    /// Get an iterator of the messages in this conversation.
-    pub fn messages(&self) -> impl Iterator<Item = &PamMessage> {
-        self.messages.iter()
-    }
-
     /// Get a mutable iterator of the messages in this conversation.
     ///
     /// This can be used to add the resulting values to the messages.

--- a/src/su/mod.rs
+++ b/src/su/mod.rs
@@ -55,7 +55,7 @@ fn authenticate(user: &str, login: bool) -> Result<PamContext<CLIConverser>, Err
         }
     }
 
-    pam.validate_account()?;
+    pam.validate_account_or_change_auth_token()?;
     pam.open_session()?;
 
     Ok(pam)

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-use std::ffi::OsString;
 use std::process::exit;
 
 use crate::cli::SudoOptions;
-use crate::common::{Context, Error};
+use crate::common::{Context, Error, Environment};
 use crate::env::environment;
 use crate::exec::ExitReason;
 use crate::sudoers::{Authorization, DirChange, Policy, PreJudgementPolicy};
@@ -23,7 +21,7 @@ pub trait PolicyPlugin {
 pub trait AuthPlugin {
     fn init(&mut self, context: &Context) -> Result<(), Error>;
     fn authenticate(&mut self, context: &Context) -> Result<(), Error>;
-    fn pre_exec(&mut self, context: &Context) -> Result<HashMap<OsString, OsString>, Error>;
+    fn pre_exec(&mut self, context: &Context) -> Result<Environment, Error>;
     fn cleanup(&mut self);
 }
 

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -1,7 +1,7 @@
 use std::process::exit;
 
 use crate::cli::SudoOptions;
-use crate::common::{Context, Error, Environment};
+use crate::common::{Context, Environment, Error};
 use crate::env::environment;
 use crate::exec::ExitReason;
 use crate::sudoers::{Authorization, DirChange, Policy, PreJudgementPolicy};

--- a/test-framework/sudo-compliance-tests/src/pam/env.rs
+++ b/test-framework/sudo-compliance-tests/src/pam/env.rs
@@ -70,7 +70,6 @@ fn stock_pam_d_sudo() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh420"]
 fn preserves_pam_env() -> Result<()> {
     let set_name = "SET_VAR";
     let set_value = "set";
@@ -102,7 +101,6 @@ fn preserves_pam_env() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh420"]
 fn pam_env_has_precedence_over_callers_env() -> Result<()> {
     let set_name = "SET_VAR";
     let set_value = "set";
@@ -192,7 +190,6 @@ fn env_check_has_precedence_over_pam_env() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh420"]
 fn var_rejected_by_env_check_falls_back_to_pam_env_value() -> Result<()> {
     let set_name = "SET_VAR";
     let set_value = "set";
@@ -236,7 +233,6 @@ fn var_rejected_by_env_check_falls_back_to_pam_env_value() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh420"]
 fn default_and_override_pam_env_vars_are_parentheses_checked_but_set_vars_are_not() -> Result<()> {
     let set_name = "SET_VAR";
     let set_value = "() set";
@@ -268,7 +264,6 @@ fn default_and_override_pam_env_vars_are_parentheses_checked_but_set_vars_are_no
 }
 
 #[test]
-#[ignore = "gh420"]
 fn pam_env_vars_are_not_env_checked() -> Result<()> {
     let set_name = "SET_VAR";
     let set_value = "%set";


### PR DESCRIPTION
Related to #195 and fixes #476 and #420

- PAM now instantiates the session for the target user instead of the user authenticating
- We now run a change password routine if the password was expired
- We now pass environment variables from PAM back up and include them in our environment variables