### PR TITLE
Fix compliance test failing due to `use_pty` default behaviour.

### DIFF
--- a/test-framework/sudo-compliance-tests/src/timestamp.rs
+++ b/test-framework/sudo-compliance-tests/src/timestamp.rs
@@ -155,13 +155,31 @@ fn cached_credential_not_shared_with_target_user_that_are_not_self() -> Result<(
 }
 
 #[test]
-#[ignore = "gh388"]
-fn cached_credential_shared_with_target_user_that_is_self() -> Result<()> {
-    let env = Env(format!("{USERNAME} ALL=(ALL:ALL) ALL"))
+fn cached_credential_shared_with_target_user_that_is_self_on_the_same_tty() -> Result<()> {
+    let env = Env(["Defaults !use_pty".to_string(), format!("{USERNAME} ALL=(ALL:ALL) ALL")])
         .user(User(USERNAME).password(PASSWORD))
         .build()?;
 
-    // FIXME switch back to `exec.assert_success`. this operation makes sudo-rs hang so we use
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "echo {PASSWORD} | sudo -S true; sudo -u {USERNAME} env '{SUDO_RS_IS_UNSTABLE}' sudo true"
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)?
+        .assert_success()?;
+
+    Ok(())
+}
+
+#[test]
+fn cached_credential_not_shared_with_self_across_ttys() -> Result<()> {
+    let env = Env(["Defaults use_pty".to_string(), format!("{USERNAME} ALL=(ALL:ALL) ALL")])
+        .user(User(USERNAME).password(PASSWORD))
+        .build()?;
+
+    // this operation should make sudo ask for a password so we use
     // `spawn` + `try_wait` polling here to avoid blocking forever
     let mut child = Command::new("sh")
         .arg("-c")
@@ -174,12 +192,12 @@ fn cached_credential_shared_with_target_user_that_is_self() -> Result<()> {
 
     for _ in 0..5 {
         if let Some(status) = child.try_wait()? {
-            assert!(status.success());
+            assert!(!status.success());
             return Ok(());
         }
 
         thread::sleep(Duration::from_secs(1));
     }
 
-    panic!("timed out")
+    Ok(())
 }


### PR DESCRIPTION
A timestamp test was failing due to the different default setting for `use_pty` (which is enabled by default for sudo-rs, enabled by default in standard /etc/sudoers files, and is likely to become the default in sudo as well in the near future).

This test has been split in two cases (`!use_pty` and `use_pty`) where we can see that sudo-rs and ogsudo behave the same.

Closing #388

NOTE: The timeout-wait loop is perhaps not really necessary since both ogsudo and sudo-rs will prompt someone for input.