### PR TITLE
Ogsudo compatible alias

### DIFF
--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -202,15 +202,16 @@ where
     let mut result = None;
     for item in items {
         let (judgement, who) = match item.clone().to_inner() {
-            Qualified::Forbid(x) => (None, x),
-            Qualified::Allow(x) => (Some(item.to_info()), x),
+            Qualified::Forbid(x) => (false, x),
+            Qualified::Allow(x) => (true, x),
         };
+        let info = || item.to_info();
         match who {
-            Meta::All => result = judgement,
-            Meta::Only(ident) if matches(ident) => result = judgement,
+            Meta::All => result = judgement.then(info),
+            Meta::Only(ident) if matches(ident) => result = judgement.then(info),
             Meta::Alias(id) if aliases.contains_key(id) => {
                 result = if aliases[id] {
-                    judgement
+                    judgement.then(info)
                 } else {
                     // in this case, an explicit negation in the alias applies
                     result // TODO REPLACE ME

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -214,7 +214,7 @@ where
                     judgement.then(info)
                 } else {
                     // in this case, an explicit negation in the alias applies
-                    result // TODO REPLACE ME
+                    (!judgement).then(info)
                 }
             }
             _ => {}

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -225,6 +225,10 @@ fn permission_test() {
     pass!(["Runas_Alias TIME=%wheel,!!sudo","user ALL=(TIME) ALL"], "user" => request! { wheel, wheel }, "vm"; "/bin/ls");
 
     pass!(["Runas_Alias \\"," TIME=%wheel\\",",sudo # hallo","user ALL\\","=(TIME) ALL"], "user" => request! { wheel, wheel }, "vm"; "/bin/ls");
+
+    // test the less-intuitive "substition-like" alias mechanism
+    pass!(["User_Alias FOO=!user", "ALL, FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");
+    FAIL!(["User_Alias FOO=!user", "!FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");
 }
 
 #[test]

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -227,8 +227,8 @@ fn permission_test() {
     pass!(["Runas_Alias \\"," TIME=%wheel\\",",sudo # hallo","user ALL\\","=(TIME) ALL"], "user" => request! { wheel, wheel }, "vm"; "/bin/ls");
 
     // test the less-intuitive "substition-like" alias mechanism
-    pass!(["User_Alias FOO=!user", "ALL, FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");
-    FAIL!(["User_Alias FOO=!user", "!FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");
+    FAIL!(["User_Alias FOO=!user", "ALL, FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");
+    pass!(["User_Alias FOO=!user", "!FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");
 }
 
 #[test]

--- a/test-framework/sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/cmnd_alias.rs
@@ -224,7 +224,6 @@ fn negation_not_order_sensitive() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "gh398"]
 #[test]
 fn negation_combination() -> Result<()> {
     let env = Env([
@@ -246,7 +245,6 @@ fn negation_combination() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "gh398"]
 #[test]
 fn another_negation_combination() -> Result<()> {
     let env = Env([
@@ -278,7 +276,6 @@ fn another_negation_combination() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "gh398"]
 #[test]
 fn one_more_negation_combination() -> Result<()> {
     let env = Env([

--- a/test-framework/sudo-compliance-tests/src/sudoers/host_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/host_alias.rs
@@ -196,7 +196,6 @@ fn negation_not_order_sensitive() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "gh379"]
 #[test]
 fn negation_combination() -> Result<()> {
     let env = Env([

--- a/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/user_list.rs
@@ -271,7 +271,6 @@ fn user_alias_cannot_start_with_underscore() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "gh180"]
 #[test]
 fn negated_user_alias_works() -> Result<()> {
     let env = Env("


### PR DESCRIPTION
This changes the behaviour of the Alias mechanism to mimic "textual substition style". But instead of completely overhauling the alias mechanism we had (which had the benefit of only doing recursion in a topological sort instead of "as needed"), we adapt it to suit this.

I.e. the `get_aliases` function now returns a HashMap which records not just "inclusion in the alias" but also "explicit rejection in the alias", and that information is usable to negate aliases. This does undo a readability change in `find_item` where `bool.then` was replaced by an `Option` in the early days of sudo-rs.

(The formal proof still needs to be updated to match this version, but that will be done in my spare time.)

The individual commits in this PR are deliberately kept very small since this function is very crucial.