### PR TITLE
remove unused set_home variable + simplify CLI help

### DIFF
--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,41 +1,26 @@
-pub const HELP_MSG: &str = "sudo - execute a command as another user
+pub const USAGE_MSG: &str = "\
+usage: sudo [-u user] [-g group] [-D directory] [-knS] [-i | -s] <command>
+       sudo -h | -K | -k | -V";
 
-usage: sudo -h | -K | -k | -V
-usage: sudo -v [-knS] [-g group] [-h host] [-u user]
-usage: sudo -l [-knS] [-g group] [-h host] [-U user] [-u user] [command]
-usage: sudo [-bEHknPS] [-D directory] [-g group] [-h host] [-R
-            directory] [-u user] [VAR=value] [-i|-s] [<command>]
-usage: sudo -e [-knS] [-D directory] [-g group] [-h host] [-R
-            directory] [-u user] file ...
+const DESCRIPTOR: &str = "sudo - run commands as another user";
 
-Options:
-  -b, --background              run command in the background
+const HELP_MSG: &str = "Options:
   -D, --chdir=directory         change the working directory before running command
-  -E, --preserve-env=list       preserve specific environment variables
-  -e, --edit                    edit files instead of running a command
   -g, --group=group             run command as the specified group name or ID
-  -H, --set-home                set HOME variable to target user's home dir
   -h, --help                    display help message and exit
-  -h, --host=host               run command on host (if supported by plugin)
   -i, --login                   run login shell as the target user; a command may also be
                                 specified
   -K, --remove-timestamp        remove timestamp file completely
   -k, --reset-timestamp         invalidate timestamp file
-  -l, --list                    list user's privileges or check a specific command; use twice
                                 for longer format
   -n, --non-interactive         non-interactive mode, no prompts are used
-  -P, --preserve-groups         preserve group vector instead of setting to target's
-  -R, --chroot=directory        change the root directory before running command
   -S, --stdin                   read password from standard input
   -s, --shell                   run shell as the target user; a command may also be specified
-  -U, --other-user=user         in list mode, display privileges for user
   -u, --user=user               run command (or edit file) as specified user name or ID
-  -V, --version                 display version information and exit
   -v, --validate                update user's timestamp without running a command
+  -V, --version                 display version information and exit
   --                            stop processing command line arguments";
 
-pub const USAGE_MSG: &str = "usage: sudo -h | -K | -k | -V
-usage: sudo -v [-knS] [-g group] [-h host] [-u user]
-usage: sudo -l [-knS] [-g group] [-h host] [-U user] [-u user] [command]
-usage: sudo [-bEHknPS] [-D directory] [-g group] [-h host] [-R directory] [-u user] [VAR=value] [-i|-s] [<command>]
-usage: sudo -e [-knS] [-D directory] [-g group] [-h host] [-R directory] [-u user] file ...";
+pub fn long_help_message() -> String {
+    format!("{DESCRIPTOR}\n{USAGE_MSG}\n{HELP_MSG}")
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,7 +32,6 @@ pub struct SudoOptions {
     pub other_user: Option<String>,
     pub preserve_env: Vec<String>,
     pub preserve_groups: bool,
-    pub set_home: bool,
     pub shell: bool,
     pub stdin: bool,
     pub user: Option<String>,
@@ -199,7 +198,6 @@ impl SudoOptions {
         // check arguments for validate action
         if matches!(self.action, SudoAction::Validate)
             && (self.background
-                || self.set_home
                 || self.preserve_groups
                 || self.login
                 || self.shell
@@ -214,7 +212,6 @@ impl SudoOptions {
         // check arguments for list action
         if matches!(self.action, SudoAction::List(_))
             && (self.background
-                || self.set_home
                 || self.preserve_groups
                 || self.login
                 || self.shell
@@ -228,7 +225,6 @@ impl SudoOptions {
         // check arguments for edit action
         if matches!(self.action, SudoAction::Edit(_))
             && (self.background
-                || self.set_home
                 || self.preserve_groups
                 || self.login
                 || self.shell
@@ -262,7 +258,8 @@ impl SudoOptions {
                         options.edit = true;
                     }
                     "-H" | "--set-home" => {
-                        options.set_home = true;
+                        // this option is ignored, since it is the default for sudo-rs; but accept
+                        // it for backwards compatibility reasons
                     }
                     "-h" | "--help" => {
                         options.help = true;

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -178,15 +178,6 @@ fn shorthand_without_argument() {
 }
 
 #[test]
-fn set_home() {
-    let cmd = SudoOptions::try_parse_from(["sudo", "-H"]).unwrap();
-    assert!(cmd.set_home);
-
-    let cmd = SudoOptions::try_parse_from(["sudo", "--set-home"]).unwrap();
-    assert!(cmd.set_home);
-}
-
-#[test]
 fn non_interactive() {
     let cmd = SudoOptions::try_parse_from(["sudo", "-n"]).unwrap();
     assert!(cmd.non_interactive);

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -81,7 +81,7 @@ fn sudo_process() -> Result<(), Error> {
     let sudo_options = match SudoOptions::from_env() {
         Ok(options) => match options.action {
             SudoAction::Help => {
-                eprintln!("{}", help::HELP_MSG);
+                eprintln!("{}", help::long_help_message());
                 std::process::exit(0);
             }
             SudoAction::Version => {


### PR DESCRIPTION
`always_set_home` was already ignored (it is the default behaviour); also the CLI help had a lot of options we don't support  or don't intend to support