### PR TITLE
`--non-interactive`

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -19,6 +19,7 @@ pub struct Context {
     pub target_user: User,
     pub target_group: Group,
     pub stdin: bool,
+    pub non_interactive: bool,
     pub use_session_records: bool,
     // system
     pub hostname: String,
@@ -61,6 +62,7 @@ impl Context {
             launch,
             chdir: sudo_options.directory,
             stdin: sudo_options.stdin,
+            non_interactive: sudo_options.non_interactive,
             process: Process::new(),
         })
     }

--- a/src/env/tests.rs
+++ b/src/env/tests.rs
@@ -134,6 +134,7 @@ fn create_test_context(sudo_options: &SudoOptions) -> Context {
         launch: crate::common::context::LaunchType::Direct,
         chdir: sudo_options.directory.clone(),
         stdin: sudo_options.stdin,
+        non_interactive: sudo_options.non_interactive,
         process: Process::new(),
         use_session_records: false,
     }

--- a/src/pam/error.rs
+++ b/src/pam/error.rs
@@ -191,6 +191,7 @@ pub enum PamError {
     SessionAlreadyOpen,
     SessionNotOpen,
     EnvListFailure,
+    InteractionRequired,
 }
 
 impl From<std::io::Error> for PamError {
@@ -227,6 +228,7 @@ impl fmt::Display for PamError {
                     "It was not possible to get a list of environment variables"
                 )
             }
+            PamError::InteractionRequired => write!(f, "Interaction is required"),
         }
     }
 }

--- a/src/pam/mod.rs
+++ b/src/pam/mod.rs
@@ -419,10 +419,15 @@ impl<C: Converser> PamContext<C> {
 
 impl PamContext<CLIConverser> {
     /// Create a builder that uses the CLI conversation function.
-    pub fn builder_cli(name: &str, use_stdin: bool) -> PamContextBuilder<CLIConverser> {
+    pub fn builder_cli(
+        name: &str,
+        use_stdin: bool,
+        no_interact: bool,
+    ) -> PamContextBuilder<CLIConverser> {
         PamContextBuilder::default().converser(CLIConverser {
             name: name.to_owned(),
             use_stdin,
+            no_interact,
         })
     }
 }

--- a/src/su/mod.rs
+++ b/src/su/mod.rs
@@ -14,7 +14,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn authenticate(user: &str, login: bool) -> Result<PamContext<CLIConverser>, Error> {
     let context = if login { "su-l" } else { "su" };
-    let mut pam = PamContext::builder_cli("su", false)
+    let mut pam = PamContext::builder_cli("su", Default::default(), Default::default())
         .target_user(user)
         .service_name(context)
         .build()?;

--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -93,7 +93,7 @@ impl<C: Converser> PamAuthenticator<C> {
 impl PamAuthenticator<CLIConverser> {
     pub fn new_cli() -> PamAuthenticator<CLIConverser> {
         PamAuthenticator::new(|context| {
-            let mut pam = PamContext::builder_cli("sudo", context.stdin)
+            let mut pam = PamContext::builder_cli("sudo", context.stdin, context.non_interactive)
                 .target_user(&context.current_user.name)
                 .service_name("sudo")
                 .build()?;

--- a/test-framework/sudo-compliance-tests/src/flag_non_interactive.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_non_interactive.rs
@@ -7,7 +7,6 @@ use sudo_test::{Command, Env, User};
 
 /* cases where password input is expected */
 #[test]
-#[ignore = "gh405"]
 fn fails_if_password_needed() -> Result<()> {
     let env = Env(SUDOERS_USER_ALL_ALL).user(USERNAME).build()?;
 
@@ -27,14 +26,17 @@ fn fails_if_password_needed() -> Result<()> {
     };
     assert_not_contains!(stderr, password_prompt);
 
-    let diagnostic = "sudo: a password is required";
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "sudo: a password is required"
+    } else {
+        "Maximum 3 incorrect authentication attempts"
+    };
     assert_contains!(stderr, diagnostic);
 
     Ok(())
 }
 
 #[test]
-#[ignore = "gh405"]
 fn flag_remove_timestamp_plus_command_fails() -> Result<()> {
     let env = Env(SUDOERS_USER_ALL_ALL).user(USERNAME).build()?;
 
@@ -57,7 +59,11 @@ fn flag_remove_timestamp_plus_command_fails() -> Result<()> {
     };
     assert_not_contains!(stderr, password_prompt);
 
-    let diagnostic = "sudo: a password is required";
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "sudo: a password is required"
+    } else {
+        "Maximum 3 incorrect authentication attempts"
+    };
     assert_contains!(stderr, diagnostic);
 
     Ok(())


### PR DESCRIPTION
Note: this PR implements this currently in the simplest way possible: if the PAM converser fails if something from stdin/the TTY is needed. However, this does result in sudo-rs trying to do this three times. I am not sure if this PR has  good way to fix that (the number of password retries is configurable in `sudo`, a cleaner approach would be to say that `-n` means you get 0 attempts).