### PR TITLE
Unfix the exception that allows a `--chdir` set to the current directory (that is then ignored)

### DIFF
--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -111,7 +111,7 @@ impl<Policy: PolicyPlugin, Auth: AuthPlugin> Pipeline<Policy, Auth> {
         match policy.chdir() {
             DirChange::Any => {}
             DirChange::Strict(optdir) => {
-                if context.chdir.is_some() && context.chdir != std::env::current_dir().ok() {
+                if context.chdir.is_some() {
                     return Err(Error::auth("no permission")); // TODO better user error messages
                 } else {
                     context.chdir = optdir.map(std::path::PathBuf::from)

--- a/test-framework/sudo-compliance-tests/src/flag_chdir.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_chdir.rs
@@ -129,7 +129,7 @@ fn cwd_set_to_non_glob_value_then_cannot_use_that_path_with_chdir_flag() -> Resu
 }
 
 #[test]
-#[ignore = "gh401"]
+#[ignore = "wontfix"]
 fn any_chdir_value_is_accepted_if_it_matches_pwd_cwd_unset() -> Result<()> {
     let path = "/root";
     let env = Env("ALL ALL=(ALL:ALL) NOPASSWD: ALL").build()?;
@@ -146,7 +146,7 @@ fn any_chdir_value_is_accepted_if_it_matches_pwd_cwd_unset() -> Result<()> {
 
 // NOTE unclear if we want to adopt this behavior
 #[test]
-#[ignore = "gh401"]
+#[ignore = "wontfix"]
 fn any_chdir_value_is_accepted_if_it_matches_pwd_cwd_set() -> Result<()> {
     let cwd_path = "/root";
     let another_path = "/tmp";

--- a/test-framework/sudo-compliance-tests/src/flag_chdir.rs
+++ b/test-framework/sudo-compliance-tests/src/flag_chdir.rs
@@ -129,6 +129,7 @@ fn cwd_set_to_non_glob_value_then_cannot_use_that_path_with_chdir_flag() -> Resu
 }
 
 #[test]
+#[ignore = "gh401"]
 fn any_chdir_value_is_accepted_if_it_matches_pwd_cwd_unset() -> Result<()> {
     let path = "/root";
     let env = Env("ALL ALL=(ALL:ALL) NOPASSWD: ALL").build()?;
@@ -143,7 +144,9 @@ fn any_chdir_value_is_accepted_if_it_matches_pwd_cwd_unset() -> Result<()> {
     Ok(())
 }
 
+// NOTE unclear if we want to adopt this behavior
 #[test]
+#[ignore = "gh401"]
 fn any_chdir_value_is_accepted_if_it_matches_pwd_cwd_set() -> Result<()> {
     let cwd_path = "/root";
     let another_path = "/tmp";


### PR DESCRIPTION
This undoes the fix for #401 and closes that issue again as a "wontfix" (it's undocumented behaviour that's now under review).