### PR TITLE
Remove superfluous quotes from 'command not found'

### DIFF
--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::InvalidCommand(p) => write!(f, "'{p:?}': command not found"),
+            Error::InvalidCommand(p) => write!(f, "'{}': command not found", p.display()),
             Error::UserNotFound(u) => write!(f, "user '{u}' not found"),
             Error::GroupNotFound(g) => write!(f, "group '{g}' not found"),
             Error::Authentication(e) => write!(f, "authentication failed: {e}"),

--- a/test-framework/sudo-compliance-tests/src/cli.rs
+++ b/test-framework/sudo-compliance-tests/src/cli.rs
@@ -48,7 +48,7 @@ fn dash_dash_before_flag_is_an_error() -> Result<()> {
     if sudo_test::is_original_sudo() {
         assert_snapshot!(stderr);
     } else {
-        assert_contains!(stderr, "'\"-u\"': command not found");
+        assert_contains!(stderr, "'-u': command not found");
     }
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/path_search.rs
+++ b/test-framework/sudo-compliance-tests/src/path_search.rs
@@ -57,7 +57,7 @@ fn when_path_is_unset_does_not_search_in_default_path_set_for_command_execution(
     if sudo_test::is_original_sudo() {
         assert_snapshot!(stderr);
     } else {
-        assert_contains!(stderr, "'\"my-script\"': command not found");
+        assert_contains!(stderr, "'my-script': command not found");
     }
 
     Ok(())

--- a/test-framework/sudo-compliance-tests/src/sudoers/secure_path.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/secure_path.rs
@@ -79,7 +79,7 @@ ALL ALL=(ALL:ALL) NOPASSWD: ALL")
     if sudo_test::is_original_sudo() {
         assert_snapshot!(stderr);
     } else {
-        assert_contains!(stderr, "'\"true\"': command not found");
+        assert_contains!(stderr, "'true': command not found");
     }
 
     Ok(())


### PR DESCRIPTION
A `Debug` formatter shouldn't be used in userfacing UI's