### PR TITLE
Restore the terminal after the command is done

### DIFF
--- a/test-framework/sudo-compliance-tests/src/use_pty.rs
+++ b/test-framework/sudo-compliance-tests/src/use_pty.rs
@@ -100,6 +100,24 @@ fn process_state() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn terminal_is_restored() -> Result<()> {
+    let env = Env([SUDOERS_ALL_ALL_NOPASSWD, "Defaults use_pty"]).build()?;
+    // Run `stty` before and after running sudo to check that the terminal configuration is
+    // restored before sudo exits.
+    let stdout = Command::new("sh")
+        .args(["-c", "stty; sudo echo 'hello'; stty"])
+        .tty(true)
+        .output(&env)?
+        .stdout()?;
+
+    assert_contains!(stdout, "hello");
+    let (before, after) = stdout.split_once("hello").unwrap();
+    assert_eq!(before.trim(), after.trim());
+
+    Ok(())
+}
+
 fn parse_ps_aux(ps_aux: &str) -> Vec<PsAuxEntry> {
     let mut entries = vec![];
     for line in ps_aux.lines().skip(1 /* header */) {


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR updates the `use_pty` behavior so it restores the terminal settings after the command is done. It also adds a test to be sure we don't break this again in the future.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/526 where a proper discussion about a solution has taken place.
