### PR TITLE
Prevent information leakage

### DIFF
--- a/src/common/command.rs
+++ b/src/common/command.rs
@@ -88,12 +88,12 @@ mod test {
         assert_eq!(
             CommandAndArguments::try_from_args(
                 None,
-                vec!["/bin/ls".into(), "hello".into()],
+                vec!["/usr/bin/fmt".into(), "hello".into()],
                 "/bin"
             )
             .unwrap(),
             CommandAndArguments {
-                command: "/bin/ls".into(),
+                command: "/usr/bin/fmt".into(),
                 arguments: vec!["hello".into()]
             }
         );

--- a/src/common/command.rs
+++ b/src/common/command.rs
@@ -52,9 +52,10 @@ impl CommandAndArguments {
             arguments.remove(0);
 
             // FIXME: we leak information here since we throw an error if a file does not exists
-            if !is_qualified(&command) {
-                command =
-                    resolve_path(&command, path).ok_or_else(|| Error::InvalidCommand(command))?
+            command = if !is_qualified(&command) {
+                resolve_path(&command, path).ok_or_else(|| Error::InvalidCommand(command))?
+            } else {
+                std::fs::canonicalize(&command).unwrap_or(command)
             };
         }
 

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -300,9 +300,6 @@ fn match_command<'a>((cmd, args): (&'a Path, &'a [String])) -> (impl Fn(&Command
         ..glob::MatchOptions::new()
     };
     move |(cmdpat, argpat)| {
-        // use the canonicalized path (not using that is less permissive)
-        let realcmd = std::fs::canonicalize(cmd);
-        let cmd = realcmd.as_deref().unwrap_or(cmd);
         cmdpat.matches_path_with(cmd, opts)
             && argpat.as_ref().map_or(true, |vec| args == vec.as_ref())
     }


### PR DESCRIPTION
This builds on #576, so that has to be merged first.

`try_from_args` is changed into an infallible function (there is nothing we can meaningfully do with an error in that function, so we shouldn't generate them); `exec` will determine whether or not the command that was resolved could actually be executed. This matches original sudo behaviour.