### PR TITLE
Test that `SIGALRM` kills command

### DIFF
--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/expects-signal.sh
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/expects-signal.sh
@@ -1,4 +1,4 @@
-trap 'echo got signal && exit 0' TERM
+trap 'echo got signal && exit 0' $@
 for _ in $(seq 1 20); do
 	sleep 0.1
 done

--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/kill-sudo.sh
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/kill-sudo.sh
@@ -16,7 +16,7 @@ for _ in $(seq 1 20); do
         # give `expects-signal.sh ` some time to execute the `trap` command
         # otherwise it'll be terminated before the signal handler is installed
 		sleep 0.1
-		kill "$sudopid"
+		kill $1 "$sudopid"
 		exit 0
 	fi
 	sleep 0.1


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR tests that when `sudo` receives `SIGALRM` it terminates the command with `SIGHUP` and `SIGTERM` in conjunction.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/448 where a proper discussion about a solution has taken place.
