### PR TITLE
Resolve paths using `realpath`

### DIFF
--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -300,6 +300,9 @@ fn match_command<'a>((cmd, args): (&'a Path, &'a [String])) -> (impl Fn(&Command
         ..glob::MatchOptions::new()
     };
     move |(cmdpat, argpat)| {
+        // use the canonicalized path (not using that is less permissive)
+        let realcmd = std::fs::canonicalize(cmd);
+        let cmd = realcmd.as_deref().unwrap_or(cmd);
         cmdpat.matches_path_with(cmd, opts)
             && argpat.as_ref().map_or(true, |vec| args == vec.as_ref())
     }

--- a/test-framework/sudo-compliance-tests/src/path_search.rs
+++ b/test-framework/sudo-compliance-tests/src/path_search.rs
@@ -80,3 +80,37 @@ fn ignores_path_for_qualified_commands() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[ignore = "gh561"]
+fn paths_are_matched_using_realpath_in_sudoers() -> Result<()> {
+    let env = Env(["ALL ALL = /bin/true"]).build()?;
+
+    // this test assumes /bin is a symbolic link for /usr/bin, which is the
+    // case on Debian bookworm; if it fails for original sudo, either change the
+    // dockerfile or explicitly create a symbolic link
+
+    Command::new("sudo")
+        .arg("/usr/bin/true")
+        .output(&env)?
+        .assert_success()?;
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "gh561"]
+fn paths_are_matched_using_realpath_in_arguments() -> Result<()> {
+    let env = Env(["ALL ALL = /usr/bin/true"]).build()?;
+
+    // this test assumes /bin is a symbolic link for /usr/bin, which is the
+    // case on Debian bookworm; if it fails for original sudo, either change the
+    // dockerfile or explicitly create a symbolic link
+
+    Command::new("sudo")
+        .arg("/bin/true")
+        .output(&env)?
+        .assert_success()?;
+
+    Ok(())
+}

--- a/test-framework/sudo-compliance-tests/src/path_search.rs
+++ b/test-framework/sudo-compliance-tests/src/path_search.rs
@@ -82,7 +82,6 @@ fn ignores_path_for_qualified_commands() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh561"]
 fn paths_are_matched_using_realpath_in_sudoers() -> Result<()> {
     let env = Env(["ALL ALL = /bin/true"]).build()?;
 
@@ -99,7 +98,6 @@ fn paths_are_matched_using_realpath_in_sudoers() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh561"]
 fn paths_are_matched_using_realpath_in_arguments() -> Result<()> {
     let env = Env(["ALL ALL = /usr/bin/true"]).build()?;
 


### PR DESCRIPTION
This problem became quite noticeable after the change to bookworm: if a sudoers line mentioned "/bin/ls", using the equivalent "/usr/bin/ls" wouldn't match (and vice versa).

Note that realpath-matching doesn't work as well when wildcards are used (e.g. "/*/ls"), but that is also the case for original sudo.