### PR TITLE
Implement a ring-buffer to pipe data between terminals

### DIFF
--- a/src/exec/event.rs
+++ b/src/exec/event.rs
@@ -1,10 +1,13 @@
-use std::{collections::BTreeMap, os::fd::AsRawFd};
+use std::{collections::BTreeMap, fmt::Debug, os::fd::AsRawFd};
 
-use crate::system::poll::{PollEvent, PollSet};
+use crate::{
+    log::dev_debug,
+    system::poll::{PollEvent, PollSet},
+};
 
 pub(super) trait Process: Sized {
     /// IO Events that this process should handle.
-    type Event: Copy + Eq;
+    type Event: Copy + Eq + Debug;
     /// Reason why the event loop should break.
     ///
     /// See [`EventRegistry::set_break`] for more information.
@@ -153,7 +156,9 @@ impl<T: Process> EventRegistry<T> {
             // FIXME: maybe we shout return the IO error instead.
             if let Ok(ids) = self.poll_set.poll() {
                 for id in ids {
-                    event_queue.push(self.events[&id]);
+                    let event = self.events[&id];
+                    dev_debug!("event {event:?} is ready");
+                    event_queue.push(event);
                 }
 
                 for event in event_queue.drain(..) {

--- a/src/exec/event.rs
+++ b/src/exec/event.rs
@@ -149,6 +149,7 @@ impl<T: Process> EventRegistry<T> {
     ///
     /// The event loop will continue indefinitely unless you call [`EventRegistry::set_break`] or
     /// [`EventRegistry::set_exit`].
+    #[track_caller]
     pub(super) fn event_loop(&mut self, process: &mut T) -> StopReason<T> {
         let mut event_queue = Vec::with_capacity(self.events.len());
 

--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -206,7 +206,7 @@ impl ExecClosure {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExecEvent {
     Signal(Signal),
 }

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -385,7 +385,7 @@ fn is_self_terminating(
     false
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MonitorEvent {
     Signal(Signal),
     ReadableErrPipe,

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -612,7 +612,7 @@ impl From<ExitReason> for ParentExit {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ParentEvent {
     Signal(Signal),
     Tty(PollEvent),

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -629,10 +629,10 @@ impl Process for ParentClosure {
         match event {
             ParentEvent::Signal(signal) => self.on_signal(signal, registry),
             ParentEvent::Tty(poll_event) => {
-                self.tty_pipe.on_left_event(poll_event).ok();
+                self.tty_pipe.on_left_event(poll_event, registry).ok();
             }
             ParentEvent::Pty(poll_event) => {
-                self.tty_pipe.on_right_event(poll_event).ok();
+                self.tty_pipe.on_right_event(poll_event, registry).ok();
             }
             ParentEvent::Backchannel(poll_event) => match poll_event {
                 PollEvent::Readable => self.on_message_received(registry),

--- a/src/exec/use_pty/pipe.rs
+++ b/src/exec/use_pty/pipe.rs
@@ -15,8 +15,6 @@ pub(super) struct Pipe<L, R> {
     right: R,
     buffer_lr: Buffer<L, R>,
     buffer_rl: Buffer<R, L>,
-    left_handles: (EventHandle, EventHandle),
-    right_handles: (EventHandle, EventHandle),
 }
 
 impl<L: Read + Write + AsRawFd, R: Read + Write + AsRawFd> Pipe<L, R> {
@@ -29,18 +27,18 @@ impl<L: Read + Write + AsRawFd, R: Read + Write + AsRawFd> Pipe<L, R> {
         f_right: fn(PollEvent) -> T::Event,
     ) -> Self {
         Self {
-            left_handles: (
+            buffer_lr: Buffer::new(
                 registry.register_event(&left, PollEvent::Readable, f_left),
-                registry.register_event(&left, PollEvent::Writable, f_left),
-            ),
-            right_handles: (
-                registry.register_event(&right, PollEvent::Readable, f_right),
                 registry.register_event(&right, PollEvent::Writable, f_right),
+                registry,
+            ),
+            buffer_rl: Buffer::new(
+                registry.register_event(&right, PollEvent::Readable, f_right),
+                registry.register_event(&left, PollEvent::Writable, f_left),
+                registry,
             ),
             left,
             right,
-            buffer_lr: Buffer::new(),
-            buffer_rl: Buffer::new(),
         }
     }
 
@@ -61,18 +59,18 @@ impl<L: Read + Write + AsRawFd, R: Read + Write + AsRawFd> Pipe<L, R> {
 
     /// Stop the poll events of this pipe.
     pub(super) fn ignore_events<T: Process>(&mut self, registry: &mut EventRegistry<T>) {
-        self.left_handles.0.ignore(registry);
-        self.left_handles.1.ignore(registry);
-        self.right_handles.0.ignore(registry);
-        self.right_handles.1.ignore(registry);
+        self.buffer_lr.read_handle.ignore(registry);
+        self.buffer_lr.write_handle.ignore(registry);
+        self.buffer_rl.read_handle.ignore(registry);
+        self.buffer_rl.write_handle.ignore(registry);
     }
 
     /// Resume the poll events of this pipe
     pub(super) fn resume_events<T: Process>(&mut self, registry: &mut EventRegistry<T>) {
-        self.left_handles.0.resume(registry);
-        self.left_handles.1.resume(registry);
-        self.right_handles.0.resume(registry);
-        self.right_handles.1.resume(registry);
+        self.buffer_lr.read_handle.resume(registry);
+        self.buffer_lr.write_handle.resume(registry);
+        self.buffer_rl.read_handle.resume(registry);
+        self.buffer_rl.write_handle.resume(registry);
     }
 
     /// Handle a poll event for the left side of the pipe.
@@ -82,37 +80,9 @@ impl<L: Read + Write + AsRawFd, R: Read + Write + AsRawFd> Pipe<L, R> {
         registry: &mut EventRegistry<T>,
     ) -> io::Result<()> {
         match poll_event {
-            PollEvent::Readable => {
-                // Don't try to read if the buffer is full.
-                if self.buffer_lr.is_full() {
-                    self.left_handles.0.ignore(registry);
-                    return Ok(());
-                }
-
-                self.buffer_lr.read(&mut self.left)?;
-
-                // We can write again if the buffer is not empty.
-                if !self.buffer_lr.is_empty() {
-                    self.right_handles.1.resume(registry);
-                }
-            }
-            PollEvent::Writable => {
-                // Don't try to write if the buffer is empty.
-                if self.buffer_rl.is_empty() {
-                    self.left_handles.1.ignore(registry);
-                    return Ok(());
-                }
-
-                self.buffer_rl.write(&mut self.left)?;
-
-                // We can read again if the buffer is not full anymore.
-                if !self.buffer_rl.is_full() {
-                    self.right_handles.0.resume(registry);
-                }
-            }
+            PollEvent::Readable => self.buffer_lr.read(&mut self.left, registry),
+            PollEvent::Writable => self.buffer_rl.write(&mut self.left, registry),
         }
-
-        Ok(())
     }
 
     /// Handle a poll event for the right side of the pipe.
@@ -122,37 +92,9 @@ impl<L: Read + Write + AsRawFd, R: Read + Write + AsRawFd> Pipe<L, R> {
         registry: &mut EventRegistry<T>,
     ) -> io::Result<()> {
         match poll_event {
-            PollEvent::Readable => {
-                // Don't try to read if the buffer is full.
-                if self.buffer_rl.is_full() {
-                    self.right_handles.0.ignore(registry);
-                    return Ok(());
-                }
-
-                self.buffer_rl.read(&mut self.right)?;
-
-                // We can write again if the buffer is not empty.
-                if !self.buffer_rl.is_empty() {
-                    self.left_handles.1.resume(registry);
-                }
-            }
-            PollEvent::Writable => {
-                // If the buffer is empty, don't try to write from it.
-                if self.buffer_lr.is_empty() {
-                    self.right_handles.1.ignore(registry);
-                    return Ok(());
-                }
-
-                self.buffer_lr.write(&mut self.right)?;
-
-                // If the buffer is not full, we can read into it again.
-                if !self.buffer_lr.is_full() {
-                    self.left_handles.0.resume(registry);
-                }
-            }
+            PollEvent::Readable => self.buffer_rl.read(&mut self.right, registry),
+            PollEvent::Writable => self.buffer_lr.write(&mut self.right, registry),
         }
-
-        Ok(())
     }
 
     /// Ensure that all the contents of the pipe's internal buffer are written to the left side.
@@ -171,16 +113,29 @@ struct Buffer<R, W> {
     start: usize,
     /// The end of the busy section of the buffer.
     end: usize,
+    /// The handle for the event of the reader.
+    read_handle: EventHandle,
+    /// The handle for the event of the writer.
+    write_handle: EventHandle,
     marker: PhantomData<(R, W)>,
 }
 
 impl<R: Read, W: Write> Buffer<R, W> {
     /// Create a new, empty buffer
-    const fn new() -> Self {
+    fn new<T: Process>(
+        read_handle: EventHandle,
+        mut write_handle: EventHandle,
+        registry: &mut EventRegistry<T>,
+    ) -> Self {
+        // The buffer is empty, don't write
+        write_handle.ignore(registry);
+
         Self {
             buffer: [0; BUFSIZE],
             start: 0,
             end: 0,
+            read_handle,
+            write_handle,
             marker: PhantomData,
         }
     }
@@ -200,11 +155,16 @@ impl<R: Read, W: Write> Buffer<R, W> {
     /// Read bytes into the buffer.
     ///
     /// Calling this function will block until `read` is ready to be read.
-    fn read(&mut self, read: &mut R) -> io::Result<()> {
-        // FIXME: This function will try to read even if the buffer is full. Meaning that in the
-        // worst case scenario where `W` is never ready to be written, we will be constantly
-        // calling this function. This could be solved by ignoring the event associated with this
-        // callback in the dispatcher until `W` is ready.
+    fn read<T: Process>(
+        &mut self,
+        read: &mut R,
+        registry: &mut EventRegistry<T>,
+    ) -> io::Result<()> {
+        // Don't read if the buffer is full.
+        if self.is_full() {
+            self.read_handle.ignore(registry);
+            return Ok(());
+        }
 
         // This is the remaining free section that follows the busy section of the buffer.
         let buffer = &mut self.buffer[self.end..];
@@ -215,17 +175,27 @@ impl<R: Read, W: Write> Buffer<R, W> {
         // Mark the `len` bytes after the busy section as busy too.
         self.end += len;
 
+        // If we read something, the buffer is not empty anymore and we can resume writing.
+        if len > 0 {
+            self.write_handle.resume(registry);
+        }
+
         Ok(())
     }
 
     /// Write bytes from the buffer.
     ///
     /// Calling this function will block until `write` is ready to be written.
-    fn write(&mut self, write: &mut W) -> io::Result<()> {
-        // FIXME: This function will try to write even if the buffer is empty. Meaning that in the
-        // worst case scenario where `R` is never ready to be readn, we will be constantly calling
-        // this function. This could be solved by ignoring the event associated with this callback
-        // in the dispatcher until `R` is ready.
+    fn write<T: Process>(
+        &mut self,
+        write: &mut W,
+        registry: &mut EventRegistry<T>,
+    ) -> io::Result<()> {
+        // Don't write if the buffer is empty.
+        if self.is_empty() {
+            self.write_handle.ignore(registry);
+            return Ok(());
+        }
 
         // This is the busy section of the buffer.
         let buffer = &self.buffer[self.start..self.end];
@@ -240,6 +210,11 @@ impl<R: Read, W: Write> Buffer<R, W> {
         } else {
             // Otherwise we just free the first `len` bytes of the busy section.
             self.start += len;
+        }
+
+        // If we wrote something, the buffer is not full anymore and we can resume reading.
+        if len > 0 {
+            self.read_handle.resume(registry);
         }
 
         Ok(())
@@ -258,11 +233,5 @@ impl<R: Read, W: Write> Buffer<R, W> {
         self.end = 0;
 
         write.flush()
-    }
-}
-
-impl<R: Read, W: Write> Default for Buffer<R, W> {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -43,10 +43,8 @@ macro_rules! dev_logger_macro {
                     (::log::log!(
                         target: $target,
                         $crate::log::Level::$rule_level,
-                        "{}:{}:{}: {}",
-                        file!(),
-                        line!(),
-                        column!(),
+                        "{}: {}",
+                        std::panic::Location::caller(),
                         format_args!($d($d arg)+)
                     ));
                 }

--- a/src/system/poll.rs
+++ b/src/system/poll.rs
@@ -8,7 +8,7 @@ use crate::cutils::cerr;
 use libc::{c_short, pollfd, POLLIN, POLLOUT};
 
 /// The kind of event that will be monitored for a file descriptor.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PollEvent {
     /// Data may be read without blocking.
     Readable,


### PR DESCRIPTION

**Describe the changes done on this pull request**
This PR replaces the linear buffer used in `exec::pipe` by a ring buffer to avoid wasting space.

This is blocked by #611 

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
