### PR TITLE
Make backchannel blocking

### DIFF
--- a/src/exec/use_pty/backchannel.rs
+++ b/src/exec/use_pty/backchannel.rs
@@ -29,8 +29,6 @@ pub(super) struct BackchannelPair {
 impl BackchannelPair {
     pub(super) fn new() -> io::Result<Self> {
         let (sock1, sock2) = UnixStream::pair()?;
-        sock1.set_nonblocking(true)?;
-        sock2.set_nonblocking(true)?;
 
         Ok(Self {
             parent: ParentBackchannel { socket: sock1 },

--- a/src/exec/use_pty/backchannel.rs
+++ b/src/exec/use_pty/backchannel.rs
@@ -130,12 +130,10 @@ impl ParentBackchannel {
         prefix_buf.copy_from_slice(&prefix.to_ne_bytes());
         data_buf.copy_from_slice(&data.to_ne_bytes());
 
-        if let Err(err) = self.socket.write_all(&buf) {
+        self.socket.write_all(&buf).map_err(|err| {
             debug_assert!(err.kind() != io::ErrorKind::WouldBlock);
-            return Err(err);
-        }
-
-        Ok(())
+            err
+        })
     }
 
     /// Receive a [`ParentMessage`].
@@ -144,10 +142,10 @@ impl ParentBackchannel {
     pub(super) fn recv(&mut self) -> io::Result<ParentMessage> {
         let mut buf = [0; ParentMessage::LEN];
 
-        if let Err(err) = self.socket.read_exact(&mut buf) {
+        self.socket.read_exact(&mut buf).map_err(|err| {
             debug_assert!(err.kind() != io::ErrorKind::WouldBlock);
-            return Err(err);
-        }
+            err
+        })?;
 
         let (prefix_buf, data_buf) = buf.split_at(PREFIX_LEN);
 
@@ -226,12 +224,10 @@ impl MonitorBackchannel {
         prefix_buf.copy_from_slice(&prefix.to_ne_bytes());
         data_buf.copy_from_slice(&data.to_ne_bytes());
 
-        if let Err(err) = self.socket.write_all(&buf) {
+        self.socket.write_all(&buf).map_err(|err| {
             debug_assert!(err.kind() != io::ErrorKind::WouldBlock);
-            return Err(err);
-        }
-
-        Ok(())
+            err
+        })
     }
 
     /// Receive a [`MonitorMessage`].
@@ -240,10 +236,10 @@ impl MonitorBackchannel {
     pub(super) fn recv(&mut self) -> io::Result<MonitorMessage> {
         let mut buf = [0; MonitorMessage::LEN];
 
-        if let Err(err) = self.socket.read_exact(&mut buf) {
+        self.socket.read_exact(&mut buf).map_err(|err| {
             debug_assert!(err.kind() != io::ErrorKind::WouldBlock);
-            return Err(err);
-        }
+            err
+        })?;
 
         let (prefix_buf, data_buf) = buf.split_at(PREFIX_LEN);
 


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR removes the `non_blocking` method call to the `exec::backchannel` socket pair which is no longer necessary because we poll the sockets to be sure we can use them without blocking.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
