### PR TITLE
Improve IO abstractions

### DIFF
--- a/src/exec/event.rs
+++ b/src/exec/event.rs
@@ -95,19 +95,6 @@ impl<T: Process> EventRegistry<T> {
         id
     }
 
-    /// Set the `fd` descriptor to be polled for read and write events and produce the event
-    /// returned by `f` when `fd` is ready for the poll event given by parameter.
-    pub(super) fn register_rw_event<F: AsRawFd>(
-        &mut self,
-        fd: &F,
-        f: fn(PollEvent) -> T::Event,
-    ) -> (EventId, EventId) {
-        (
-            self.register_event(fd, PollEvent::Readable, f),
-            self.register_event(fd, PollEvent::Writable, f),
-        )
-    }
-
     /// Deregister the event associated with the given ID, meaning that the file descriptor for
     /// this event will not be polled anymore for that specific event.
     pub(super) fn deregister_event(&mut self, event_id: EventId) -> bool {

--- a/src/exec/event.rs
+++ b/src/exec/event.rs
@@ -87,11 +87,11 @@ impl<T: Process> EventRegistry<T> {
         &mut self,
         fd: &F,
         poll_event: PollEvent,
-        event: T::Event,
+        event_fn: impl Fn(PollEvent) -> T::Event,
     ) -> EventId {
         let id = self.next_id();
         self.poll_set.add_fd(id, fd, poll_event);
-        self.events.insert(id, event);
+        self.events.insert(id, event_fn(poll_event));
         id
     }
 
@@ -103,8 +103,8 @@ impl<T: Process> EventRegistry<T> {
         f: fn(PollEvent) -> T::Event,
     ) -> (EventId, EventId) {
         (
-            self.register_event(fd, PollEvent::Readable, f(PollEvent::Readable)),
-            self.register_event(fd, PollEvent::Writable, f(PollEvent::Writable)),
+            self.register_event(fd, PollEvent::Readable, f),
+            self.register_event(fd, PollEvent::Writable, f),
         )
     }
 

--- a/src/exec/event.rs
+++ b/src/exec/event.rs
@@ -1,15 +1,10 @@
-use std::{io, os::fd::AsRawFd};
+use std::os::fd::AsRawFd;
 
-use crate::log::dev_error;
-use crate::system::signal::SignalAction;
-use crate::system::{
-    poll::PollSet,
-    signal::{SignalHandler, SignalInfo, SignalNumber},
-};
+use crate::system::poll::PollSet;
 
-use signal_hook::consts::*;
-
-pub(super) trait EventClosure: Sized {
+pub(super) trait Process: Sized {
+    /// IO Events that this process should handle.
+    type Event: Copy;
     /// Reason why the event loop should break.
     ///
     /// See [`EventDispatcher::set_break`] for more information.
@@ -18,74 +13,16 @@ pub(super) trait EventClosure: Sized {
     ///
     /// See [`EventDispatcher::set_exit`] for more information.
     type Exit;
-    /// Operation that the closure must do when a signal arrives.
-    fn on_signal(&mut self, info: SignalInfo, dispatcher: &mut EventDispatcher<Self>);
+    /// Handle the corresponding event.
+    fn on_event(&mut self, event: Self::Event, dispatcher: &mut EventDispatcher<Self>);
 }
 
-/// This macro ensures that we don't forget to set signal handlers.
-macro_rules! define_signals {
-    ($($signal:ident = $repr:literal,)*) => {
-        /// The signals that we can handle.
-        pub(super) const SIGNALS: &[SignalNumber] = &[$($signal,)*];
-
-        impl<T: EventClosure> EventDispatcher<T> {
-            /// Create a new and empty event handler.
-            ///
-            /// Calling this function also creates new signal handlers for the signals in
-            /// [`SIGNALS`] and sets the callbacks for each one of them using the
-            /// [`EventClosure::on_signal`] implementation.
-            pub(super) fn new() -> io::Result<Self> {
-                let mut dispatcher = Self {
-                    signal_handlers: [$(SignalHandler::new($signal).map_err(|err| {
-                        dev_error!(
-                            "unable to set handler for {}",
-                            super::signal_fmt($signal)
-                        );
-                        err
-                    })?,)*],
-                    poll_set: PollSet::new(),
-                    callbacks: Vec::with_capacity(SIGNALS.len()),
-                    status: Status::Continue,
-                };
-
-                $(
-                    let handler = &dispatcher.signal_handlers[$repr].as_raw_fd();
-                    dispatcher.set_read_callback(handler, |closure, dispatcher| {
-                        let handler = &mut dispatcher.signal_handlers[$repr];
-                        if let Ok(info) = handler.recv() {
-                            closure.on_signal(info, dispatcher);
-                        }
-                    });
-                )*
-
-                Ok(dispatcher)
-            }
-        }
-    };
-
-}
-
-define_signals! {
-    SIGINT = 0,
-    SIGQUIT = 1,
-    SIGTSTP = 2,
-    SIGTERM = 3,
-    SIGHUP = 4,
-    SIGALRM = 5,
-    SIGPIPE = 6,
-    SIGUSR1 = 7,
-    SIGUSR2 = 8,
-    SIGCHLD = 9,
-    SIGCONT = 10,
-    SIGWINCH = 11,
-}
-
-enum Status<T: EventClosure> {
+enum Status<T: Process> {
     Continue,
     Stop(StopReason<T>),
 }
 
-impl<T: EventClosure> Status<T> {
+impl<T: Process> Status<T> {
     fn is_break(&self) -> bool {
         matches!(self, Self::Stop(StopReason::Break(_)))
     }
@@ -96,17 +33,6 @@ impl<T: EventClosure> Status<T> {
         match status {
             Status::Continue => None,
             Status::Stop(reason) => Some(reason),
-        }
-    }
-
-    fn take_break(&mut self) -> Option<T::Break> {
-        match self.take_stop()? {
-            StopReason::Break(break_reason) => Some(break_reason),
-            reason @ StopReason::Exit(_) => {
-                // Replace back the status because it was not a `Break`.
-                *self = Self::Stop(reason);
-                None
-            }
         }
     }
 
@@ -122,7 +48,7 @@ impl<T: EventClosure> Status<T> {
     }
 }
 
-pub(super) enum StopReason<T: EventClosure> {
+pub(super) enum StopReason<T: Process> {
     Break(T::Break),
     Exit(T::Exit),
 }
@@ -130,31 +56,37 @@ pub(super) enum StopReason<T: EventClosure> {
 #[derive(PartialEq, Eq, Hash, Clone)]
 struct EventId(usize);
 
-pub(super) type Callback<T> = fn(&mut T, &mut EventDispatcher<T>);
-
 /// A type able to poll file descriptors and run callbacks when the descriptors are ready.
-pub(super) struct EventDispatcher<T: EventClosure> {
-    signal_handlers: [SignalHandler; SIGNALS.len()],
+pub(super) struct EventDispatcher<T: Process> {
     poll_set: PollSet<EventId>,
-    callbacks: Vec<Callback<T>>,
+    events: Vec<T::Event>,
     status: Status<T>,
 }
 
-impl<T: EventClosure> EventDispatcher<T> {
+impl<T: Process> EventDispatcher<T> {
+    /// Create a new and empty event handler.
+    pub(super) fn new() -> Self {
+        Self {
+            poll_set: PollSet::new(),
+            events: Vec::new(),
+            status: Status::Continue,
+        }
+    }
+
     /// Set the `fd` descriptor to be polled for read events and set `callback` to be called if
     /// `fd` is ready.
-    pub(super) fn set_read_callback<F: AsRawFd>(&mut self, fd: &F, callback: Callback<T>) {
-        let id = EventId(self.callbacks.len());
+    pub(super) fn register_read_event<F: AsRawFd>(&mut self, fd: &F, event: T::Event) {
+        let id = EventId(self.events.len());
         self.poll_set.add_fd_read(id, fd);
-        self.callbacks.push(callback);
+        self.events.push(event);
     }
 
     /// Set the `fd` descriptor to be polled for write events and set `callback` to be called if
     /// `fd` is ready.
-    pub(super) fn set_write_callback<F: AsRawFd>(&mut self, fd: &F, callback: Callback<T>) {
-        let id = EventId(self.callbacks.len());
+    pub(super) fn register_write_event<F: AsRawFd>(&mut self, fd: &F, event: T::Event) {
+        let id = EventId(self.events.len());
         self.poll_set.add_fd_write(id, fd);
-        self.callbacks.push(callback);
+        self.events.push(event);
     }
 
     /// Stop the event loop when the current callback is done and set a reason for it.
@@ -180,43 +112,29 @@ impl<T: EventClosure> EventDispatcher<T> {
     ///
     /// The event loop will continue indefinitely unless you call [`EventDispatcher::set_break`] or
     /// [`EventDispatcher::set_exit`].
-    pub(super) fn event_loop(&mut self, state: &mut T) -> StopReason<T> {
+    pub(super) fn event_loop(&mut self, process: &mut T) -> StopReason<T> {
+        let mut event_queue = Vec::with_capacity(self.events.len());
+
         loop {
+            // FIXME: maybe we shout return the IO error instead.
             if let Ok(ids) = self.poll_set.poll() {
                 for EventId(id) in ids {
-                    self.callbacks[id](state, self);
+                    let event = self.events[id];
+                    event_queue.push(event);
+                }
 
-                    if let Some(reason) = self.status.take_break() {
-                        return StopReason::Break(reason);
+                for event in event_queue.drain(..) {
+                    process.on_event(event, self);
+
+                    if let Some(reason) = self.status.take_exit() {
+                        return StopReason::Exit(reason);
                     }
                 }
-                if let Some(reason) = self.status.take_exit() {
-                    return StopReason::Exit(reason);
-                }
-            } else {
-                // FIXME: maybe we shout return the IO error instead.
-                if let Some(reason) = self.status.take_stop() {
-                    return reason;
-                }
             }
-        }
-    }
 
-    /// Unregister all the handlers created by the dispatcher.
-    pub(super) fn unregister_handlers(self) {
-        for handler in self.signal_handlers {
-            handler.unregister();
-        }
-    }
-
-    /// Set the signal action for a specific signal handler.
-    pub(super) fn set_signal_action(&mut self, signal: SignalNumber, action: SignalAction) {
-        if let Some(i) = SIGNALS
-            .iter()
-            .enumerate()
-            .find_map(|(i, &sig)| (signal == sig).then_some(i))
-        {
-            self.signal_handlers[i].set_action(action);
+            if let Some(reason) = self.status.take_stop() {
+                return reason;
+            }
         }
     }
 }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -4,6 +4,7 @@ mod event;
 mod interface;
 mod io_util;
 mod no_pty;
+mod signal_manager;
 mod use_pty;
 
 use std::{

--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -242,7 +242,7 @@ impl ExecClosure {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum ExecEvent {
     Signal(Signal),
 }

--- a/src/exec/signal_manager.rs
+++ b/src/exec/signal_manager.rs
@@ -1,6 +1,9 @@
 use std::io;
 
-use crate::system::signal::{SignalAction, SignalHandler, SignalInfo, SignalNumber};
+use crate::system::{
+    poll::PollEvent,
+    signal::{SignalAction, SignalHandler, SignalInfo, SignalNumber},
+};
 
 use signal_hook::consts::*;
 
@@ -24,7 +27,7 @@ impl SignalManager {
         f: fn(Signal) -> T::Event,
     ) {
         for (&signal, handler) in Signal::ALL.iter().zip(&self.handlers) {
-            registry.register_read_event(handler, f(signal));
+            registry.register_event(handler, PollEvent::Readable, f(signal));
         }
     }
 }

--- a/src/exec/signal_manager.rs
+++ b/src/exec/signal_manager.rs
@@ -24,7 +24,7 @@ impl SignalManager {
         f: fn(Signal) -> T::Event,
     ) {
         for (&signal, handler) in Signal::ALL.iter().zip(&self.handlers) {
-            registry.register_read_event(handler, f(signal))
+            registry.register_read_event(handler, f(signal));
         }
     }
 }

--- a/src/exec/signal_manager.rs
+++ b/src/exec/signal_manager.rs
@@ -27,7 +27,7 @@ impl SignalManager {
         f: fn(Signal) -> T::Event,
     ) {
         for (&signal, handler) in Signal::ALL.iter().zip(&self.handlers) {
-            registry.register_event(handler, PollEvent::Readable, f(signal));
+            registry.register_event(handler, PollEvent::Readable, |_| f(signal));
         }
     }
 }

--- a/src/exec/signal_manager.rs
+++ b/src/exec/signal_manager.rs
@@ -1,0 +1,81 @@
+use std::io;
+
+use crate::system::signal::{SignalHandler, SignalNumber};
+
+use signal_hook::consts::*;
+
+pub(super) struct SignalManager {
+    handlers: [SignalHandler; Signal::ALL.len()],
+}
+
+impl SignalManager {
+    /// Unregister all the handlers created by the dispatcher.
+    pub(super) fn unregister_handlers(self) {
+        for handler in self.handlers {
+            handler.unregister();
+        }
+    }
+
+    pub(super) fn handlers(&self) -> impl Iterator<Item = (Signal, &SignalHandler)> {
+        (Signal::ALL).iter().copied().zip(self.handlers.iter())
+    }
+
+}
+
+macro_rules! define_signals {
+    ($($signal:ident = $index:literal,)*) => {
+        #[allow(clippy::upper_case_acronyms)]
+        /// Signals that can be handled
+        #[derive(Clone, Copy, Debug)]
+        pub(super) enum Signal {
+            $($signal,)*
+        }
+
+        impl Signal {
+            const ALL: &[Self] = &[$(Self::$signal,)*];
+
+            pub(super) fn try_from_number(signal: SignalNumber) -> Option<Self> {
+                match signal {
+                    $($signal => Some(Self::$signal),)*
+                    _ => None,
+                }
+            }
+        }
+
+        impl SignalManager {
+            pub(super) fn new() -> io::Result<Self> {
+                Ok(Self {
+                    handlers: [$(SignalHandler::new($signal)?,)*],
+                })
+            }
+
+            pub(super) fn get_handler(&self, signal: Signal) -> &SignalHandler {
+                match signal {
+                    $(Signal::$signal => &self.handlers[$index],)*
+                }
+            }
+
+            pub(super) fn get_handler_mut(&mut self, signal: Signal) -> &mut SignalHandler {
+                match signal {
+                    $(Signal::$signal => &mut self.handlers[$index],)*
+                }
+            }
+        }
+
+    };
+}
+
+define_signals! {
+    SIGINT = 0,
+    SIGQUIT = 1,
+    SIGTSTP = 2,
+    SIGTERM = 3,
+    SIGHUP = 4,
+    SIGALRM = 5,
+    SIGPIPE = 6,
+    SIGUSR1 = 7,
+    SIGUSR2 = 8,
+    SIGCHLD = 9,
+    SIGCONT = 10,
+    SIGWINCH = 11,
+}

--- a/src/exec/signal_manager.rs
+++ b/src/exec/signal_manager.rs
@@ -4,14 +4,14 @@ use crate::system::signal::{SignalAction, SignalHandler, SignalInfo, SignalNumbe
 
 use signal_hook::consts::*;
 
-use super::event::{EventDispatcher, Process};
+use super::event::{EventRegistry, Process};
 
 pub(super) struct SignalManager {
     handlers: [SignalHandler; Signal::ALL.len()],
 }
 
 impl SignalManager {
-    /// Unregister all the handlers created by the dispatcher.
+    /// Unregister all the handlers created by the registry.
     pub(super) fn unregister_handlers(self) {
         for handler in self.handlers {
             handler.unregister();
@@ -20,11 +20,11 @@ impl SignalManager {
 
     pub(super) fn register_handlers<T: Process>(
         &self,
-        dispatcher: &mut EventDispatcher<T>,
+        registry: &mut EventRegistry<T>,
         f: fn(Signal) -> T::Event,
     ) {
         for (&signal, handler) in Signal::ALL.iter().zip(&self.handlers) {
-            dispatcher.register_read_event(handler, f(signal))
+            registry.register_read_event(handler, f(signal))
         }
     }
 }

--- a/src/exec/signal_manager.rs
+++ b/src/exec/signal_manager.rs
@@ -33,7 +33,7 @@ macro_rules! define_signals {
     ($($signal:ident = $index:literal,)*) => {
         #[allow(clippy::upper_case_acronyms)]
         /// Signals that can be handled
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
         pub(super) enum Signal {
             $($signal,)*
         }

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -218,18 +218,14 @@ impl<'a> MonitorClosure<'a> {
         let monitor_pgrp = getpgrp();
 
         // Register the callback to receive the IO error if the command fails to execute.
-        registry.register_event(
-            &errpipe_rx,
-            PollEvent::Readable,
-            MonitorEvent::ReadableErrPipe,
-        );
+        registry.register_event(&errpipe_rx, PollEvent::Readable, |_| {
+            MonitorEvent::ReadableErrPipe
+        });
 
         // Register the callback to receive events from the backchannel
-        registry.register_event(
-            backchannel,
-            PollEvent::Readable,
-            MonitorEvent::ReadableBackchannel,
-        );
+        registry.register_event(backchannel, PollEvent::Readable, |_| {
+            MonitorEvent::ReadableBackchannel
+        });
 
         signal_manager.register_handlers(registry, MonitorEvent::Signal);
 

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -12,6 +12,7 @@ use crate::{
         use_pty::{SIGCONT_BG, SIGCONT_FG},
     },
     log::{dev_error, dev_info, dev_warn},
+    system::poll::PollEvent,
 };
 use crate::{
     exec::{signal_manager::Signal, terminate_process},
@@ -217,10 +218,18 @@ impl<'a> MonitorClosure<'a> {
         let monitor_pgrp = getpgrp();
 
         // Register the callback to receive the IO error if the command fails to execute.
-        registry.register_read_event(&errpipe_rx, MonitorEvent::ReadableErrPipe);
+        registry.register_event(
+            &errpipe_rx,
+            PollEvent::Readable,
+            MonitorEvent::ReadableErrPipe,
+        );
 
         // Register the callback to receive events from the backchannel
-        registry.register_read_event(backchannel, MonitorEvent::ReadableBackchannel);
+        registry.register_event(
+            backchannel,
+            PollEvent::Readable,
+            MonitorEvent::ReadableBackchannel,
+        );
 
         signal_manager.register_handlers(registry, MonitorEvent::Signal);
 

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -420,7 +420,7 @@ fn is_self_terminating(
     false
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum MonitorEvent {
     Signal(Signal),
     ReadableErrPipe,

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -222,9 +222,7 @@ impl<'a> MonitorClosure<'a> {
         // Register the callback to receive events from the backchannel
         dispatcher.register_read_event(backchannel, MonitorEvent::ReadableBackchannel);
 
-        for (signal, signal_handler) in signal_manager.handlers() {
-            dispatcher.register_read_event(signal_handler, MonitorEvent::Signal(signal));
-        }
+        signal_manager.register_handlers(dispatcher, MonitorEvent::Signal);
 
         // Put the command in its own process group.
         let command_pgrp = command_pid;
@@ -366,7 +364,7 @@ impl<'a> MonitorClosure<'a> {
     }
 
     fn on_signal(&mut self, signal: Signal, dispatcher: &mut EventDispatcher<Self>) {
-        let info = match self.signal_manager.get_handler_mut(signal).recv() {
+        let info = match self.signal_manager.recv(signal) {
             Ok(info) => info,
             Err(err) => {
                 dev_error!("monitor could not receive signal {signal:?}: {err}");

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -5,7 +5,8 @@ use std::process::{exit, Command};
 
 use signal_hook::consts::*;
 
-use crate::exec::event::{EventClosure, EventDispatcher, StopReason};
+use crate::exec::event::{EventDispatcher, Process, StopReason};
+use crate::exec::signal_manager::{Signal, SignalManager};
 use crate::exec::use_pty::monitor::exec_monitor;
 use crate::exec::use_pty::SIGCONT_FG;
 use crate::exec::{cond_fmt, opt_fmt, signal_fmt, terminate_process};
@@ -19,7 +20,7 @@ use crate::system::signal::{SignalAction, SignalHandler, SignalNumber};
 use crate::system::term::{Pty, PtyLeader, Terminal, UserTerm};
 use crate::system::wait::{Wait, WaitError, WaitOptions};
 use crate::system::{chown, fork, getpgrp, kill, killpg, ForkResult, Group, User};
-use crate::system::{getpgid, interface::ProcessId, signal::SignalInfo};
+use crate::system::{getpgid, interface::ProcessId};
 
 use super::pipe::Pipe;
 use super::SIGCONT_BG;
@@ -66,27 +67,19 @@ pub(crate) fn exec_pty(
     command.stdout(clone_follower()?);
     command.stderr(clone_follower()?);
 
-    let mut dispatcher = EventDispatcher::<ParentClosure>::new()?;
+    let mut dispatcher = EventDispatcher::<ParentClosure>::new();
 
     let mut tty_pipe = Pipe::new(user_tty, pty.leader);
 
     let (user_tty, pty_leader) = tty_pipe.both_mut();
 
     //  Read from `/dev/tty` and write to the leader if not in the background.
-    dispatcher.set_read_callback(user_tty, |parent, _| {
-        parent.tty_pipe.read_left().ok();
-    });
-    dispatcher.set_write_callback(pty_leader, |parent, _| {
-        parent.tty_pipe.write_right().ok();
-    });
+    dispatcher.register_read_event(user_tty, ParentEvent::ReadableTty);
+    dispatcher.register_write_event(pty_leader, ParentEvent::WritablePty);
 
     // Read from the leader and write to `/dev/tty`.
-    dispatcher.set_read_callback(pty_leader, |parent, _| {
-        parent.tty_pipe.read_right().ok();
-    });
-    dispatcher.set_write_callback(user_tty, |parent, _| {
-        parent.tty_pipe.write_left().ok();
-    });
+    dispatcher.register_read_event(pty_leader, ParentEvent::ReadablePty);
+    dispatcher.register_write_event(user_tty, ParentEvent::WritableTty);
 
     // Check if we are the foreground process
     let mut foreground = user_tty
@@ -120,8 +113,9 @@ pub(crate) fn exec_pty(
         term_raw = true;
     }
 
-    // FIXME: it would be better if we didn't create the dispatcher before the fork and managed
+    // FIXME: it would be better if we didn't create the manager before the fork and managed
     // to block all the signals here instead.
+    let signal_manager = SignalManager::new()?;
 
     let ForkResult::Parent(monitor_pid) = fork().map_err(|err| {
         dev_error!("unable to fork monitor process: {err}");
@@ -133,7 +127,7 @@ pub(crate) fn exec_pty(
 
         // Unregister all the handlers so `exec_monitor` can register new ones for the monitor
         // process.
-        dispatcher.unregister_handlers();
+        signal_manager.unregister_handlers();
 
         // If `exec_monitor` returns, it means we failed to execute the command somehow.
         if let Err(err) = exec_monitor(
@@ -175,6 +169,7 @@ pub(crate) fn exec_pty(
         tty_pipe,
         foreground,
         term_raw,
+        signal_manager,
         &mut dispatcher,
     );
 
@@ -236,6 +231,7 @@ struct ParentClosure {
     foreground: bool,
     term_raw: bool,
     message_queue: VecDeque<MonitorMessage>,
+    signal_manager: SignalManager,
 }
 
 impl ParentClosure {
@@ -248,17 +244,18 @@ impl ParentClosure {
         tty_pipe: Pipe<UserTerm, PtyLeader>,
         foreground: bool,
         term_raw: bool,
+        signal_manager: SignalManager,
         dispatcher: &mut EventDispatcher<Self>,
     ) -> Self {
-        dispatcher.set_read_callback(&backchannel, |parent, dispatcher| {
-            parent.on_message_received(dispatcher)
-        });
+        dispatcher.register_read_event(&backchannel, ParentEvent::ReadableBackchannel);
 
         // Check for queued messages only when the backchannel can be written so we can send
         // messages to the monitor process without blocking.
-        dispatcher.set_write_callback(&backchannel, |parent, dispatcher| {
-            parent.check_message_queue(dispatcher)
-        });
+        dispatcher.register_write_event(&backchannel, ParentEvent::WritableBackchannel);
+
+        for (signal, signal_handler) in signal_manager.handlers() {
+            dispatcher.register_read_event(signal_handler, ParentEvent::Signal(signal));
+        }
 
         Self {
             monitor_pid: Some(monitor_pid),
@@ -270,6 +267,7 @@ impl ParentClosure {
             foreground,
             term_raw,
             message_queue: VecDeque::new(),
+            signal_manager,
         }
     }
 
@@ -322,7 +320,7 @@ impl ParentClosure {
                                 signal_fmt(signal)
                             );
                             // Suspend parent and tell monitor how to resume on return
-                            if let Some(signal) = self.suspend_pty(signal, dispatcher) {
+                            if let Some(signal) = self.suspend_pty(signal) {
                                 self.schedule_signal(signal);
                             }
                             // FIXME: enable IO events here.
@@ -395,7 +393,7 @@ impl ParentClosure {
     }
 
     /// Handle changes to the monitor status.
-    fn handle_sigchld(&mut self, monitor_pid: ProcessId, dispatcher: &mut EventDispatcher<Self>) {
+    fn handle_sigchld(&mut self, monitor_pid: ProcessId) {
         const OPTS: WaitOptions = WaitOptions::new().all().untraced().no_hang();
 
         let status = loop {
@@ -424,7 +422,7 @@ impl ParentClosure {
                 "monitor ({monitor_pid}) was stopped by {}, suspending sudo",
                 signal_fmt(signal)
             );
-            if let Some(signal) = self.suspend_pty(signal, dispatcher) {
+            if let Some(signal) = self.suspend_pty(signal) {
                 self.schedule_signal(signal);
             }
             // FIXME: Restore IO events here.
@@ -439,13 +437,12 @@ impl ParentClosure {
     ///
     /// Return `SIGCONT_FG` or `SIGCONT_BG` to state whether the command should be resumend in the
     /// foreground or not.
-    fn suspend_pty(
-        &mut self,
-        signal: SignalNumber,
-        dispatcher: &mut EventDispatcher<Self>,
-    ) -> Option<SignalNumber> {
+    fn suspend_pty(&mut self, signal: SignalNumber) -> Option<SignalNumber> {
         // Ignore `SIGCONT` while suspending to avoid resuming the terminal twice.
-        dispatcher.set_signal_action(SIGCONT, SignalAction::Ignore);
+        let sigcont_action = self
+            .signal_manager
+            .get_handler(Signal::SIGCONT)
+            .set_action(SignalAction::Ignore);
 
         if let SIGTTOU | SIGTTIN = signal {
             // If sudo is already the foreground process we can resume the command in the
@@ -479,9 +476,15 @@ impl ParentClosure {
             }
         }
 
-        if signal != SIGSTOP {
-            dispatcher.set_signal_action(signal, SignalAction::Default);
-        }
+        // FIXME: we should set the action even if we don't have a handler for that signal.
+        let saved_signal_action = (signal != SIGSTOP).then_some(signal).and_then(|number| {
+            let signal = Signal::try_from_number(number)?;
+            let action = self
+                .signal_manager
+                .get_handler(signal)
+                .set_action(SignalAction::Default);
+            Some((signal, action))
+        });
 
         if self.parent_pgrp != self.sudo_pid && kill(self.parent_pgrp, 0).is_err()
             || killpg(self.parent_pgrp, signal).is_err()
@@ -492,8 +495,8 @@ impl ParentClosure {
             }
         }
 
-        if signal != SIGSTOP {
-            dispatcher.set_signal_action(signal, SignalAction::Stream);
+        if let Some((signal, action)) = saved_signal_action {
+            self.signal_manager.get_handler(signal).set_action(action);
         }
 
         if self.command_pid.is_none() || self.resume_terminal().is_err() {
@@ -506,7 +509,9 @@ impl ParentClosure {
             SIGCONT_BG
         };
 
-        dispatcher.set_signal_action(SIGCONT, SignalAction::Stream);
+        self.signal_manager
+            .get_handler(Signal::SIGCONT)
+            .set_action(sigcont_action);
 
         Some(ret_signal)
     }
@@ -550,6 +555,41 @@ impl ParentClosure {
 
         Ok(())
     }
+
+    fn on_signal(&mut self, signal: Signal) {
+        let info = match self.signal_manager.get_handler_mut(signal).recv() {
+            Ok(info) => info,
+            Err(err) => {
+                dev_error!("parent could not receive signal {signal:?}: {err}");
+                return;
+            }
+        };
+
+        dev_info!(
+            "parent received{} {} from {}",
+            opt_fmt(info.is_user_signaled(), " user signaled"),
+            signal_fmt(info.signal()),
+            info.pid()
+        );
+
+        let Some(monitor_pid) = self.monitor_pid else {
+            dev_info!("monitor was terminated, ignoring signal");
+            return;
+        };
+
+        match info.signal() {
+            SIGCHLD => self.handle_sigchld(monitor_pid),
+            SIGCONT => {
+                self.resume_terminal().ok();
+            }
+            // FIXME: check `sync_ttysize`
+            SIGWINCH => {}
+            // Skip the signal if it was sent by the user and it is self-terminating.
+            _ if info.is_user_signaled() && self.is_self_terminating(info.pid()) => {}
+            // FIXME: check `send_command_status`
+            signal => self.schedule_signal(signal),
+        }
+    }
 }
 
 enum ParentExit {
@@ -571,34 +611,39 @@ impl From<ExitReason> for ParentExit {
     }
 }
 
-impl EventClosure for ParentClosure {
+#[derive(Clone, Copy)]
+enum ParentEvent {
+    Signal(Signal),
+    ReadableTty,
+    WritableTty,
+    ReadablePty,
+    WritablePty,
+    ReadableBackchannel,
+    WritableBackchannel,
+}
+
+impl Process for ParentClosure {
+    type Event = ParentEvent;
     type Break = io::Error;
     type Exit = ParentExit;
 
-    fn on_signal(&mut self, info: SignalInfo, dispatcher: &mut EventDispatcher<Self>) {
-        dev_info!(
-            "parent received{} {} from {}",
-            opt_fmt(info.is_user_signaled(), " user signaled"),
-            signal_fmt(info.signal()),
-            info.pid()
-        );
-
-        let Some(monitor_pid) = self.monitor_pid else {
-            dev_info!("monitor was terminated, ignoring signal");
-            return;
-        };
-
-        match info.signal() {
-            SIGCHLD => self.handle_sigchld(monitor_pid, dispatcher),
-            SIGCONT => {
-                self.resume_terminal().ok();
+    fn on_event(&mut self, event: Self::Event, dispatcher: &mut EventDispatcher<Self>) {
+        match event {
+            ParentEvent::Signal(signal) => self.on_signal(signal),
+            ParentEvent::ReadableTty => {
+                self.tty_pipe.read_left().ok();
             }
-            // FIXME: check `sync_ttysize`
-            SIGWINCH => {}
-            // Skip the signal if it was sent by the user and it is self-terminating.
-            _ if info.is_user_signaled() && self.is_self_terminating(info.pid()) => {}
-            // FIXME: check `send_command_status`
-            signal => self.schedule_signal(signal),
+            ParentEvent::WritableTty => {
+                self.tty_pipe.write_left().ok();
+            }
+            ParentEvent::ReadablePty => {
+                self.tty_pipe.read_right().ok();
+            }
+            ParentEvent::WritablePty => {
+                self.tty_pipe.write_right().ok();
+            }
+            ParentEvent::ReadableBackchannel => self.on_message_received(dispatcher),
+            ParentEvent::WritableBackchannel => self.check_message_queue(dispatcher),
         }
     }
 }

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -243,7 +243,9 @@ impl ParentClosure {
         signal_manager: SignalManager,
         registry: &mut EventRegistry<Self>,
     ) -> Self {
-        registry.register_rw_event(&backchannel, ParentEvent::Backchannel);
+        registry.register_event(&backchannel, PollEvent::Readable, ParentEvent::Backchannel);
+        registry.register_event(&backchannel, PollEvent::Writable, ParentEvent::Backchannel);
+
         signal_manager.register_handlers(registry, ParentEvent::Signal);
 
         Self {

--- a/src/exec/use_pty/pipe.rs
+++ b/src/exec/use_pty/pipe.rs
@@ -55,11 +55,17 @@ impl<L: Read + Write + AsRawFd, R: Read + Write + AsRawFd> Pipe<L, R> {
         f_right: fn(PollEvent) -> T::Event,
     ) {
         if self.left_ids.is_none() {
-            self.left_ids = Some(registry.register_rw_event(&self.left, f_left));
+            self.left_ids = Some((
+                registry.register_event(&self.left, PollEvent::Readable, f_left),
+                registry.register_event(&self.left, PollEvent::Writable, f_left),
+            ));
         }
 
         if self.right_ids.is_none() {
-            self.right_ids = Some(registry.register_rw_event(&self.right, f_right));
+            self.right_ids = Some((
+                registry.register_event(&self.right, PollEvent::Readable, f_right),
+                registry.register_event(&self.right, PollEvent::Writable, f_right),
+            ));
         }
     }
 

--- a/src/system/poll.rs
+++ b/src/system/poll.rs
@@ -1,6 +1,5 @@
 use std::{
-    collections::HashMap,
-    hash::Hash,
+    collections::{BTreeMap, HashMap},
     io,
     os::fd::{AsRawFd, RawFd},
 };
@@ -10,20 +9,14 @@ use libc::{c_short, pollfd, POLLIN, POLLOUT};
 
 /// A set of indexed file descriptors to be polled using the [`poll`](https://manpage.me/?q=poll) system call.
 pub struct PollSet<K> {
-    fds: HashMap<K, (RawFd, c_short)>,
+    fds: BTreeMap<K, (RawFd, c_short)>,
 }
 
-impl<K: Eq + PartialEq + Hash + Clone> Default for PollSet<K> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<K: Eq + PartialEq + Hash + Clone> PollSet<K> {
+impl<K: Eq + PartialEq + Ord + PartialOrd + Clone> PollSet<K> {
     /// Create an empty set of file descriptors.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
-            fds: HashMap::new(),
+            fds: BTreeMap::new(),
         }
     }
 

--- a/src/system/poll.rs
+++ b/src/system/poll.rs
@@ -49,6 +49,11 @@ impl<K: Eq + PartialEq + Hash + Clone> PollSet<K> {
         self.fds.insert(key, (fd.as_raw_fd(), events));
     }
 
+    /// Remove a the file descriptor under the provided key, if any.
+    pub fn remove_fd(&mut self, key: K) -> bool {
+        self.fds.remove(&key).is_some()
+    }
+
     /// Poll the set of file descriptors and return the key of the descriptors that are ready to be
     /// read or written.
     ///


### PR DESCRIPTION
**Describe the changes done on this pull request**

This PR rewrites some of the IO abstractions that we currently have so their use is less error prone:
- All the signal logic from `exec::event` was moved to a new `SignalManager` type using @japaric's idea of defining an `enum` for the signals that can be handled by it.
- Rename `EventClosure` to `Process`.
- Stop relying on callbacks to process events and instead use a single method `Process::on_event`.
- Now it is possible to ignore events on file descriptors to avoid polling them if desired.
- Stop polling the terminals when the command stops and start polling them again when the command continues.
- Rename the `EventDispatcher` to `EventRegistry`.
- Introduce the `PollEvent` type to have a single method `PollSet::add_fd` instead of the two we had before `PollSet::add_read_fd` and `PollSet::add_write_fd`.
- Delegate the registration and deregistration of events to the `Pipe`.

This PR is better reviewed commit-per-commit

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will partially fix https://github.com/memorysafety/sudo-rs/issues/522 where a proper discussion about a solution has taken place.
