### PR TITLE
Improve terminal API

### DIFF
--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -1,10 +1,7 @@
 use std::{
     ffi::c_int,
     io::{self, Read, Write},
-    os::{
-        fd::OwnedFd,
-        unix::{net::UnixStream, process::CommandExt},
-    },
+    os::unix::{net::UnixStream, process::CommandExt},
     process::{exit, Command},
 };
 
@@ -15,7 +12,7 @@ use crate::{
         interface::ProcessId,
         kill, setpgid, setsid,
         signal::SignalInfo,
-        term::Terminal,
+        term::{PtyFollower, Terminal},
         wait::{Wait, WaitError, WaitOptions, WaitStatus},
         ForkResult,
     },
@@ -39,7 +36,7 @@ use crate::exec::{opt_fmt, signal_fmt};
 
 // FIXME: This should return `io::Result<!>` but `!` is not stable yet.
 pub(super) fn exec_monitor(
-    pty_follower: OwnedFd,
+    pty_follower: PtyFollower,
     command: Command,
     foreground: bool,
     backchannel: &mut MonitorBackchannel,
@@ -161,7 +158,7 @@ pub(super) fn exec_monitor(
 }
 
 // FIXME: This should return `io::Result<!>` but `!` is not stable yet.
-fn exec_command(mut command: Command, foreground: bool, pty_follower: OwnedFd) -> io::Error {
+fn exec_command(mut command: Command, foreground: bool, pty_follower: PtyFollower) -> io::Error {
     // FIXME (ogsudo): Do any additional configuration that needs to be run after `fork` but before `exec`
     let command_pid = std::process::id() as ProcessId;
 
@@ -188,7 +185,7 @@ struct MonitorClosure<'a> {
     command_pid: Option<ProcessId>,
     command_pgrp: ProcessId,
     monitor_pgrp: ProcessId,
-    pty_follower: OwnedFd,
+    pty_follower: PtyFollower,
     errpipe_rx: UnixStream,
     backchannel: &'a mut MonitorBackchannel,
 }
@@ -196,7 +193,7 @@ struct MonitorClosure<'a> {
 impl<'a> MonitorClosure<'a> {
     fn new(
         command_pid: ProcessId,
-        pty_follower: OwnedFd,
+        pty_follower: PtyFollower,
         errpipe_rx: UnixStream,
         backchannel: &'a mut MonitorBackchannel,
         dispatcher: &mut EventDispatcher<Self>,

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -185,7 +185,6 @@ pub(crate) fn exec_pty(
 
     // Flush the terminal
     closure.tty_pipe.flush_left().ok();
-    closure.tty_pipe.left_mut().flush().ok();
 
     // Restore the terminal settings
     if closure.term_raw {

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -28,7 +28,7 @@ use super::SIGCONT_BG;
 pub(crate) fn exec_pty(
     sudo_pid: ProcessId,
     mut command: Command,
-    mut user_tty: UserTerm,
+    user_tty: UserTerm,
 ) -> io::Result<(ExitReason, Box<dyn FnOnce()>)> {
     // Allocate a pseudoterminal.
     let pty = get_pty()?;
@@ -69,22 +69,24 @@ pub(crate) fn exec_pty(
 
     let mut dispatcher = EventDispatcher::<ParentClosure>::new()?;
 
+    let mut tty_pipe = Pipe::new(user_tty, pty.leader.into());
+
+    let (user_tty, pty_leader) = tty_pipe.both_mut();
+
     //  Read from `/dev/tty` and write to the leader if not in the background.
-    let tty_pipe = Pipe::new();
-    dispatcher.set_read_callback(&user_tty, |parent, _| {
-        parent.tty_pipe.on_read(&mut parent.user_tty)
+    dispatcher.set_read_callback(user_tty, |parent, _| {
+        parent.tty_pipe.read_left().ok();
     });
-    dispatcher.set_write_callback(&pty.leader, |parent, _| {
-        parent.tty_pipe.on_write(&mut parent.pty_leader)
+    dispatcher.set_write_callback(pty_leader, |parent, _| {
+        parent.tty_pipe.write_right().ok();
     });
 
     // Read from the leader and write to `/dev/tty`.
-    let pty_pipe = Pipe::new();
-    dispatcher.set_read_callback(&pty.leader, |parent, _| {
-        parent.pty_pipe.on_read(&mut parent.pty_leader)
+    dispatcher.set_read_callback(pty_leader, |parent, _| {
+        parent.tty_pipe.read_right().ok();
     });
-    dispatcher.set_write_callback(&user_tty, |parent, _| {
-        parent.pty_pipe.on_write(&mut parent.user_tty)
+    dispatcher.set_write_callback(user_tty, |parent, _| {
+        parent.tty_pipe.write_left().ok();
     });
 
     // Check if we are the foreground process
@@ -127,7 +129,7 @@ pub(crate) fn exec_pty(
         err
     })? else {
         // Close the file descriptors that we don't access
-        drop(pty.leader);
+        drop(tty_pipe);
         drop(backchannels.parent);
 
         // Unregister all the handlers so `exec_monitor` can register new ones for the monitor
@@ -171,12 +173,9 @@ pub(crate) fn exec_pty(
         sudo_pid,
         parent_pgrp,
         backchannels.parent,
-        user_tty,
         tty_pipe,
         foreground,
         term_raw,
-        pty.leader.into(),
-        pty_pipe,
         &mut dispatcher,
     );
 
@@ -186,15 +185,15 @@ pub(crate) fn exec_pty(
     // FIXME (ogsudo): Retry if `/dev/tty` is revoked.
 
     // Flush the terminal
-    closure.pty_pipe.flush(&mut closure.user_tty).ok();
-    closure.user_tty.flush().ok();
+    closure.tty_pipe.flush_left().ok();
+    closure.tty_pipe.left_mut().flush().ok();
 
     // Restore the terminal settings
     if closure.term_raw {
         // Only restore the terminal if sudo is the foreground process.
-        if let Ok(pgrp) = closure.user_tty.tcgetpgrp() {
+        if let Ok(pgrp) = closure.tty_pipe.left().tcgetpgrp() {
             if pgrp == closure.parent_pgrp {
-                match closure.user_tty.restore(false) {
+                match closure.tty_pipe.left_mut().restore(false) {
                     Ok(()) => closure.term_raw = false,
                     Err(err) => dev_warn!("cannot restore terminal settings: {err}"),
                 }
@@ -235,12 +234,9 @@ struct ParentClosure {
     parent_pgrp: ProcessId,
     command_pid: Option<ProcessId>,
     backchannel: ParentBackchannel,
-    user_tty: UserTerm,
     tty_pipe: Pipe<UserTerm, File>,
     foreground: bool,
     term_raw: bool,
-    pty_leader: File,
-    pty_pipe: Pipe<File, UserTerm>,
     message_queue: VecDeque<MonitorMessage>,
 }
 
@@ -251,12 +247,9 @@ impl ParentClosure {
         sudo_pid: ProcessId,
         parent_pgrp: ProcessId,
         backchannel: ParentBackchannel,
-        user_tty: UserTerm,
         tty_pipe: Pipe<UserTerm, File>,
         foreground: bool,
         term_raw: bool,
-        pty_leader: File,
-        pty_pipe: Pipe<File, UserTerm>,
         dispatcher: &mut EventDispatcher<Self>,
     ) -> Self {
         dispatcher.set_read_callback(&backchannel, |parent, dispatcher| {
@@ -275,12 +268,9 @@ impl ParentClosure {
             parent_pgrp,
             command_pid: None,
             backchannel,
-            user_tty,
             tty_pipe,
             foreground,
             term_raw,
-            pty_leader,
-            pty_pipe,
             message_queue: VecDeque::new(),
         }
     }
@@ -473,7 +463,7 @@ impl ParentClosure {
                     signal_fmt(signal)
                 );
                 if !self.term_raw {
-                    if self.user_tty.set_raw_mode(false).is_ok() {
+                    if self.tty_pipe.left_mut().set_raw_mode(false).is_ok() {
                         self.term_raw = true;
                     }
                     // Resume command in the foreground
@@ -485,7 +475,7 @@ impl ParentClosure {
         // FIXME: we should stop polling the terminal if we're suspending.
 
         if self.term_raw {
-            match self.user_tty.restore(false) {
+            match self.tty_pipe.left_mut().restore(false) {
                 Ok(()) => self.term_raw = false,
                 Err(err) => dev_warn!("unable to restore terminal settings: {err}"),
             }
@@ -525,7 +515,7 @@ impl ParentClosure {
 
     /// Check whether we are part of the foreground process group and update the foreground flag.
     fn check_foreground(&mut self) -> io::Result<()> {
-        let pgrp = self.user_tty.tcgetpgrp()?;
+        let pgrp = self.tty_pipe.left().tcgetpgrp()?;
         self.foreground = pgrp == self.parent_pgrp;
         Ok(())
     }
@@ -535,10 +525,13 @@ impl ParentClosure {
         self.check_foreground()?;
 
         // Update the pty settings based on the user's tty.
-        self.user_tty.copy_to(&self.pty_leader).map_err(|err| {
-            dev_error!("cannot copy terminal settings to pty: {err}");
-            err
-        })?;
+        self.tty_pipe
+            .left()
+            .copy_to(self.tty_pipe.right())
+            .map_err(|err| {
+                dev_error!("cannot copy terminal settings to pty: {err}");
+                err
+            })?;
         // FIXME: sync the terminal size here.
         dev_info!(
             "parent is in {} ({} -> {})",
@@ -549,7 +542,7 @@ impl ParentClosure {
 
         if self.foreground {
             // We're in the foreground, set tty to raw mode.
-            if self.user_tty.set_raw_mode(false).is_ok() {
+            if self.tty_pipe.left_mut().set_raw_mode(false).is_ok() {
                 self.term_raw = true;
             }
         } else {

--- a/src/exec/use_pty/pipe.rs
+++ b/src/exec/use_pty/pipe.rs
@@ -160,7 +160,7 @@ impl<R: Read, W: Write> Buffer<R, W> {
         self.start = 0;
         self.end = 0;
 
-        Ok(())
+        write.flush()
     }
 }
 

--- a/src/exec/use_pty/pipe.rs
+++ b/src/exec/use_pty/pipe.rs
@@ -154,7 +154,13 @@ impl<R: Read, W: Write> Buffer<R, W> {
         let buffer = &self.buffer[self.start..self.end];
 
         // Write the complete busy section to `write`.
-        write.write_all(buffer)
+        write.write_all(buffer)?;
+
+        // If we were able to write all the busy section, we can mark the whole buffer as free.
+        self.start = 0;
+        self.end = 0;
+
+        Ok(())
     }
 }
 

--- a/src/exec/use_pty/pipe.rs
+++ b/src/exec/use_pty/pipe.rs
@@ -3,24 +3,95 @@ use std::{
     marker::PhantomData,
 };
 
+// A pipe able to stream data bidirectionally between two read-write types.
+pub(super) struct Pipe<L, R> {
+    left: L,
+    right: R,
+    buffer_lr: Buffer<L, R>,
+    buffer_rl: Buffer<R, L>,
+}
+
+impl<L: Read + Write, R: Read + Write> Pipe<L, R> {
+    /// Create a new pipe between two read-write types.
+    pub fn new(left: L, right: R) -> Self {
+        Self {
+            left,
+            right,
+            buffer_lr: Buffer::new(),
+            buffer_rl: Buffer::new(),
+        }
+    }
+
+    /// Get a reference to the left side of the pipe.
+    pub(super) fn left(&self) -> &L {
+        &self.left
+    }
+
+    /// Get a mutable reference to the left side of the pipe.
+    pub(super) fn left_mut(&mut self) -> &mut L {
+        &mut self.left
+    }
+
+    /// Get a reference to the right side of the pipe.
+    pub(super) fn right(&self) -> &R {
+        &self.right
+    }
+
+    /// Get mutable references to both sides of the pipe.
+    pub(crate) fn both_mut(&mut self) -> (&mut L, &mut R) {
+        (&mut self.left, &mut self.right)
+    }
+
+    /// Read from the left side of the pipe.
+    ///
+    /// Calling this function will block until the left side is ready to be read.
+    pub fn read_left(&mut self) -> io::Result<()> {
+        self.buffer_lr.read(&mut self.left)
+    }
+
+    /// Write into the left side of the pipe.
+    ///
+    /// Calling this function will block until the left side is ready to be written.
+    pub fn write_left(&mut self) -> io::Result<()> {
+        self.buffer_rl.write(&mut self.left)
+    }
+
+    /// Read from the right side of the pipe.
+    ///
+    /// Calling this function will block until the right side is ready to be read.
+    pub fn read_right(&mut self) -> io::Result<()> {
+        self.buffer_rl.read(&mut self.right)
+    }
+
+    /// Write into the right side of the pipe.
+    ///
+    /// Calling this function will block until the right side is ready to be written.
+    pub fn write_right(&mut self) -> io::Result<()> {
+        self.buffer_lr.write(&mut self.right)
+    }
+
+    /// Ensure that all the contents of the pipe's internal buffer are written to the left side.
+    pub fn flush_left(&mut self) -> io::Result<()> {
+        self.buffer_rl.flush(&mut self.left)
+    }
+}
+
 /// The size of the internal buffer of the pipe.
 const BUFSIZE: usize = 6 * 1024;
 
-/// A pipe to connect a [`Read`] to a [`Write`].
-///
-/// This type uses an internal buffer so it can store the bytes read from `R` before they are
-/// written to `W`.
-pub(super) struct Pipe<R: Read, W: Write> {
+/// A buffer that stores the bytes read from `R` before they are written to `W`.
+struct Buffer<R, W> {
     buffer: [u8; BUFSIZE],
-    // The start of the busy section of the buffer.
+    /// The start of the busy section of the buffer.
     start: usize,
-    // The end of the busy section of the buffer.
+    /// The end of the busy section of the buffer.
     end: usize,
     marker: PhantomData<(R, W)>,
 }
 
-impl<R: Read, W: Write> Pipe<R, W> {
-    pub(super) const fn new() -> Self {
+impl<R: Read, W: Write> Buffer<R, W> {
+    /// Create a new, empty buffer
+    const fn new() -> Self {
         Self {
             buffer: [0; BUFSIZE],
             start: 0,
@@ -28,12 +99,13 @@ impl<R: Read, W: Write> Pipe<R, W> {
             marker: PhantomData,
         }
     }
-    /// Read bytes into the internal buffer of the pipe.
+
+    /// Read bytes into the buffer.
     ///
     /// Calling this function will block until `read` is ready to be read.
-    pub(super) fn on_read(&mut self, read: &mut R) {
-        // FIXME: This function will try to read even if the internal buffer is full. Meaning that
-        // in the worst case scenario where `W` is never ready to be written, we will be constantly
+    fn read(&mut self, read: &mut R) -> io::Result<()> {
+        // FIXME: This function will try to read even if the buffer is full. Meaning that in the
+        // worst case scenario where `W` is never ready to be written, we will be constantly
         // calling this function. This could be solved by ignoring the event associated with this
         // callback in the dispatcher until `W` is ready.
 
@@ -41,30 +113,28 @@ impl<R: Read, W: Write> Pipe<R, W> {
         let buffer = &mut self.buffer[self.end..];
 
         // Read `len` bytes from `read` into the buffer.
-        let Ok(len) = read.read(buffer) else {
-            return;
-        };
+        let len = read.read(buffer)?;
 
         // Mark the `len` bytes after the busy section as busy too.
         self.end += len;
+
+        Ok(())
     }
 
-    /// Write bytes from the internal buffer of the pipe.
+    /// Write bytes from the buffer.
     ///
     /// Calling this function will block until `write` is ready to be written.
-    pub(super) fn on_write(&mut self, write: &mut W) {
-        // FIXME: This function will try to write even if the internal buffer is empty. Meaning that
-        // in the worst case scenario where `R` is never ready to be readn, we will be constantly
-        // calling this function. This could be solved by ignoring the event associated with this
-        // callback in the dispatcher until `R` is ready.
+    fn write(&mut self, write: &mut W) -> io::Result<()> {
+        // FIXME: This function will try to write even if the buffer is empty. Meaning that in the
+        // worst case scenario where `R` is never ready to be readn, we will be constantly calling
+        // this function. This could be solved by ignoring the event associated with this callback
+        // in the dispatcher until `R` is ready.
 
         // This is the busy section of the buffer.
         let buffer = &self.buffer[self.start..self.end];
 
         // Write the first `len` bytes of the busy section to `write`.
-        let Ok(len) = write.write(buffer) else {
-            return;
-        };
+        let len = write.write(buffer)?;
 
         if len == buffer.len() {
             // If we were able to write all the busy section, we can mark the whole buffer as free.
@@ -74,10 +144,12 @@ impl<R: Read, W: Write> Pipe<R, W> {
             // Otherwise we just free the first `len` bytes of the busy section.
             self.start += len;
         }
+
+        Ok(())
     }
 
-    /// Flush this pipe, ensuring that all the contents of its internal buffer are written.
-    pub(super) fn flush(&mut self, write: &mut W) -> io::Result<()> {
+    /// Flush this buffer, ensuring that all the contents of its internal buffer are written.
+    fn flush(&mut self, write: &mut W) -> io::Result<()> {
         // This is the busy section of the buffer.
         let buffer = &self.buffer[self.start..self.end];
 
@@ -86,7 +158,7 @@ impl<R: Read, W: Write> Pipe<R, W> {
     }
 }
 
-impl<R: Read, W: Write> Default for Pipe<R, W> {
+impl<R: Read, W: Write> Default for Buffer<R, W> {
     fn default() -> Self {
         Self::new()
     }


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR introduces new types to have better abstractions over terminals:
- It refactors the `Pipe` type so it owns the both read-write types being piped.
- It adds dedicated newtypes for the leader and follower sides of a pseudoterminal.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
