### PR TITLE
ci: use a working nightly toolchain in track-dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -333,11 +333,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set rust nightly version
+        run: echo "NIGHTLY_VERSION=$(curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustc)" >> $GITHUB_ENV
+
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-${{ env.NIGHTLY_VERSION }}
           override: true
 
       - name: Install cargo-udeps


### PR DESCRIPTION
this is uses a similar approach to the one used to pick a working nightly toolchain for the miri job