### PR TITLE
Implement the `--validate` flag

### DIFF
--- a/src/pam/error.rs
+++ b/src/pam/error.rs
@@ -1,4 +1,4 @@
-use std::{ffi::NulError, fmt};
+use std::{ffi::NulError, fmt, str::Utf8Error};
 
 use crate::cutils::string_from_ptr;
 
@@ -185,6 +185,7 @@ impl PamErrorType {
 #[derive(Debug)]
 pub enum PamError {
     UnexpectedNulByte(NulError),
+    Utf8Error(Utf8Error),
     InvalidState,
     Pam(PamErrorType, String),
     IoError(std::io::Error),
@@ -206,10 +207,17 @@ impl From<NulError> for PamError {
     }
 }
 
+impl From<Utf8Error> for PamError {
+    fn from(err: Utf8Error) -> Self {
+        PamError::Utf8Error(err)
+    }
+}
+
 impl fmt::Display for PamError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PamError::UnexpectedNulByte(_) => write!(f, "Unexpected nul byte in input"),
+            PamError::Utf8Error(_) => write!(f, "Could not read input data as UTF-8 string"),
             PamError::InvalidState => {
                 write!(
                     f,

--- a/src/pam/mod.rs
+++ b/src/pam/mod.rs
@@ -206,13 +206,7 @@ impl<C: Converser> PamContext<C> {
     /// Get the user that is currently active in the PAM handle
     pub fn get_user(&mut self) -> PamResult<String> {
         let mut data = std::ptr::null();
-        pam_err(unsafe {
-            pam_get_item(
-                self.pamh,
-                PAM_USER as i32,
-                &mut data
-            )
-        })?;
+        pam_err(unsafe { pam_get_item(self.pamh, PAM_USER as i32, &mut data) })?;
 
         // safety check to make sure that we do not ready a null ptr into a cstr
         if data.is_null() {

--- a/src/pam/mod.rs
+++ b/src/pam/mod.rs
@@ -203,6 +203,28 @@ impl<C: Converser> PamContext<C> {
         })
     }
 
+    /// Get the user that is currently active in the PAM handle
+    pub fn get_user(&mut self) -> PamResult<String> {
+        let mut data = std::ptr::null();
+        pam_err(unsafe {
+            pam_get_item(
+                self.pamh,
+                PAM_USER as i32,
+                &mut data
+            )
+        })?;
+
+        // safety check to make sure that we do not ready a null ptr into a cstr
+        if data.is_null() {
+            return Err(PamError::InvalidState);
+        }
+
+        // unsafe conversion to cstr
+        let cstr = unsafe { CStr::from_ptr(data as *const i8) };
+
+        Ok(cstr.to_str()?.to_owned())
+    }
+
     /// Set the TTY path for the current TTY that this PAM session started from.
     pub fn set_tty<P: AsRef<OsStr>>(&mut self, tty_path: P) -> PamResult<()> {
         let data = CString::new(tty_path.as_ref().as_bytes())?;

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -99,7 +99,7 @@ fn sudo_process() -> Result<(), Error> {
                 let mut record_file =
                     SessionRecordFile::open_for_user(&user.name, Duration::seconds(0))?;
                 record_file.reset()?;
-                return Ok(());
+                Ok(())
             }
             SudoAction::ResetTimestamp => {
                 if let Some(scope) = RecordScope::for_process(&Process::new()) {
@@ -108,11 +108,9 @@ fn sudo_process() -> Result<(), Error> {
                         SessionRecordFile::open_for_user(&user.name, Duration::seconds(0))?;
                     record_file.disable(scope, None)?;
                 }
-                return Ok(());
+                Ok(())
             }
-            SudoAction::Validate => {
-                return pipeline.run_validate(options);
-            }
+            SudoAction::Validate => pipeline.run_validate(options),
             SudoAction::Run(ref cmd) => {
                 // special case for when no command is given
                 if cmd.is_empty() && !options.shell && !options.login {
@@ -121,7 +119,7 @@ fn sudo_process() -> Result<(), Error> {
                 } else {
                     unstable_warning();
 
-                    return pipeline.run(options);
+                    pipeline.run(options)
                 }
             }
             SudoAction::List(_) => {
@@ -135,7 +133,7 @@ fn sudo_process() -> Result<(), Error> {
             eprintln!("{e}\n{}", help::USAGE_MSG);
             std::process::exit(1);
         }
-    };
+    }
 }
 
 pub fn main() {

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -3,8 +3,9 @@
 use crate::cli::{help, SudoAction, SudoOptions};
 use crate::common::{resolve::resolve_current_user, Context, Error};
 use crate::log::dev_info;
+use crate::system::timestamp::RecordScope;
 use crate::system::{time::Duration, timestamp::SessionRecordFile, Process};
-use pam::{determine_record_scope, PamAuthenticator};
+use pam::PamAuthenticator;
 use pipeline::{Pipeline, PolicyPlugin};
 use std::env;
 
@@ -77,8 +78,13 @@ fn sudo_process() -> Result<(), Error> {
 
     dev_info!("development logs are enabled");
 
+    let pipeline = Pipeline {
+        policy: SudoersPolicy::default(),
+        authenticator: PamAuthenticator::new_cli(),
+    };
+
     // parse cli options
-    let sudo_options = match SudoOptions::from_env() {
+    match SudoOptions::from_env() {
         Ok(options) => match options.action {
             SudoAction::Help => {
                 eprintln!("{}", help::long_help_message());
@@ -96,7 +102,7 @@ fn sudo_process() -> Result<(), Error> {
                 return Ok(());
             }
             SudoAction::ResetTimestamp => {
-                if let Some(scope) = determine_record_scope(&Process::new()) {
+                if let Some(scope) = RecordScope::for_process(&Process::new()) {
                     let user = resolve_current_user()?;
                     let mut record_file =
                         SessionRecordFile::open_for_user(&user.name, Duration::seconds(0))?;
@@ -105,14 +111,17 @@ fn sudo_process() -> Result<(), Error> {
                 return Ok(());
             }
             SudoAction::Validate => {
-                unimplemented!();
+                return pipeline.run_validate(options);
             }
             SudoAction::Run(ref cmd) => {
+                // special case for when no command is given
                 if cmd.is_empty() && !options.shell && !options.login {
                     eprintln!("{}", help::USAGE_MSG);
                     std::process::exit(1);
                 } else {
-                    options
+                    unstable_warning();
+
+                    return pipeline.run(options);
                 }
             }
             SudoAction::List(_) => {
@@ -127,14 +136,6 @@ fn sudo_process() -> Result<(), Error> {
             std::process::exit(1);
         }
     };
-
-    unstable_warning();
-
-    let mut pipeline = Pipeline {
-        policy: SudoersPolicy::default(),
-        authenticator: PamAuthenticator::new_cli(),
-    };
-    pipeline.run(sudo_options)
 }
 
 pub fn main() {

--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -47,11 +47,7 @@ impl<C: Converser> AuthPlugin for PamAuthenticator<C> {
         Ok(())
     }
 
-    fn authenticate(
-        &mut self,
-        non_interactive: bool,
-        max_tries: u16,
-    ) -> Result<(), Error> {
+    fn authenticate(&mut self, non_interactive: bool, max_tries: u16) -> Result<(), Error> {
         let pam = self
             .pam
             .as_mut()
@@ -75,7 +71,7 @@ impl<C: Converser> AuthPlugin for PamAuthenticator<C> {
         let user = pam.get_user()?;
         if user != target_user {
             // switch pam over to the target user
-            pam.set_user(&target_user)?;
+            pam.set_user(target_user)?;
 
             // make sure that credentials are loaded for the target user
             // errors are ignored because not all modules support this functionality
@@ -106,7 +102,13 @@ impl<C: Converser> AuthPlugin for PamAuthenticator<C> {
     }
 }
 
-pub fn init_pam(is_login_shell: bool, use_stdin: bool, non_interactive: bool, auth_user: &str, requesting_user: &str) -> PamResult<PamContext<CLIConverser>> {
+pub fn init_pam(
+    is_login_shell: bool,
+    use_stdin: bool,
+    non_interactive: bool,
+    auth_user: &str,
+    requesting_user: &str,
+) -> PamResult<PamContext<CLIConverser>> {
     let service_name = if is_login_shell { "sudo-i" } else { "sudo" };
     let mut pam = PamContext::builder_cli("sudo", use_stdin, non_interactive)
         .service_name(service_name)
@@ -124,7 +126,11 @@ pub fn init_pam(is_login_shell: bool, use_stdin: bool, non_interactive: bool, au
     Ok(pam)
 }
 
-pub fn attempt_authenticate<C: Converser>(pam: &mut PamContext<C>, non_interactive: bool, mut max_tries: u16) -> Result<(), Error> {
+pub fn attempt_authenticate<C: Converser>(
+    pam: &mut PamContext<C>,
+    non_interactive: bool,
+    mut max_tries: u16,
+) -> Result<(), Error> {
     let mut current_try = 0;
     loop {
         current_try += 1;

--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -1,81 +1,13 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
-use std::fs::File;
 
 use crate::common::context::LaunchType;
 use crate::common::{error::Error, Context};
-use crate::log::{auth_warn, dev_info, user_warn};
+use crate::log::{dev_info, user_warn};
 use crate::pam::{CLIConverser, Converser, PamContext, PamError, PamErrorType, PamResult};
 use crate::system::term::current_tty_name;
-use crate::system::{
-    time::Duration,
-    timestamp::{RecordScope, SessionRecordFile, TouchResult},
-    Process, WithProcess,
-};
 
 use super::pipeline::AuthPlugin;
-
-/// Tries to determine a record match scope for the current context.
-/// This should never produce an error since any actual error should just be
-/// ignored and no session record file should be used in that case.
-pub fn determine_record_scope(process: &Process) -> Option<RecordScope> {
-    let tty = Process::tty_device_id(WithProcess::Current);
-    if let Ok(Some(tty_device)) = tty {
-        if let Ok(init_time) = Process::starting_time(WithProcess::Other(process.session_id)) {
-            Some(RecordScope::Tty {
-                tty_device,
-                session_pid: process.session_id,
-                init_time,
-            })
-        } else {
-            auth_warn!("Could not get terminal foreground process starting time");
-            None
-        }
-    } else if let Some(parent_pid) = process.parent_pid {
-        if let Ok(init_time) = Process::starting_time(WithProcess::Other(parent_pid)) {
-            Some(RecordScope::Ppid {
-                group_pid: parent_pid,
-                init_time,
-            })
-        } else {
-            auth_warn!("Could not get parent process starting time");
-            None
-        }
-    } else {
-        None
-    }
-}
-
-/// This should determine what the authentication status for the given record
-/// match limit and origin/target user from the context is.
-fn determine_auth_status(
-    record_for: Option<RecordScope>,
-    context: &Context,
-    prior_validity: Duration,
-) -> (bool, Option<SessionRecordFile<File>>) {
-    if let (true, Some(record_for)) = (context.use_session_records, record_for) {
-        match SessionRecordFile::open_for_user(&context.current_user.name, prior_validity) {
-            Ok(mut sr) => {
-                match sr.touch(record_for, context.current_user.uid) {
-                    // if a record was found and updated within the timeout, we do not need to authenticate
-                    Ok(TouchResult::Updated { .. }) => (false, Some(sr)),
-                    Ok(TouchResult::NotFound | TouchResult::Outdated { .. }) => (true, Some(sr)),
-                    Err(e) => {
-                        auth_warn!("Unexpected error while reading session information: {e}");
-                        (true, None)
-                    }
-                }
-            }
-            // if we cannot open the session record file we just assume there is none and continue as normal
-            Err(e) => {
-                auth_warn!("Could not use session information: {e}");
-                (true, None)
-            }
-        }
-    } else {
-        (true, None)
-    }
-}
 
 type PamBuilder<C> = dyn Fn(&Context) -> PamResult<PamContext<C>>;
 
@@ -98,18 +30,13 @@ impl<C: Converser> PamAuthenticator<C> {
 impl PamAuthenticator<CLIConverser> {
     pub fn new_cli() -> PamAuthenticator<CLIConverser> {
         PamAuthenticator::new(|context| {
-            let service_name = if matches!(context.launch, LaunchType::Login) {
-                "sudo-i"
-            } else {
-                "sudo"
-            };
-            let mut pam = PamContext::builder_cli("sudo", context.stdin, context.non_interactive)
-                .target_user(&context.current_user.name)
-                .service_name(service_name)
-                .build()?;
-            pam.mark_silent(true);
-            pam.mark_allow_null_auth_token(false);
-            Ok(pam)
+            init_pam(
+                matches!(context.launch, LaunchType::Login),
+                context.stdin,
+                context.non_interactive,
+                &context.current_user.name,
+                &context.current_user.name,
+            )
         })
     }
 }
@@ -122,74 +49,20 @@ impl<C: Converser> AuthPlugin for PamAuthenticator<C> {
 
     fn authenticate(
         &mut self,
-        context: &Context,
-        prior_validity: Duration,
-        mut max_tries: u16,
+        non_interactive: bool,
+        max_tries: u16,
     ) -> Result<(), Error> {
         let pam = self
             .pam
             .as_mut()
             .expect("Pam must be initialized before authenticate");
-        pam.set_user(&context.current_user.name)?;
-        pam.set_requesting_user(&context.current_user.name)?;
 
-        // attempt to set the TTY this session is communicating on
-        if let Ok(pam_tty) = current_tty_name() {
-            pam.set_tty(&pam_tty)?;
-        }
-
-        // determine session limit
-        let scope = determine_record_scope(&context.process);
-
-        // only if there is an interactive terminal or parent process we can store session information
-        let (must_authenticate, records_file) =
-            determine_auth_status(scope, context, prior_validity);
-
-        if must_authenticate {
-            let mut current_try = 0;
-            loop {
-                current_try += 1;
-                match pam.authenticate() {
-                    // there was no error, so authentication succeeded
-                    Ok(_) => break,
-
-                    // maxtries was reached, pam does not allow any more tries
-                    Err(PamError::Pam(PamErrorType::MaxTries, _)) => {
-                        return Err(Error::MaxAuthAttempts(current_try));
-                    }
-
-                    // there was an authentication error, we can retry
-                    Err(PamError::Pam(PamErrorType::AuthError, _)) => {
-                        max_tries -= 1;
-                        if max_tries == 0 {
-                            return Err(Error::MaxAuthAttempts(current_try));
-                        } else if context.non_interactive {
-                            return Err(Error::Authentication("interaction required".to_string()));
-                        } else {
-                            user_warn!("Authentication failed, try again.");
-                        }
-                    }
-
-                    // there was another pam error, return the error
-                    Err(e) => {
-                        return Err(e.into());
-                    }
-                }
-            }
-            if let (Some(mut session_records), Some(scope)) = (records_file, scope) {
-                match session_records.create(scope, context.current_user.uid) {
-                    Ok(_) => (),
-                    Err(e) => {
-                        auth_warn!("Could not update session record file with new record: {e}");
-                    }
-                }
-            }
-        }
+        attempt_authenticate(pam, non_interactive, max_tries)?;
 
         Ok(())
     }
 
-    fn pre_exec(&mut self, context: &Context) -> Result<HashMap<OsString, OsString>, Error> {
+    fn pre_exec(&mut self, target_user: &str) -> Result<HashMap<OsString, OsString>, Error> {
         let pam = self
             .pam
             .as_mut()
@@ -198,16 +71,20 @@ impl<C: Converser> AuthPlugin for PamAuthenticator<C> {
         // make sure that the user that needed to authenticate has a valid token
         pam.validate_account_or_change_auth_token()?;
 
-        // switch pam over to the target user
-        pam.set_user(&context.target_user.name)?;
+        // check what the current user in PAM is
+        let user = pam.get_user()?;
+        if user != target_user {
+            // switch pam over to the target user
+            pam.set_user(&target_user)?;
 
-        // make sure that credentials are loaded for the target user
-        // errors are ignored because not all modules support this functionality
-        if let Err(e) = pam.credentials_reinitialize() {
-            dev_info!(
-                "PAM gave an error while trying to re-initialize credentials: {:?}",
-                e
-            );
+            // make sure that credentials are loaded for the target user
+            // errors are ignored because not all modules support this functionality
+            if let Err(e) = pam.credentials_reinitialize() {
+                dev_info!(
+                    "PAM gave an error while trying to re-initialize credentials: {:?}",
+                    e
+                );
+            }
         }
 
         pam.open_session()?;
@@ -227,4 +104,57 @@ impl<C: Converser> AuthPlugin for PamAuthenticator<C> {
         // do anything with it
         let _ = pam.close_session();
     }
+}
+
+pub fn init_pam(is_login_shell: bool, use_stdin: bool, non_interactive: bool, auth_user: &str, requesting_user: &str) -> PamResult<PamContext<CLIConverser>> {
+    let service_name = if is_login_shell { "sudo-i" } else { "sudo" };
+    let mut pam = PamContext::builder_cli("sudo", use_stdin, non_interactive)
+        .service_name(service_name)
+        .build()?;
+    pam.mark_silent(!is_login_shell);
+    pam.mark_allow_null_auth_token(false);
+    pam.set_requesting_user(requesting_user)?;
+    pam.set_user(auth_user)?;
+
+    // attempt to set the TTY this session is communicating on
+    if let Ok(pam_tty) = current_tty_name() {
+        pam.set_tty(&pam_tty)?;
+    }
+
+    Ok(pam)
+}
+
+pub fn attempt_authenticate<C: Converser>(pam: &mut PamContext<C>, non_interactive: bool, mut max_tries: u16) -> Result<(), Error> {
+    let mut current_try = 0;
+    loop {
+        current_try += 1;
+        match pam.authenticate() {
+            // there was no error, so authentication succeeded
+            Ok(_) => break,
+
+            // maxtries was reached, pam does not allow any more tries
+            Err(PamError::Pam(PamErrorType::MaxTries, _)) => {
+                return Err(Error::MaxAuthAttempts(current_try));
+            }
+
+            // there was an authentication error, we can retry
+            Err(PamError::Pam(PamErrorType::AuthError, _)) => {
+                max_tries -= 1;
+                if max_tries == 0 {
+                    return Err(Error::MaxAuthAttempts(current_try));
+                } else if non_interactive {
+                    return Err(Error::Authentication("interaction required".to_string()));
+                } else {
+                    user_warn!("Authentication failed, try again.");
+                }
+            }
+
+            // there was another pam error, return the error
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -1,11 +1,16 @@
+use std::fs::File;
 use std::process::exit;
 
 use crate::cli::SudoOptions;
 use crate::common::{Context, Environment, Error};
 use crate::env::environment;
 use crate::exec::ExitReason;
+use crate::log::auth_warn;
 use crate::sudo::Duration;
 use crate::sudoers::{Authorization, DirChange, Policy, PreJudgementPolicy};
+use crate::system::Process;
+use crate::system::interface::UserId;
+use crate::system::timestamp::{RecordScope, SessionRecordFile, TouchResult};
 
 pub trait PolicyPlugin {
     type PreJudgementPolicy: PreJudgementPolicy;
@@ -23,11 +28,10 @@ pub trait AuthPlugin {
     fn init(&mut self, context: &Context) -> Result<(), Error>;
     fn authenticate(
         &mut self,
-        context: &Context,
-        prior_validity: Duration,
-        attempts: u16,
+        non_interactive: bool,
+        max_tries: u16,
     ) -> Result<(), Error>;
-    fn pre_exec(&mut self, context: &Context) -> Result<Environment, Error>;
+    fn pre_exec(&mut self, target_user: &str) -> Result<Environment, Error>;
     fn cleanup(&mut self);
 }
 
@@ -37,15 +41,14 @@ pub struct Pipeline<Policy: PolicyPlugin, Auth: AuthPlugin> {
 }
 
 impl<Policy: PolicyPlugin, Auth: AuthPlugin> Pipeline<Policy, Auth> {
-    pub fn run(&mut self, sudo_options: SudoOptions) -> Result<(), Error> {
+    pub fn run(mut self, cmd_opts: SudoOptions) -> Result<(), Error> {
         let pre = self.policy.init()?;
-        let secure_path: String = pre
-            .secure_path()
-            .unwrap_or_else(|| std::env::var("PATH").unwrap_or_default());
-        let mut context = Context::build_from_options(sudo_options, secure_path)?;
+        let mut context = build_context(cmd_opts, &pre)?;
 
         let policy = self.policy.judge(pre, &context)?;
         let authorization = policy.authorization();
+        let scope = RecordScope::for_process(&Process::new());
+
 
         match authorization {
             Authorization::Forbidden => {
@@ -60,15 +63,35 @@ impl<Policy: PolicyPlugin, Auth: AuthPlugin> Pipeline<Policy, Auth> {
                 allowed_attempts,
             } => {
                 self.apply_policy_to_context(&mut context, &policy)?;
+
+                let mut auth_status = determine_auth_status(
+                    must_authenticate,
+                    context.use_session_records,
+                    scope,
+                    context.current_user.uid,
+                    &context.current_user.name,
+                    prior_validity
+                );
+
                 self.authenticator.init(&context)?;
-                if must_authenticate {
-                    self.authenticator
-                        .authenticate(&context, prior_validity, allowed_attempts)?;
+                if auth_status.must_authenticate {
+                    self.authenticator.authenticate(
+                        context.non_interactive,
+                        allowed_attempts
+                    )?;
+                    if let (Some(record_file), Some(scope)) = (&mut auth_status.record_file, scope) {
+                        match record_file.create(scope, context.current_user.uid) {
+                            Ok(_) => (),
+                            Err(e) => {
+                                auth_warn!("Could not update session record file with new record: {e}");
+                            }
+                        }
+                    }
                 }
             }
         }
 
-        let additional_env = self.authenticator.pre_exec(&context)?;
+        let additional_env = self.authenticator.pre_exec(&context.target_user.name)?;
 
         // build environment
         let current_env = std::env::vars_os().collect();
@@ -102,6 +125,53 @@ impl<Policy: PolicyPlugin, Auth: AuthPlugin> Pipeline<Policy, Auth> {
         Ok(())
     }
 
+    pub fn run_validate(mut self, cmd_opts: SudoOptions) -> Result<(), Error> {
+        let scope = RecordScope::for_process(&Process::new());
+        let pre = self.policy.init()?;
+        let context = build_context(cmd_opts, &pre)?;
+
+        match pre.validate_authorization() {
+            Authorization::Forbidden => {
+                return Err(Error::auth(&format!(
+                    "I'm sorry {}. I'm afraid I can't do that",
+                    context.current_user.name
+                )));
+            }
+            Authorization::Allowed {
+                must_authenticate,
+                allowed_attempts,
+                prior_validity,
+            } => {
+                let mut auth_status = determine_auth_status(
+                    must_authenticate,
+                    context.use_session_records,
+                    scope,
+                    context.current_user.uid,
+                    &context.current_user.name,
+                    prior_validity
+                );
+
+                self.authenticator.init(&context)?;
+                if auth_status.must_authenticate {
+                    self.authenticator.authenticate(
+                        context.non_interactive,
+                        allowed_attempts
+                    )?;
+                    if let (Some(record_file), Some(scope)) = (&mut auth_status.record_file, scope) {
+                        match record_file.create(scope, context.current_user.uid) {
+                            Ok(_) => (),
+                            Err(e) => {
+                                auth_warn!("Could not update session record file with new record: {e}");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn apply_policy_to_context(
         &mut self,
         context: &mut Context,
@@ -124,5 +194,62 @@ impl<Policy: PolicyPlugin, Auth: AuthPlugin> Pipeline<Policy, Auth> {
         }
 
         Ok(())
+    }
+}
+
+fn build_context(cmd_opts: SudoOptions, pre: &dyn PreJudgementPolicy) -> Result<Context, Error> {
+    let secure_path: String = pre
+            .secure_path()
+            .unwrap_or_else(|| std::env::var("PATH").unwrap_or_default());
+    Context::build_from_options(cmd_opts, secure_path)
+}
+
+/// This should determine what the authentication status for the given record
+/// match limit and origin/target user from the context is.
+fn determine_auth_status(
+    must_policy_authenticate: bool,
+    use_session_records: bool,
+    record_for: Option<RecordScope>,
+    auth_uid: UserId,
+    current_user: &str,
+    prior_validity: Duration,
+) -> AuthStatus {
+    if !must_policy_authenticate {
+        AuthStatus::new(false, None)
+    } else if let (true, Some(record_for)) = (use_session_records, record_for) {
+        match SessionRecordFile::open_for_user(current_user, prior_validity) {
+            Ok(mut sr) => {
+                match sr.touch(record_for, auth_uid) {
+                    // if a record was found and updated within the timeout, we do not need to authenticate
+                    Ok(TouchResult::Updated { .. }) => AuthStatus::new(false, Some(sr)),
+                    Ok(TouchResult::NotFound | TouchResult::Outdated { .. }) => AuthStatus::new(true, Some(sr)),
+                    Err(e) => {
+                        auth_warn!("Unexpected error while reading session information: {e}");
+                        AuthStatus::new(true, None)
+                    }
+                }
+            }
+            // if we cannot open the session record file we just assume there is none and continue as normal
+            Err(e) => {
+                auth_warn!("Could not use session information: {e}");
+                AuthStatus::new(true, None)
+            }
+        }
+    } else {
+        AuthStatus::new(true, None)
+    }
+}
+
+struct AuthStatus<'a> {
+    must_authenticate: bool,
+    record_file: Option<SessionRecordFile<'a, File>>,
+}
+
+impl<'a> AuthStatus<'a> {
+    fn new(must_authenticate: bool, record_file: Option<SessionRecordFile<'a, File>>) -> AuthStatus<'a> {
+        AuthStatus {
+            must_authenticate,
+            record_file,
+        }
     }
 }

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -89,6 +89,7 @@ impl Policy for Judgement {
 
 pub trait PreJudgementPolicy {
     fn secure_path(&self) -> Option<String>;
+    fn validate_authorization(&self) -> Authorization;
 }
 
 impl PreJudgementPolicy for Sudoers {
@@ -96,6 +97,14 @@ impl PreJudgementPolicy for Sudoers {
         self.settings.str_value["secure_path"]
             .as_ref()
             .map(|s| s.to_string())
+    }
+
+    fn validate_authorization(&self) -> Authorization {
+        Authorization::Allowed {
+            must_authenticate: true,
+            allowed_attempts: self.settings.int_value["passwd_tries"].try_into().unwrap(),
+            prior_validity: Duration::seconds(self.settings.int_value["timestamp_timeout"]),
+        }
     }
 }
 

--- a/src/system/timestamp.rs
+++ b/src/system/timestamp.rs
@@ -10,7 +10,8 @@ use super::{
     audit::secure_open_cookie_file,
     file::Lockable,
     interface::UserId,
-    time::{Duration, SystemTime}, Process, WithProcess,
+    time::{Duration, SystemTime},
+    Process, WithProcess,
 };
 
 /// Truncates or extends the underlying data

--- a/src/system/timestamp.rs
+++ b/src/system/timestamp.rs
@@ -4,13 +4,13 @@ use std::{
     path::PathBuf,
 };
 
-use crate::log::auth_info;
+use crate::log::{auth_info, auth_warn};
 
 use super::{
     audit::secure_open_cookie_file,
     file::Lockable,
     interface::UserId,
-    time::{Duration, SystemTime},
+    time::{Duration, SystemTime}, Process, WithProcess,
 };
 
 /// Truncates or extends the underlying data
@@ -411,6 +411,37 @@ impl RecordScope {
                 io::ErrorKind::InvalidInput,
                 format!("Unexpected scope variant discriminator: {x}"),
             )),
+        }
+    }
+
+    /// Tries to determine a record match scope for the current context.
+    /// This should never produce an error since any actual error should just be
+    /// ignored and no session record file should be used in that case.
+    pub fn for_process(process: &Process) -> Option<RecordScope> {
+        let tty = Process::tty_device_id(WithProcess::Current);
+        if let Ok(Some(tty_device)) = tty {
+            if let Ok(init_time) = Process::starting_time(WithProcess::Other(process.session_id)) {
+                Some(RecordScope::Tty {
+                    tty_device,
+                    session_pid: process.session_id,
+                    init_time,
+                })
+            } else {
+                auth_warn!("Could not get terminal foreground process starting time");
+                None
+            }
+        } else if let Some(parent_pid) = process.parent_pid {
+            if let Ok(init_time) = Process::starting_time(WithProcess::Other(parent_pid)) {
+                Some(RecordScope::Ppid {
+                    group_pid: parent_pid,
+                    init_time,
+                })
+            } else {
+                auth_warn!("Could not get parent process starting time");
+                None
+            }
+        } else {
+            None
         }
     }
 }

--- a/test-framework/sudo-compliance-tests/src/timestamp/validate.rs
+++ b/test-framework/sudo-compliance-tests/src/timestamp/validate.rs
@@ -3,7 +3,6 @@ use sudo_test::{Command, Env, User};
 use crate::{Result, PASSWORD, USERNAME};
 
 #[test]
-#[ignore = "gh395"]
 fn revalidation() -> Result<()> {
     let env = Env(format!(
         "{USERNAME} ALL=(ALL:ALL) ALL
@@ -26,7 +25,6 @@ Defaults timestamp_timeout=0.1"
 }
 
 #[test]
-#[ignore = "gh395"]
 fn prompts_for_password() -> Result<()> {
     let env = Env(format!("{USERNAME} ALL=(ALL:ALL) ALL"))
         .user(User(USERNAME).password(PASSWORD))

--- a/test-framework/sudo-test/src/docker/command.rs
+++ b/test-framework/sudo-test/src/docker/command.rs
@@ -129,6 +129,7 @@ impl Child {
 
 /// the output of a finished `Command`
 #[must_use]
+#[derive(Debug)]
 pub struct Output {
     pub(super) status: ExitStatus,
     pub(super) stderr: String,


### PR DESCRIPTION
This PR implements the validate flag, fixing #395 

Aside from that there are a few changes to the sudo pipeline to allow for easier composability, maybe even (in the future) reusing large parts for su. I still think that the `run` and `run_validate` look an awful lot like each other, but did not want to spend any more time on refactoring them right now. I've also derived Debug on the Output struct in the validation framework, that allowed me some easy debugging of a failing test.