### PR TITLE
Make the `system` module more rusty

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -92,7 +92,7 @@ pub fn run_command(
         options.group().clone(),
     );
 
-    match UserTerm::new() {
+    match UserTerm::open() {
         Ok(user_tty) => exec_pty(options.pid(), command, user_tty),
         Err(err) => {
             dev_info!("Could not open user's terminal, not allocating a pty: {err}");

--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -10,7 +10,7 @@ use crate::{
     exec::{io_util::was_interrupted, opt_fmt, signal_fmt},
     log::{dev_error, dev_info, dev_warn},
     system::{
-        getpgid,
+        getpgid, getpgrp,
         interface::ProcessId,
         kill, killpg,
         signal::{SignalAction, SignalInfo, SignalNumber},
@@ -58,12 +58,10 @@ struct ExecClosure {
 
 impl ExecClosure {
     fn new(command_pid: ProcessId, sudo_pid: ProcessId) -> Self {
-        // FIXME: handle this!
-        let parent_pgrp = getpgid(0).unwrap_or(-1);
         Self {
             command_pid: Some(command_pid),
             sudo_pid,
-            parent_pgrp,
+            parent_pgrp: getpgrp(),
         }
     }
 

--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -14,7 +14,7 @@ use crate::{
         interface::ProcessId,
         kill, killpg,
         signal::{SignalAction, SignalInfo, SignalNumber},
-        term::{tcgetpgrp, UserTerm},
+        term::{Terminal, UserTerm},
         wait::{waitpid, WaitError, WaitOptions},
     },
 };
@@ -129,7 +129,7 @@ impl ExecClosure {
         let mut opt_pgrp = None;
 
         if let Some(tty) = opt_tty.as_ref() {
-            if let Ok(saved_pgrp) = tcgetpgrp(tty) {
+            if let Ok(saved_pgrp) = tty.tcgetpgrp() {
                 // Save the terminal's foreground process group so we can restore it after resuming
                 // if needed.
                 opt_pgrp = Some(saved_pgrp);

--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -123,7 +123,7 @@ impl ExecClosure {
 
     /// Suspend the main process.
     fn suspend_parent(&self, signal: SignalNumber, dispatcher: &mut EventDispatcher<Self>) {
-        let mut opt_tty = UserTerm::new().ok();
+        let mut opt_tty = UserTerm::open().ok();
         let mut opt_pgrp = None;
 
         if let Some(tty) = opt_tty.as_ref() {

--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -15,7 +15,7 @@ use crate::{
         kill, killpg,
         signal::{SignalAction, SignalInfo, SignalNumber},
         term::{Terminal, UserTerm},
-        wait::{waitpid, WaitError, WaitOptions},
+        wait::{Wait, WaitError, WaitOptions},
     },
 };
 
@@ -92,7 +92,7 @@ impl ExecClosure {
         const OPTS: WaitOptions = WaitOptions::new().all().untraced().no_hang();
 
         let status = loop {
-            match waitpid(command_pid, OPTS) {
+            match command_pid.wait(OPTS) {
                 Err(WaitError::Io(err)) if was_interrupted(&err) => {}
                 Err(_) => {}
                 Ok((_pid, status)) => break status,

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -16,7 +16,7 @@ use crate::{
         kill, setpgid, setsid,
         signal::SignalInfo,
         term::Terminal,
-        wait::{waitpid, WaitError, WaitOptions, WaitStatus},
+        wait::{Wait, WaitError, WaitOptions, WaitStatus},
     },
 };
 use crate::{
@@ -259,7 +259,7 @@ impl<'a> MonitorClosure<'a> {
 
     fn handle_sigchld(&mut self, command_pid: ProcessId, dispatcher: &mut EventDispatcher<Self>) {
         let status = loop {
-            match waitpid(command_pid, WaitOptions::new().untraced().no_hang()) {
+            match command_pid.wait(WaitOptions::new().untraced().no_hang()) {
                 Ok((_pid, status)) => break status,
                 Err(WaitError::Io(err)) if was_interrupted(&err) => {}
                 Err(_) => return,

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -15,7 +15,7 @@ use crate::{
         interface::ProcessId,
         kill, setpgid, setsid,
         signal::SignalInfo,
-        term::{set_controlling_terminal, tcgetpgrp, tcsetpgrp},
+        term::Terminal,
         wait::{waitpid, WaitError, WaitOptions, WaitStatus},
     },
 };
@@ -57,7 +57,7 @@ pub(super) fn exec_monitor(
     })?;
 
     // Set the follower side of the pty as the controlling terminal for the session.
-    set_controlling_terminal(&pty_follower).map_err(|err| {
+    pty_follower.make_controlling_terminal().map_err(|err| {
         dev_warn!("cannot set the controlling terminal: {err}");
         err
     })?;
@@ -112,7 +112,7 @@ pub(super) fn exec_monitor(
 
     // Set the foreground group for the pty follower.
     if foreground {
-        if let Err(err) = tcsetpgrp(&closure.pty_follower, closure.command_pgrp) {
+        if let Err(err) = closure.pty_follower.tcsetpgrp(closure.command_pgrp) {
             dev_error!(
                 "cannot set foreground progess group to command ({}): {err}",
                 closure.command_pgrp
@@ -129,7 +129,7 @@ pub(super) fn exec_monitor(
     // FIXME (ogsudo): Terminate the command using `killpg` if it's not terminated.
 
     // Take the controlling tty so the command's children don't receive SIGHUP when we exit.
-    if let Err(err) = tcsetpgrp(&closure.pty_follower, closure.monitor_pgrp) {
+    if let Err(err) = closure.pty_follower.tcsetpgrp(closure.monitor_pgrp) {
         dev_error!(
             "cannot set foreground process group to monitor ({}): {err}",
             closure.monitor_pgrp
@@ -160,7 +160,7 @@ fn exec_command(mut command: Command, foreground: bool, pty_follower: OwnedFd) -
     // Wait for the monitor to set us as the foreground group for the pty if we are in the
     // foreground.
     if foreground {
-        while !tcgetpgrp(&pty_follower).is_ok_and(|pid| pid == command_pid) {
+        while !pty_follower.tcgetpgrp().is_ok_and(|pid| pid == command_pid) {
             std::thread::sleep(std::time::Duration::from_micros(1));
         }
     }
@@ -285,7 +285,7 @@ impl<'a> MonitorClosure<'a> {
                 signal_fmt(signal),
             );
             // Save the foreground process group ID so we can restore it later.
-            if let Ok(pgrp) = tcgetpgrp(&self.pty_follower) {
+            if let Ok(pgrp) = self.pty_follower.tcgetpgrp() {
                 if pgrp != self.monitor_pgrp {
                     self.command_pgrp = pgrp;
                 }
@@ -342,7 +342,7 @@ impl<'a> MonitorClosure<'a> {
             }
             SIGCONT_FG => {
                 // Continue with the command as the foreground process group
-                if let Err(err) = tcsetpgrp(&self.pty_follower, self.command_pgrp) {
+                if let Err(err) = self.pty_follower.tcsetpgrp(self.command_pgrp) {
                     dev_error!(
                         "cannot set the foreground process group to command ({}): {err}",
                         self.command_pgrp
@@ -352,7 +352,7 @@ impl<'a> MonitorClosure<'a> {
             }
             SIGCONT_BG => {
                 // Continue with the monitor as the foreground process group
-                if let Err(err) = tcsetpgrp(&self.pty_follower, self.monitor_pgrp) {
+                if let Err(err) = self.pty_follower.tcsetpgrp(self.monitor_pgrp) {
                     dev_error!(
                         "cannot set the foreground process group to monitor ({}): {err}",
                         self.monitor_pgrp

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -11,7 +11,7 @@ use std::{
 use crate::{
     exec::terminate_process,
     system::{
-        fork, getpgid,
+        fork, getpgid, getpgrp,
         interface::ProcessId,
         kill, setpgid, setsid,
         signal::SignalInfo,
@@ -192,8 +192,7 @@ impl<'a> MonitorClosure<'a> {
         dispatcher: &mut EventDispatcher<Self>,
     ) -> Self {
         // Store the pgid of the monitor.
-        // FIXME: ogsudo does not handle this error explicitly.
-        let monitor_pgrp = getpgid(0).unwrap_or(-1);
+        let monitor_pgrp = getpgrp();
 
         // Register the callback to receive the IO error if the command fails to execute.
         dispatcher.set_read_callback(&errpipe_rx, |monitor, dispatcher| {

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -18,7 +18,7 @@ use crate::exec::{
 use crate::log::{dev_error, dev_info, dev_warn};
 use crate::system::signal::{SignalAction, SignalHandler, SignalNumber};
 use crate::system::term::{Pty, Terminal, UserTerm};
-use crate::system::wait::{waitpid, WaitError, WaitOptions};
+use crate::system::wait::{Wait, WaitError, WaitOptions};
 use crate::system::{chown, fork, kill, killpg, Group, User};
 use crate::system::{getpgid, interface::ProcessId, signal::SignalInfo};
 
@@ -414,7 +414,7 @@ impl ParentClosure {
         const OPTS: WaitOptions = WaitOptions::new().all().untraced().no_hang();
 
         let status = loop {
-            match waitpid(monitor_pid, OPTS) {
+            match monitor_pid.wait(OPTS) {
                 Err(WaitError::Io(err)) if was_interrupted(&err) => {}
                 // This only happens if we receive `SIGCHLD` but there's no status update from the
                 // monitor.

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -19,7 +19,7 @@ use crate::log::{dev_error, dev_info, dev_warn};
 use crate::system::signal::{SignalAction, SignalHandler, SignalNumber};
 use crate::system::term::{Pty, Terminal, UserTerm};
 use crate::system::wait::{Wait, WaitError, WaitOptions};
-use crate::system::{chown, fork, kill, killpg, Group, User};
+use crate::system::{chown, fork, getpgrp, kill, killpg, Group, User};
 use crate::system::{getpgid, interface::ProcessId, signal::SignalInfo};
 
 use super::pipe::Pipe;
@@ -53,9 +53,7 @@ pub(crate) fn exec_pty(
     // FIXME (ogsudo): initializes ttyblock sigset here by calling `init_ttyblock`
 
     // Fetch the parent process group so we can signals to it.
-
-    // FIXME: ogsudo never handles this error explicitly.
-    let parent_pgrp = getpgid(0).unwrap_or(-1);
+    let parent_pgrp = getpgrp();
 
     // Set all the IO streams for the command to the follower side of the pty.
     let clone_follower = || {

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -115,7 +115,7 @@ pub(crate) fn exec_pty(
     }
 
     // Start in raw mode unless we're part of a pipeline or backgrounded.
-    if foreground && !pipeline && !exec_bg && user_tty.term_raw(false).is_ok() {
+    if foreground && !pipeline && !exec_bg && user_tty.set_raw_mode(false).is_ok() {
         term_raw = true;
     }
 
@@ -474,7 +474,7 @@ impl ParentClosure {
                     signal_fmt(signal)
                 );
                 if !self.term_raw {
-                    if self.user_tty.term_raw(false).is_ok() {
+                    if self.user_tty.set_raw_mode(false).is_ok() {
                         self.term_raw = true;
                     }
                     // Resume command in the foreground
@@ -550,7 +550,7 @@ impl ParentClosure {
 
         if self.foreground {
             // We're in the foreground, set tty to raw mode.
-            if self.user_tty.term_raw(false).is_ok() {
+            if self.user_tty.set_raw_mode(false).is_ok() {
                 self.term_raw = true;
             }
         } else {

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -61,19 +61,35 @@ impl Pty {
     }
 }
 
-pub fn set_controlling_terminal<F: AsRawFd>(fd: &F) -> io::Result<()> {
-    cerr(unsafe { libc::ioctl(fd.as_raw_fd(), libc::TIOCSCTTY, 0) })?;
-    Ok(())
+mod sealed {
+    use std::os::fd::AsRawFd;
+
+    pub(crate) trait Sealed {}
+
+    impl<F: AsRawFd> Sealed for F {}
 }
 
-/// Set the foreground process group ID associated with the `fd` terminal device to `pgrp`.
-pub fn tcsetpgrp<F: AsRawFd>(fd: &F, pgrp: ProcessId) -> io::Result<()> {
-    cerr(unsafe { libc::tcsetpgrp(fd.as_raw_fd(), pgrp) }).map(|_| ())
+pub(crate) trait Terminal: sealed::Sealed {
+    fn tcgetpgrp(&self) -> io::Result<ProcessId>;
+    fn tcsetpgrp(&self, pgrp: ProcessId) -> io::Result<()>;
+    fn make_controlling_terminal(&self) -> io::Result<()>;
 }
 
-/// Get the foreground process group ID associated with the `fd` terminal device.
-pub fn tcgetpgrp<F: AsRawFd>(fd: &F) -> io::Result<ProcessId> {
-    cerr(unsafe { libc::tcgetpgrp(fd.as_raw_fd()) })
+impl<F: AsRawFd> Terminal for F {
+    /// Get the foreground process group ID associated with this terminal.
+    fn tcgetpgrp(&self) -> io::Result<ProcessId> {
+        cerr(unsafe { libc::tcgetpgrp(self.as_raw_fd()) })
+    }
+    /// Set the foreground process group ID associated with this terminalto `pgrp`.
+    fn tcsetpgrp(&self, pgrp: ProcessId) -> io::Result<()> {
+        cerr(unsafe { libc::tcsetpgrp(self.as_raw_fd(), pgrp) }).map(|_| ())
+    }
+
+    /// Make the given terminal the controlling terminal of the calling process.
+    fn make_controlling_terminal(&self) -> io::Result<()> {
+        cerr(unsafe { libc::ioctl(self.as_raw_fd(), libc::TIOCSCTTY, 0) })?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -109,16 +125,16 @@ mod tests {
             // Open a new pseudoterminal.
             let leader = Pty::open().unwrap().leader;
             // The pty leader should not have a foreground process group yet.
-            assert_eq!(tcgetpgrp(&leader).unwrap(), 0);
+            assert_eq!(leader.tcgetpgrp().unwrap(), 0);
             // Create a new session so we can change the controlling terminal.
             setsid().unwrap();
             // Set the pty leader as the controlling terminal.
-            set_controlling_terminal(&leader).unwrap();
+            leader.make_controlling_terminal().unwrap();
             // Set us as the foreground process group of the pty leader.
             let pgid = getpgid(0).unwrap();
-            tcsetpgrp(&leader, pgid).unwrap();
+            leader.tcsetpgrp(pgid).unwrap();
             // Check that we are in fact the foreground process group of the pty leader.
-            assert_eq!(pgid, tcgetpgrp(&leader).unwrap());
+            assert_eq!(pgid, leader.tcgetpgrp().unwrap());
             // If we haven't panicked yet, send a byte to the parent.
             tx.write_all(&[42]).unwrap();
         }

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -19,9 +19,8 @@ use libc::{
     TIOCGWINSZ, TIOCSWINSZ, TOSTOP,
 };
 
+use super::Terminal;
 use crate::{cutils::cerr, system::interface::ProcessId};
-
-use super::tcsetpgrp;
 
 const INPUT_FLAGS: tcflag_t = IGNPAR
     | PARMRK
@@ -231,7 +230,7 @@ impl UserTerm {
         unsafe { sigaction(SIGTTOU, &action, original_action.as_mut_ptr()) };
         // Call `tcsetattr` until it suceeds and ignore interruptions if we did not receive `SIGTTOU`.
         let result = loop {
-            match tcsetpgrp(&self.tty, pgrp) {
+            match self.tty.tcsetpgrp(pgrp) {
                 Ok(()) => break Ok(()),
                 Err(err) => {
                     let got_sigttou = GOT_SIGTTOU.load(Ordering::SeqCst);

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -169,7 +169,7 @@ impl UserTerm {
 
     /// Set the user's terminal to raw mode. Enable terminal signals if `with_signals` is set to
     /// `true`.
-    pub fn term_raw(&mut self, with_signals: bool) -> io::Result<()> {
+    pub fn set_raw_mode(&mut self, with_signals: bool) -> io::Result<()> {
         let fd = self.tty.as_raw_fd();
 
         if !self.changed {

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -108,7 +108,7 @@ pub struct UserTerm {
 
 impl UserTerm {
     /// Open the user's terminal.
-    pub fn new() -> io::Result<Self> {
+    pub fn open() -> io::Result<Self> {
         Ok(Self {
             tty: OpenOptions::new().read(true).write(true).open("/dev/tty")?,
             original_termios: MaybeUninit::uninit(),

--- a/src/system/wait.rs
+++ b/src/system/wait.rs
@@ -9,28 +9,39 @@ use signal_hook::low_level::signal_name;
 use crate::cutils::cerr;
 use crate::{system::interface::ProcessId, system::signal::SignalNumber};
 
-/// Wait for a process to change state.
-///
-/// Calling this function will block until a child specified by [`WaitPid`] has changed state. This
-/// can be configured further using [`WaitOptions`].
-pub fn waitpid<P: Into<WaitPid>>(
-    pid: P,
-    options: WaitOptions,
-) -> Result<(ProcessId, WaitStatus), WaitError> {
-    let pid = pid.into().pid;
-    let mut status: c_int = 0;
+mod sealed {
+    use super::WaitPid;
 
-    let pid =
-        cerr(unsafe { libc::waitpid(pid, &mut status, options.flags) }).map_err(WaitError::Io)?;
+    pub(crate) trait Sealed {}
 
-    if pid == 0 && options.flags & WNOHANG != 0 {
-        return Err(WaitError::NotReady);
-    }
-
-    Ok((pid, WaitStatus { status }))
+    impl<W: Into<WaitPid>> Sealed for W {}
 }
 
-/// Error values returned when [`waitpid`] fails.
+pub(crate) trait Wait: sealed::Sealed {
+    /// Wait for a process to change state.
+    ///
+    /// Calling this function will block until a child specified by [`WaitPid`] has changed state. This
+    /// can be configured further using [`WaitOptions`].
+    fn wait(self, options: WaitOptions) -> Result<(ProcessId, WaitStatus), WaitError>;
+}
+
+impl<W: Into<WaitPid>> Wait for W {
+    fn wait(self, options: WaitOptions) -> Result<(ProcessId, WaitStatus), WaitError> {
+        let pid = self.into().pid;
+        let mut status: c_int = 0;
+
+        let pid = cerr(unsafe { libc::waitpid(pid, &mut status, options.flags) })
+            .map_err(WaitError::Io)?;
+
+        if pid == 0 && options.flags & WNOHANG != 0 {
+            return Err(WaitError::NotReady);
+        }
+
+        Ok((pid, WaitStatus { status }))
+    }
+}
+
+/// Error values returned when [`Wait::wait`] fails.
 #[derive(Debug)]
 pub enum WaitError {
     // No children were in a waitable state.
@@ -59,7 +70,7 @@ impl From<ProcessId> for WaitPid {
     }
 }
 
-/// Options to configure how [`waitpid`] waits for children.
+/// Options to configure how [`Wait::wait`] waits for children.
 pub struct WaitOptions {
     flags: c_int,
 }
@@ -194,7 +205,7 @@ mod tests {
         fork,
         interface::ProcessId,
         kill,
-        wait::{waitpid, WaitError, WaitOptions, WaitPid},
+        wait::{Wait, WaitError, WaitOptions, WaitPid},
     };
 
     #[test]
@@ -206,7 +217,7 @@ mod tests {
 
         let command_pid = command.id() as ProcessId;
 
-        let (pid, status) = waitpid(command_pid, WaitOptions::new()).unwrap();
+        let (pid, status) = command_pid.wait(WaitOptions::new()).unwrap();
         assert_eq!(command_pid, pid);
         assert!(status.did_exit());
         assert_eq!(status.exit_status(), Some(42));
@@ -218,7 +229,7 @@ mod tests {
         assert!(!status.did_continue());
 
         // Waiting when there are no children should fail.
-        let WaitError::Io(err) = waitpid(command_pid, WaitOptions::new()).unwrap_err() else {
+        let WaitError::Io(err) = command_pid.wait(WaitOptions::new()).unwrap_err() else {
             panic!("`WaitError::NotReady` should not happens if `WaitOptions::no_hang` was not called.");
         };
         assert_eq!(err.raw_os_error(), Some(libc::ECHILD));
@@ -235,19 +246,19 @@ mod tests {
 
         kill(command_pid, SIGSTOP).unwrap();
 
-        let (pid, status) = waitpid(command_pid, WaitOptions::new().untraced()).unwrap();
+        let (pid, status) = command_pid.wait(WaitOptions::new().untraced()).unwrap();
         assert_eq!(command_pid, pid);
         assert_eq!(status.stop_signal(), Some(SIGSTOP));
 
         kill(command_pid, SIGCONT).unwrap();
 
-        let (pid, status) = waitpid(command_pid, WaitOptions::new().continued()).unwrap();
+        let (pid, status) = command_pid.wait(WaitOptions::new().continued()).unwrap();
         assert_eq!(command_pid, pid);
         assert!(status.did_continue());
 
         kill(command_pid, SIGKILL).unwrap();
 
-        let (pid, status) = waitpid(command_pid, WaitOptions::new()).unwrap();
+        let (pid, status) = command_pid.wait(WaitOptions::new()).unwrap();
         assert_eq!(command_pid, pid);
         assert!(status.was_signaled());
         assert_eq!(status.term_signal(), Some(SIGKILL));
@@ -270,7 +281,7 @@ mod tests {
 
         let mut count = 0;
         let (pid, status) = loop {
-            match waitpid(command_pid, WaitOptions::new().no_hang()) {
+            match command_pid.wait(WaitOptions::new().no_hang()) {
                 Ok(ok) => break ok,
                 Err(WaitError::NotReady) => count += 1,
                 Err(WaitError::Io(err)) => panic!("{err}"),
@@ -304,7 +315,7 @@ mod tests {
                 .spawn()
                 .unwrap();
 
-            let (pid, status) = waitpid(WaitPid::any(), WaitOptions::new()).unwrap();
+            let (pid, status) = WaitPid::any().wait(WaitOptions::new()).unwrap();
             assert_eq!(cmd1.id() as ProcessId, pid);
             assert_eq!(status.exit_status(), Some(42));
 
@@ -314,7 +325,7 @@ mod tests {
             assert!(status.stop_signal().is_none());
             assert!(!status.did_continue());
 
-            let (pid, status) = waitpid(WaitPid::any(), WaitOptions::new()).unwrap();
+            let (pid, status) = WaitPid::any().wait(WaitOptions::new()).unwrap();
             assert_eq!(cmd2.id() as ProcessId, pid);
             assert_eq!(status.exit_status(), Some(43));
 
@@ -327,7 +338,7 @@ mod tests {
             exit(44);
         }
 
-        let (pid, status) = waitpid(child_pid, WaitOptions::new()).unwrap();
+        let (pid, status) = child_pid.wait(WaitOptions::new()).unwrap();
         assert_eq!(child_pid, pid);
         assert_eq!(status.exit_status(), Some(44));
 


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR changes the API for some system calls:
- Rename `UserTerm::raw_term` to `UserTerm::set_raw_mode`.
- Rename `UserTerm::new` to `UserTerm::open`.
- Introduce a `Terminal` trait for the `tcsetpgrp`, `tcgetpgrp` and `ioctl(TIOCSCTTY)` syscalls.
- Introduce a `Wait` trait for the `waitpid` syscall.
- Add the infallible `getpgrp` syscall to avoid doing `getpgid(0).unwrap()`.

This PR is blocked by #535 and it is better reviewed commit-per-commit.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
