### PR TITLE
Introduce the `HandleSigchld` trait

### DIFF
--- a/src/exec/use_pty/mod.rs
+++ b/src/exec/use_pty/mod.rs
@@ -3,6 +3,8 @@ mod monitor;
 mod parent;
 mod pipe;
 
+use std::ffi::c_int;
+
 pub(super) use parent::exec_pty;
 
 use crate::system::signal::SignalNumber;
@@ -11,3 +13,9 @@ use crate::system::signal::SignalNumber;
 pub(super) const SIGCONT_FG: SignalNumber = -2;
 /// Continue running in the background
 pub(super) const SIGCONT_BG: SignalNumber = -3;
+
+enum CommandStatus {
+    Exit(c_int),
+    Term(SignalNumber),
+    Stop(SignalNumber),
+}

--- a/src/system/wait.rs
+++ b/src/system/wait.rs
@@ -107,7 +107,6 @@ impl WaitOptions {
 }
 
 /// The status of the waited child.
-#[derive(Clone, Copy)]
 pub struct WaitStatus {
     status: c_int,
 }
@@ -137,14 +136,6 @@ impl std::fmt::Debug for WaitStatus {
 }
 
 impl WaitStatus {
-    pub const fn from_raw(status: c_int) -> Self {
-        Self { status }
-    }
-
-    pub const fn into_raw(self) -> c_int {
-        self.status
-    }
-
     /// Return `true` if the child terminated normally, i.e., by calling `exit`.
     pub const fn did_exit(&self) -> bool {
         WIFEXITED(self.status)


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR introduces a new trait `HandleSigchld` to deduplicate code from the `exec::use_pty` and `exec::no_pty` modules where a process is waiting for a child process status report.

This is blocked by #596.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.