### PR TITLE
Test ownership of the pty

### DIFF
--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -216,7 +216,7 @@ fn get_pty() -> io::Result<Pty> {
         dev_error!("unable to allocate pty: {err}");
         err
     })?;
-    // FIXME: Test this
+
     chown(&pty.path, User::effective_uid(), tty_gid).map_err(|err| {
         dev_error!("unable to change owner for pty: {err}");
         err

--- a/test-framework/sudo-compliance-tests/src/use_pty.rs
+++ b/test-framework/sudo-compliance-tests/src/use_pty.rs
@@ -118,6 +118,21 @@ fn terminal_is_restored() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn pty_owner() -> Result<()> {
+    let env = Env([SUDOERS_ALL_ALL_NOPASSWD, "Defaults use_pty"]).build()?;
+
+    let stdout = Command::new("sudo")
+        .args(["sh", "-c", "stat $(tty) --format '%U %G'"])
+        .tty(true)
+        .output(&env)?
+        .stdout()?;
+
+    assert_eq!(stdout.trim(), "root tty");
+
+    Ok(())
+}
+
 fn parse_ps_aux(ps_aux: &str) -> Vec<PsAuxEntry> {
     let mut entries = vec![];
     for line in ps_aux.lines().skip(1 /* header */) {


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR tests if the owner user and group of the pseudoterminal are `root` and `tty` when `use_pty` is enabled.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
