### PR TITLE
Flush the pty pipe

### DIFF
--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -186,6 +186,7 @@ pub(crate) fn exec_pty(
     // FIXME (ogsudo): Retry if `/dev/tty` is revoked.
 
     // Flush the terminal
+    closure.pty_pipe.flush(&mut closure.user_tty).ok();
     closure.user_tty.flush().ok();
 
     // Restore the terminal settings

--- a/src/exec/use_pty/pipe.rs
+++ b/src/exec/use_pty/pipe.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{Read, Write},
+    io::{self, Read, Write},
     marker::PhantomData,
 };
 
@@ -74,6 +74,15 @@ impl<R: Read, W: Write> Pipe<R, W> {
             // Otherwise we just free the first `len` bytes of the busy section.
             self.start += len;
         }
+    }
+
+    /// Flush this pipe, ensuring that all the contents of its internal buffer are written.
+    pub(super) fn flush(&mut self, write: &mut W) -> io::Result<()> {
+        // This is the busy section of the buffer.
+        let buffer = &self.buffer[self.start..self.end];
+
+        // Write the complete busy section to `write`.
+        write.write_all(buffer)
     }
 }
 


### PR DESCRIPTION
**Describe the changes done on this pull request**
This guarantees that `sudo` writes any buffered content from the pseudoterminal into the user's terminal.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/542 where a proper discussion about a solution has taken place.
