### PR TITLE
Implement `timestamp_timeout`

### DIFF
--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -4,7 +4,7 @@
 // "verifypw" and "logfile"
 pub enum SudoDefault {
     Flag(bool),
-    Integer(OptTuple<i128>, fn(&str) -> Option<i128>),
+    Integer(OptTuple<i64>, fn(&str) -> Option<i64>),
     Text(OptTuple<Option<&'static str>>),
     List(&'static [&'static str]),
     Enum(OptTuple<StrEnum<'static>>),

--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -40,6 +40,8 @@ defaults! {
     secure_path               = None (!= None)
     verifypw                  = "all" (!= "never") [all, always, any, never]
 
+    timestamp_timeout         = 15 (!= 0)
+
     env_keep                  = ["COLORS", "DISPLAY", "HOSTNAME", "KRB5CCNAME", "LS_COLORS", "PATH",
                                  "PS1", "PS2", "XAUTHORITY", "XAUTHORIZATION", "XDG_CURRENT_DESKTOP"]
 

--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -40,7 +40,7 @@ defaults! {
     secure_path               = None (!= None)
     verifypw                  = "all" (!= "never") [all, always, any, never]
 
-    timestamp_timeout         = 15 (!= 0)
+    timestamp_timeout         = (15*60) (!= 0) {fractional_minutes}
 
     env_keep                  = ["COLORS", "DISPLAY", "HOSTNAME", "KRB5CCNAME", "LS_COLORS", "PATH",
                                  "PS1", "PS2", "XAUTHORITY", "XAUTHORIZATION", "XDG_CURRENT_DESKTOP"]
@@ -54,6 +54,16 @@ defaults! {
                                 "PERLLIB", "PERL5LIB", "PERL5OPT", "PERL5DB", "FPATH", "NULLCMD",
                                 "READNULLCMD", "ZDOTDIR", "TMPPREFIX", "PYTHONHOME", "PYTHONPATH",
                                 "PYTHONINSPECT", "PYTHONUSERBASE", "RUBYLIB", "RUBYOPT", "*=()*"]
+}
+
+/// A custom parser to parse seconds as fractional "minutes", the format used by
+/// passwd_timeout and timestamp_timeout.
+fn fractional_minutes(input: &str) -> Option<i64> {
+    if input.contains('.') {
+        Some((input.parse::<f64>().ok()? * 60.0).floor() as i64)
+    } else {
+        Some(input.parse::<i64>().ok()? * 60)
+    }
 }
 
 #[cfg(test)]

--- a/src/defaults/settings_dsl.rs
+++ b/src/defaults/settings_dsl.rs
@@ -56,7 +56,7 @@ macro_rules! optional {
 }
 
 macro_rules! defaults {
-    ($($name:ident = $value:tt $((!= $negate:tt))? $([$($key:ident),*])? $([$first:literal ..= $last:literal$(; radix: $radix: expr)?])?)*) => {
+    ($($name:ident = $value:tt $((!= $negate:tt))? $([$($key:ident),*])? $([$first:literal ..= $last:literal$(; radix: $radix: expr)?])? $({$fn: expr})?)*) => {
         pub const ALL_PARAMS: &'static [&'static str] = &[
             $(stringify!($name)),*
         ];
@@ -86,6 +86,11 @@ macro_rules! defaults {
                           $(
                               if let SudoDefault::Integer(_, ref mut checker) = &mut result {
                                   *checker = |text| i64::from_str_radix(text, 10$(*0 + $radix)?).ok().filter(|val| ($first ..= $last).contains(val));
+                              }
+                          )?
+                          $(
+                              if let SudoDefault::Integer(_, ref mut checker) = &mut result {
+                                  *checker = $fn
                               }
                           )?
                           result

--- a/src/defaults/settings_dsl.rs
+++ b/src/defaults/settings_dsl.rs
@@ -68,7 +68,7 @@ macro_rules! defaults {
         #[allow(clippy::from_str_radix_10)]
         pub fn sudo_default(var: &str) -> Option<SudoDefault> {
             add_from!(Flag, bool);
-            add_from!(Integer, i128, negatable, |text| i128::from_str_radix(text, 10).ok());
+            add_from!(Integer, i64, negatable, |text| i64::from_str_radix(text, 10).ok());
             add_from!(Text, &'static str, negatable);
             add_from!(Text, Option<&'static str>, negatable);
             add_from!(List, &'static [&'static str]);
@@ -85,7 +85,7 @@ macro_rules! defaults {
                           let mut result = tupleify!(datum$(, restrict($negate))?).into();
                           $(
                               if let SudoDefault::Integer(_, ref mut checker) = &mut result {
-                                  *checker = |text| i128::from_str_radix(text, 10$(*0 + $radix)?).ok().filter(|val| ($first ..= $last).contains(val));
+                                  *checker = |text| i64::from_str_radix(text, 10$(*0 + $radix)?).ok().filter(|val| ($first ..= $last).contains(val));
                               }
                           )?
                           result

--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -49,9 +49,10 @@ pub fn determine_record_scope(process: &Process) -> Option<RecordScope> {
 fn determine_auth_status(
     record_for: Option<RecordScope>,
     context: &Context,
+    prior_validity: Duration,
 ) -> (bool, Option<SessionRecordFile<File>>) {
     if let (true, Some(record_for)) = (context.use_session_records, record_for) {
-        match SessionRecordFile::open_for_user(&context.current_user.name, Duration::minutes(15)) {
+        match SessionRecordFile::open_for_user(&context.current_user.name, prior_validity) {
             Ok(mut sr) => {
                 match sr.touch(record_for, context.current_user.uid) {
                     // if a record was found and updated within the timeout, we do not need to authenticate
@@ -112,7 +113,12 @@ impl<C: Converser> AuthPlugin for PamAuthenticator<C> {
         Ok(())
     }
 
-    fn authenticate(&mut self, context: &Context, mut max_tries: u16) -> Result<(), Error> {
+    fn authenticate(
+        &mut self,
+        context: &Context,
+        prior_validity: Duration,
+        mut max_tries: u16,
+    ) -> Result<(), Error> {
         let pam = self
             .pam
             .as_mut()
@@ -123,7 +129,8 @@ impl<C: Converser> AuthPlugin for PamAuthenticator<C> {
         let scope = determine_record_scope(&context.process);
 
         // only if there is an interactive terminal or parent process we can store session information
-        let (must_authenticate, records_file) = determine_auth_status(scope, context);
+        let (must_authenticate, records_file) =
+            determine_auth_status(scope, context, prior_validity);
 
         if must_authenticate {
             let mut current_try = 0;

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -79,7 +79,7 @@ pub type TextEnum = crate::defaults::StrEnum<'static>;
 pub enum ConfigValue {
     Flag(bool),
     Text(Option<Box<str>>),
-    Num(i128),
+    Num(i64),
     List(Mode, Vec<String>),
     Enum(TextEnum),
 }

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -343,7 +343,7 @@ pub struct Settings {
     pub flags: HashSet<String>,
     pub str_value: HashMap<String, Option<Box<str>>>,
     pub enum_value: HashMap<String, TextEnum>,
-    pub int_value: HashMap<String, i128>,
+    pub int_value: HashMap<String, i64>,
     pub list: HashMap<String, HashSet<String>>,
 }
 

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -47,11 +47,11 @@ impl Policy for Judgement {
     fn authorization(&self) -> Authorization {
         if let Some(tag) = &self.flags {
             let allowed_attempts = self.settings.int_value["passwd_tries"].try_into().unwrap();
-            let valid_minutes = self.settings.int_value["timestamp_timeout"];
+            let valid_seconds = self.settings.int_value["timestamp_timeout"];
             Authorization::Allowed {
                 must_authenticate: tag.passwd,
                 allowed_attempts,
-                prior_validity: Duration::minutes(valid_minutes),
+                prior_validity: Duration::seconds(valid_seconds),
             }
         } else {
             Authorization::Forbidden

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -47,7 +47,7 @@ impl Policy for Judgement {
     fn authorization(&self) -> Authorization {
         if let Some(tag) = &self.flags {
             let allowed_attempts = self.settings.int_value["passwd_tries"].try_into().unwrap();
-            let valid_minutes = self.settings.int_value["timestamp_timeout"].try_into().unwrap();
+            let valid_minutes = self.settings.int_value["timestamp_timeout"];
             Authorization::Allowed {
                 must_authenticate: tag.passwd,
                 allowed_attempts,

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -46,10 +46,12 @@ pub enum DirChange<'a> {
 impl Policy for Judgement {
     fn authorization(&self) -> Authorization {
         if let Some(tag) = &self.flags {
+            let allowed_attempts = self.settings.int_value["passwd_tries"].try_into().unwrap();
+            let valid_minutes = self.settings.int_value["timestamp_timeout"].try_into().unwrap();
             Authorization::Allowed {
                 must_authenticate: tag.passwd,
-                allowed_attempts: self.settings.int_value["passwd_tries"].try_into().unwrap(),
-                prior_validity: Duration::minutes(15),
+                allowed_attempts,
+                prior_validity: Duration::minutes(valid_minutes),
             }
         } else {
             Authorization::Forbidden

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -1,6 +1,7 @@
 use super::Sudoers;
 
 use super::Judgement;
+use crate::system::time::Duration;
 /// Data types and traits that represent what the "terms and conditions" are after a succesful
 /// permission check.
 ///
@@ -30,6 +31,7 @@ pub enum Authorization {
     Allowed {
         must_authenticate: bool,
         allowed_attempts: u16,
+        prior_validity: Duration,
     },
     Forbidden,
 }
@@ -47,6 +49,7 @@ impl Policy for Judgement {
             Authorization::Allowed {
                 must_authenticate: tag.passwd,
                 allowed_attempts: self.settings.int_value["passwd_tries"].try_into().unwrap(),
+                prior_validity: Duration::minutes(15),
             }
         } else {
             Authorization::Forbidden
@@ -112,6 +115,7 @@ mod test {
             Authorization::Allowed {
                 must_authenticate: true,
                 allowed_attempts: 3,
+                prior_validity: Duration::minutes(15),
             }
         );
         judge.mod_flag(|tag| tag.passwd = false);
@@ -120,6 +124,7 @@ mod test {
             Authorization::Allowed {
                 must_authenticate: false,
                 allowed_attempts: 3,
+                prior_validity: Duration::minutes(15),
             }
         );
     }

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -46,7 +46,7 @@ impl Token for Numeric {
     }
 
     fn accept(c: char) -> bool {
-        c.is_ascii_hexdigit()
+        c.is_ascii_hexdigit() || c == '.'
     }
 }
 

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -39,7 +39,7 @@ impl Token for Digits {
 pub struct Numeric(pub String);
 
 impl Token for Numeric {
-    const MAX_LEN: usize = 38;
+    const MAX_LEN: usize = 18;
 
     fn construct(s: String) -> Result<Self, String> {
         Ok(Numeric(s))

--- a/test-framework/sudo-compliance-tests/src/su.rs
+++ b/test-framework/sudo-compliance-tests/src/su.rs
@@ -47,14 +47,13 @@ fn target_user_must_exist_in_passwd_db() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
 
-
     let diagnostic = if sudo_test::is_original_sudo() {
         format!("user {USERNAME} does not exist or the user entry does not contain all the required fields")
     } else {
         format!("user '{USERNAME}' not found")
     };
 
-    assert_contains!(output.stderr(), diagnostic );
+    assert_contains!(output.stderr(), diagnostic);
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/sudoers/timestamp_timeout.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/timestamp_timeout.rs
@@ -13,6 +13,17 @@ Defaults timestamp_timeout=0.1"
     .build()?;
 
     // input valid credentials
+    // try to sudo without a password
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "echo {PASSWORD} | sudo -S true; sudo true"
+        ))
+        .as_user(USERNAME)
+        .output(&env)?
+        .assert_success()?;
+
+    // input valid credentials
     // wait until they expire / timeout
     // try to sudo without a password
     let output = Command::new("sh")

--- a/test-framework/sudo-compliance-tests/src/sudoers/timestamp_timeout.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/timestamp_timeout.rs
@@ -3,7 +3,6 @@ use sudo_test::{Command, Env, User};
 use crate::{Result, PASSWORD, USERNAME};
 
 #[test]
-#[ignore = "gh394"]
 fn nonzero() -> Result<()> {
     let env = Env(format!(
         "{USERNAME} ALL=(ALL:ALL) ALL

--- a/test-framework/sudo-compliance-tests/src/sudoers/timestamp_timeout.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/timestamp_timeout.rs
@@ -37,7 +37,6 @@ Defaults timestamp_timeout=0.1"
 }
 
 #[test]
-#[ignore = "gh394"]
 fn zero_always_prompts_for_password() -> Result<()> {
     let env = Env(format!(
         "{USERNAME} ALL=(ALL:ALL) ALL

--- a/test-framework/sudo-compliance-tests/src/sudoers/timestamp_timeout.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/timestamp_timeout.rs
@@ -3,7 +3,7 @@ use sudo_test::{Command, Env, User};
 use crate::{Result, PASSWORD, USERNAME};
 
 #[test]
-fn nonzero() -> Result<()> {
+fn credential_caching_works_with_custom_timeout() -> Result<()> {
     let env = Env(format!(
         "{USERNAME} ALL=(ALL:ALL) ALL
 Defaults timestamp_timeout=0.1"
@@ -21,6 +21,18 @@ Defaults timestamp_timeout=0.1"
         .as_user(USERNAME)
         .output(&env)?
         .assert_success()?;
+
+    Ok(())
+}
+
+#[test]
+fn nonzero() -> Result<()> {
+    let env = Env(format!(
+        "{USERNAME} ALL=(ALL:ALL) ALL
+Defaults timestamp_timeout=0.1"
+    ))
+    .user(User(USERNAME).password(PASSWORD))
+    .build()?;
 
     // input valid credentials
     // wait until they expire / timeout


### PR DESCRIPTION
~~Note: if it passed the compliance test, it can be merged already, except that to close #394 we also need to support the fractional notation (for other timeouts sudo uses a different, probably more recent syntax)~~

This PR adds support for timestamp_timeout, and slightly extends the defaults DSL with support for "ad hoc" parsers for numerical values (can also come in handy if we do different things), since there seems to be less regularity in them than previously thought.