### PR TITLE
Introduce `ForkResult`

### DIFF
--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -19,7 +19,7 @@ use crate::log::{dev_error, dev_info, dev_warn};
 use crate::system::signal::{SignalAction, SignalHandler, SignalNumber};
 use crate::system::term::{tcgetpgrp, Pty, UserTerm};
 use crate::system::wait::{waitpid, WaitError, WaitOptions};
-use crate::system::{chown, fork, kill, killpg, Group, User};
+use crate::system::{chown, fork, kill, killpg, ForkResult, Group, User};
 use crate::system::{getpgid, interface::ProcessId, signal::SignalInfo};
 
 use super::pipe::Pipe;
@@ -122,12 +122,10 @@ pub(crate) fn exec_pty(
     // FIXME: it would be better if we didn't create the dispatcher before the fork and managed
     // to block all the signals here instead.
 
-    let monitor_pid = fork().map_err(|err| {
+    let ForkResult::Parent(monitor_pid) = fork().map_err(|err| {
         dev_error!("unable to fork monitor process: {err}");
         err
-    })?;
-
-    if monitor_pid == 0 {
+    })? else {
         // Close the file descriptors that we don't access
         drop(pty.leader);
         drop(backchannels.parent);
@@ -154,7 +152,7 @@ pub(crate) fn exec_pty(
         }
         // FIXME: drop everything before calling `exit`.
         exit(1)
-    }
+    };
 
     // Close the file descriptors that we don't access
     drop(pty.follower);

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -34,12 +34,28 @@ pub mod term;
 
 pub mod wait;
 
+pub(crate) enum ForkResult {
+    // Parent process branch with the child process' PID.
+    Parent(ProcessId),
+    // Child process branch.
+    Child,
+}
+
+unsafe fn inner_fork() -> io::Result<ForkResult> {
+    let pid = cerr(unsafe { libc::fork() })?;
+    if pid == 0 {
+        Ok(ForkResult::Child)
+    } else {
+        Ok(ForkResult::Parent(pid))
+    }
+}
+
 #[cfg(target_os = "linux")]
 /// Create a new process.
-pub fn fork() -> io::Result<ProcessId> {
+pub(crate) fn fork() -> io::Result<ForkResult> {
     // SAFETY: `fork` is implemented using `clone` in linux so we don't need to worry about signal
     // safety.
-    cerr(unsafe { libc::fork() })
+    unsafe { inner_fork() }
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -49,8 +65,8 @@ pub fn fork() -> io::Result<ProcessId> {
 ///
 /// In a multithreaded program, only async-signal-safe functions are guaranteed to work in the
 /// child process until a call to `execve` or a similar function is done.
-pub unsafe fn fork() -> io::Result<ProcessId> {
-    cerr(unsafe { libc::fork() })
+pub(crate) unsafe fn fork() -> io::Result<ForkResult> {
+    inner_fork()
 }
 
 pub fn setsid() -> io::Result<ProcessId> {
@@ -565,9 +581,12 @@ mod tests {
     use std::{
         io::{Read, Write},
         os::unix::net::UnixStream,
+        process::exit,
     };
 
     use libc::SIGKILL;
+
+    use crate::system::ForkResult;
 
     use super::{fork, setpgid, Group, User, WithProcess};
 
@@ -647,13 +666,11 @@ mod tests {
             getpgid(0).unwrap()
         );
         match super::fork().unwrap() {
-            // child
-            0 => {
+            ForkResult::Child => {
                 // wait for the parent.
                 std::thread::sleep(std::time::Duration::from_secs(1))
             }
-            // parent
-            child_pid => {
+            ForkResult::Parent(child_pid) => {
                 // The child should be in our process group.
                 assert_eq!(getpgid(child_pid).unwrap(), getpgid(0).unwrap(),);
                 // Move the child to its own process group
@@ -677,17 +694,17 @@ mod tests {
         // Create a socket so the children write to it if they aren't terminated by `killpg`.
         let (mut rx, mut tx) = UnixStream::pair().unwrap();
 
-        let pid1 = fork().unwrap();
-        if pid1 == 0 {
+        let ForkResult::Parent(pid1) = fork().unwrap() else {
             std::thread::sleep(std::time::Duration::from_secs(1));
             tx.write_all(&[42]).unwrap();
-        }
+            exit(0);
+        };
 
-        let pid2 = fork().unwrap();
-        if pid2 == 0 {
+        let ForkResult::Parent(pid2) = fork().unwrap() else {
             std::thread::sleep(std::time::Duration::from_secs(1));
             tx.write_all(&[42]).unwrap();
-        }
+            exit(0);
+        };
 
         drop(tx);
 

--- a/src/system/wait.rs
+++ b/src/system/wait.rs
@@ -195,6 +195,7 @@ mod tests {
         interface::ProcessId,
         kill,
         wait::{waitpid, WaitError, WaitOptions, WaitPid},
+        ForkResult,
     };
 
     #[test]
@@ -292,8 +293,7 @@ mod tests {
     #[test]
     fn any() {
         // We fork so waiting for `WaitPid::Any` doesn't wait for other tests.
-        let child_pid = fork().unwrap();
-        if child_pid == 0 {
+        let ForkResult::Parent(child_pid) = fork().unwrap() else {
             let cmd1 = std::process::Command::new("sh")
                 .args(["-c", "sleep 0.1; exit 42"])
                 .spawn()
@@ -325,7 +325,7 @@ mod tests {
             assert!(!status.did_continue());
             // Exit with a specific status code so we can check it from the parent.
             exit(44);
-        }
+        };
 
         let (pid, status) = waitpid(child_pid, WaitOptions::new()).unwrap();
         assert_eq!(child_pid, pid);


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR introduces the `ForkResult` type which allows to use the `let ... else` syntax so the child code can be forced to be divergent.

This PR was also authored by stealing @squell's idea :trollface:.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/470 where a proper discussion about a solution has taken place.
