### PR TITLE
Don't use a pseudoterminal if the user's terminal is not available

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -1,11 +1,9 @@
 #![deny(unsafe_code)]
 
-mod backchannel;
 mod event;
 mod interface;
 mod io_util;
-mod monitor;
-mod parent;
+mod use_pty;
 
 use std::{
     ffi::{CString, OsStr},
@@ -18,9 +16,10 @@ use std::{
 use crate::common::Environment;
 use crate::log::user_error;
 use crate::system::set_target_user;
-use parent::exec_pty;
 
 pub use interface::RunOptions;
+
+use self::use_pty::exec_pty;
 
 /// Based on `ogsudo`s `exec_pty` function.
 ///

--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -99,7 +99,10 @@ impl ExecClosure {
                 "command ({command_pid}) was stopped by {}",
                 signal_fmt(signal),
             );
-            // FIXME: check `sudo_suspend_parent`
+            // FIXME: this isn't right as the command has not exited if the signal is
+            // not a termination one. However, doing this makes us fail an ignored
+            // compliance test instead of hanging forever.
+            dispatcher.set_exit(ExitReason::Signal(signal));
         } else if let Some(signal) = status.term_signal() {
             dev_info!(
                 "command ({command_pid}) was terminated by {}",

--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -1,0 +1,132 @@
+use std::{io, process::Command};
+
+use signal_hook::consts::*;
+
+use super::{
+    event::{EventClosure, EventDispatcher, StopReason},
+    terminate_process, ExitReason,
+};
+use crate::{
+    exec::io_util::was_interrupted,
+    system::{
+        getpgid,
+        interface::ProcessId,
+        kill,
+        signal::SignalInfo,
+        wait::{waitpid, WaitError, WaitOptions},
+    },
+};
+
+pub(crate) fn exec_no_pty(
+    sudo_pid: ProcessId,
+    mut command: Command,
+) -> io::Result<(ExitReason, impl FnOnce())> {
+    // FIXME (ogsudo): Initialize the policy plugin's session here.
+
+    // FIXME: block signals directly instead of using the dispatcher.
+    let mut dispatcher = EventDispatcher::new()?;
+
+    // FIXME (ogsudo): Some extra config happens here if selinux is available.
+
+    let command = command.spawn()?;
+
+    let mut closure = ExecClosure::new(command.id() as ProcessId, sudo_pid);
+
+    // FIXME: restore signal mask here.
+
+    let exit_reason = match dispatcher.event_loop(&mut closure) {
+        StopReason::Break(reason) => match reason {},
+        StopReason::Exit(reason) => reason,
+    };
+
+    Ok((exit_reason, move || drop(dispatcher)))
+}
+
+struct ExecClosure {
+    command_pid: Option<ProcessId>,
+    sudo_pid: ProcessId,
+}
+
+impl ExecClosure {
+    fn new(command_pid: ProcessId, sudo_pid: ProcessId) -> Self {
+        Self {
+            command_pid: Some(command_pid),
+            sudo_pid,
+        }
+    }
+
+    /// Decides if the signal sent by the process with `signaler_pid` PID is self-terminating.
+    ///
+    /// A signal is self-terminating if `signaler_pid`:
+    /// - is the same PID of the command, or
+    /// - is in the process group of the command and either sudo or the command is the leader.
+    fn is_self_terminating(&self, signaler_pid: ProcessId) -> bool {
+        if signaler_pid != 0 {
+            if Some(signaler_pid) == self.command_pid {
+                return true;
+            }
+
+            if let Ok(signaler_pgrp) = getpgid(signaler_pid) {
+                if Some(signaler_pgrp) == self.command_pid || signaler_pgrp == self.sudo_pid {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    fn handle_sigchld(&mut self, command_pid: ProcessId, dispatcher: &mut EventDispatcher<Self>) {
+        const OPTS: WaitOptions = WaitOptions::new().all().untraced().no_hang();
+
+        let status = loop {
+            match waitpid(command_pid, OPTS) {
+                Err(WaitError::Io(err)) if was_interrupted(&err) => {}
+                Err(_) => {}
+                Ok((_pid, status)) => break status,
+            }
+        };
+
+        if let Some(_signal) = status.stop_signal() {
+            // FIXME: check `sudo_suspend_parent`
+        } else if let Some(signal) = status.term_signal() {
+            dispatcher.set_exit(ExitReason::Signal(signal));
+            self.command_pid = None;
+        } else if let Some(exit_code) = status.exit_status() {
+            dispatcher.set_exit(ExitReason::Code(exit_code));
+            self.command_pid = None;
+        }
+    }
+}
+
+impl EventClosure for ExecClosure {
+    type Break = std::convert::Infallible;
+    type Exit = ExitReason;
+
+    fn on_signal(&mut self, info: SignalInfo, dispatcher: &mut EventDispatcher<Self>) {
+        let Some(command_pid) = self.command_pid else {
+            return;
+        };
+
+        match info.signal() {
+            SIGCHLD => {
+                self.handle_sigchld(command_pid, dispatcher);
+            }
+            signal => {
+                if signal == SIGWINCH {
+                    // FIXME: check `handle_sigwinch_no_pty`.
+                }
+                // Skip the signal if it was sent by the user and it is self-terminating.
+                if info.is_user_signaled() && self.is_self_terminating(info.pid()) {
+                    return;
+                }
+
+                if signal == SIGALRM {
+                    terminate_process(command_pid, false);
+                } else {
+                    kill(command_pid, signal).ok();
+                }
+            }
+        }
+    }
+}

--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -20,7 +20,7 @@ use crate::{
 pub(crate) fn exec_no_pty(
     sudo_pid: ProcessId,
     mut command: Command,
-) -> io::Result<(ExitReason, impl FnOnce())> {
+) -> io::Result<(ExitReason, Box<dyn FnOnce()>)> {
     // FIXME (ogsudo): Initialize the policy plugin's session here.
 
     // FIXME: block signals directly instead of using the dispatcher.
@@ -39,7 +39,7 @@ pub(crate) fn exec_no_pty(
         StopReason::Exit(reason) => reason,
     };
 
-    Ok((exit_reason, move || drop(dispatcher)))
+    Ok((exit_reason, Box::new(move || drop(dispatcher))))
 }
 
 struct ExecClosure {

--- a/src/exec/use_pty/backchannel.rs
+++ b/src/exec/use_pty/backchannel.rs
@@ -8,9 +8,8 @@ use std::{
     },
 };
 
+use crate::exec::{signal_fmt, ExitReason};
 use crate::system::{interface::ProcessId, signal::SignalNumber};
-
-use super::{signal_fmt, ExitReason};
 
 type Prefix = u8;
 type ParentData = c_int;

--- a/src/exec/use_pty/mod.rs
+++ b/src/exec/use_pty/mod.rs
@@ -1,0 +1,5 @@
+mod backchannel;
+mod monitor;
+mod parent;
+
+pub(super) use parent::exec_pty;

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -24,13 +24,13 @@ use crate::{
 
 use signal_hook::consts::*;
 
-use super::{
-    backchannel::{MonitorBackchannel, MonitorMessage, ParentMessage},
+use crate::exec::{cond_fmt, signal_fmt};
+use crate::exec::{
     event::{EventClosure, EventDispatcher},
     io_util::{retry_while_interrupted, was_interrupted},
+    use_pty::backchannel::{MonitorBackchannel, MonitorMessage, ParentMessage},
     ExitReason,
 };
-use super::{cond_fmt, signal_fmt};
 
 // FIXME: This should return `io::Result<!>` but `!` is not stable yet.
 pub(super) fn exec_monitor(

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -6,20 +6,22 @@ use std::{
         unix::{net::UnixStream, process::CommandExt},
     },
     process::{exit, Command},
-    time::Duration,
 };
 
-use crate::system::{
-    fork, getpgid,
-    interface::ProcessId,
-    kill, setpgid, setsid,
-    signal::SignalInfo,
-    term::{set_controlling_terminal, tcgetpgrp, tcsetpgrp},
-    wait::{waitpid, WaitError, WaitOptions},
-};
 use crate::{
     exec::event::StopReason,
     log::{dev_info, dev_warn},
+};
+use crate::{
+    exec::terminate_process,
+    system::{
+        fork, getpgid,
+        interface::ProcessId,
+        kill, setpgid, setsid,
+        signal::SignalInfo,
+        term::{set_controlling_terminal, tcgetpgrp, tcsetpgrp},
+        wait::{waitpid, WaitError, WaitOptions},
+    },
 };
 
 use signal_hook::consts::*;
@@ -296,11 +298,7 @@ fn send_signal(signal: c_int, command_pid: ProcessId, from_parent: bool) {
     // FIXME: We should call `killpg` instead of `kill`.
     match signal {
         SIGALRM => {
-            // Kill the command with increasing urgency. Based on `terminate_command`.
-            kill(command_pid, SIGHUP).ok();
-            kill(command_pid, SIGTERM).ok();
-            std::thread::sleep(Duration::from_secs(2));
-            kill(command_pid, SIGKILL).ok();
+            terminate_process(command_pid, false);
         }
         signal => {
             // Send the signal to the command.

--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/mod.rs
@@ -5,10 +5,59 @@ use crate::{
     Result, SUDOERS_ALL_ALL_NOPASSWD, SUDOERS_USER_ALL_NOPASSWD, SUDOERS_USE_PTY, USERNAME,
 };
 
+mod tty {
+    use crate::Result;
+
+    #[test]
+    fn signal_sent_by_child_process_is_ignored() -> Result<()> {
+        super::signal_sent_by_child_process_is_ignored(true)
+    }
+
+    #[test]
+    fn signal_is_forwarded_to_child() -> Result<()> {
+        super::signal_is_forwarded_to_child(true)
+    }
+
+    #[test]
+    fn child_terminated_by_signal() -> Result<()> {
+        super::child_terminated_by_signal(true)
+    }
+
+    #[test]
+    #[ignore = "gh325"]
+    fn sigtstp_works() -> Result<()> {
+        super::sigtstp_works(true)
+    }
+}
+
+mod no_tty {
+    use crate::Result;
+
+    #[test]
+    fn signal_sent_by_child_process_is_ignored() -> Result<()> {
+        super::signal_sent_by_child_process_is_ignored(false)
+    }
+
+    #[test]
+    fn signal_is_forwarded_to_child() -> Result<()> {
+        super::signal_is_forwarded_to_child(false)
+    }
+
+    #[test]
+    fn child_terminated_by_signal() -> Result<()> {
+        super::child_terminated_by_signal(false)
+    }
+
+    #[test]
+    #[ignore = "gh325"]
+    fn sigtstp_works() -> Result<()> {
+        super::sigtstp_works(false)
+    }
+}
+
 // man sudo > Signal handling
 // "As a special case, sudo will not relay signals that were sent by the command it is running."
-#[test]
-fn signal_sent_by_child_process_is_ignored() -> Result<()> {
+fn signal_sent_by_child_process_is_ignored(tty: bool) -> Result<()> {
     let script = include_str!("kill-sudo-parent.sh");
 
     let kill_sudo_parent = "/root/kill-sudo-parent.sh";
@@ -20,13 +69,12 @@ fn signal_sent_by_child_process_is_ignored() -> Result<()> {
     Command::new("sudo")
         .args(["sh", kill_sudo_parent])
         .as_user(USERNAME)
-        .tty(true)
+        .tty(tty)
         .output(&env)?
         .assert_success()
 }
 
-#[test]
-fn signal_is_forwarded_to_child() -> Result<()> {
+fn signal_is_forwarded_to_child(tty: bool) -> Result<()> {
     let expected = "got signal";
     let expects_signal = "/root/expects-signal.sh";
     let kill_sudo = "/root/kill-sudo.sh";
@@ -43,7 +91,7 @@ fn signal_is_forwarded_to_child() -> Result<()> {
 
     Command::new("sh")
         .arg(kill_sudo)
-        .tty(true)
+        .tty(tty)
         .output(&env)?
         .assert_success()?;
 
@@ -56,8 +104,7 @@ fn signal_is_forwarded_to_child() -> Result<()> {
 
 // man sudo > Exit value
 // "If the command terminated due to receipt of a signal, sudo will send itself the same signal that terminated the command."
-#[test]
-fn child_terminated_by_signal() -> Result<()> {
+fn child_terminated_by_signal(tty: bool) -> Result<()> {
     let env = Env([SUDOERS_USER_ALL_NOPASSWD, SUDOERS_USE_PTY])
         .user(USERNAME)
         .build()?;
@@ -66,7 +113,7 @@ fn child_terminated_by_signal() -> Result<()> {
     let output = Command::new("sudo")
         .args(["sh", "-c", "kill $$"])
         .as_user(USERNAME)
-        .tty(true)
+        .tty(tty)
         .output(&env)?;
 
     assert_eq!(Some(143), output.status().code());
@@ -75,9 +122,7 @@ fn child_terminated_by_signal() -> Result<()> {
     Ok(())
 }
 
-#[test]
-#[ignore = "gh325"]
-fn sigtstp_works() -> Result<()> {
+fn sigtstp_works(tty: bool) -> Result<()> {
     const STOP_DELAY: u64 = 5;
     const NUM_ITERATIONS: usize = 5;
 
@@ -88,7 +133,7 @@ fn sigtstp_works() -> Result<()> {
 
     let output = Command::new("bash")
         .arg(script_path)
-        .tty(true)
+        .tty(tty)
         .output(&env)?
         .stdout()?;
 

--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/mod.rs
@@ -5,54 +5,38 @@ use crate::{
     Result, SUDOERS_ALL_ALL_NOPASSWD, SUDOERS_USER_ALL_NOPASSWD, SUDOERS_USE_PTY, USERNAME,
 };
 
-mod tty {
-    use crate::Result;
+macro_rules! dup {
+    ($($(#[$attrs:meta])* $name:ident,)*) => {
+        mod tty {
+            use crate::Result;
+            $(
+                #[test]
+                $(#[$attrs])*
+                fn $name() -> Result<()> {
+                    super::$name(true)
+                }
+            )*
+        }
 
-    #[test]
-    fn signal_sent_by_child_process_is_ignored() -> Result<()> {
-        super::signal_sent_by_child_process_is_ignored(true)
-    }
-
-    #[test]
-    fn signal_is_forwarded_to_child() -> Result<()> {
-        super::signal_is_forwarded_to_child(true)
-    }
-
-    #[test]
-    fn child_terminated_by_signal() -> Result<()> {
-        super::child_terminated_by_signal(true)
-    }
-
-    #[test]
-    #[ignore = "gh325"]
-    fn sigtstp_works() -> Result<()> {
-        super::sigtstp_works(true)
-    }
+        mod no_tty {
+            use crate::Result;
+            $(
+                #[test]
+                $(#[$attrs])*
+                fn $name() -> Result<()> {
+                    super::$name(false)
+                }
+            )*
+        }
+    };
 }
 
-mod no_tty {
-    use crate::Result;
-
-    #[test]
-    fn signal_sent_by_child_process_is_ignored() -> Result<()> {
-        super::signal_sent_by_child_process_is_ignored(false)
-    }
-
-    #[test]
-    fn signal_is_forwarded_to_child() -> Result<()> {
-        super::signal_is_forwarded_to_child(false)
-    }
-
-    #[test]
-    fn child_terminated_by_signal() -> Result<()> {
-        super::child_terminated_by_signal(false)
-    }
-
-    #[test]
+dup! {
+    signal_sent_by_child_process_is_ignored,
+    signal_is_forwarded_to_child,
+    child_terminated_by_signal,
     #[ignore = "gh325"]
-    fn sigtstp_works() -> Result<()> {
-        super::sigtstp_works(false)
-    }
+    sigtstp_works,
 }
 
 // man sudo > Signal handling


### PR DESCRIPTION
**Describe the changes done on this pull request**

This PR brings back the `no_pty` behavior and runs it when sudo cannot open `/dev/tty` even if `use_pty` is set in the sudoers file.

It also updates the signal handling tests to run with and without a tty.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
