### PR TITLE
Close all the file descriptors before running the command

### DIFF
--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -1,22 +1,29 @@
-use std::{ffi::c_int, io, os::unix::process::CommandExt, process::Command};
+use std::{
+    ffi::c_int,
+    io::{self, Read, Write},
+    os::unix::{net::UnixStream, process::CommandExt},
+    process::{exit, Command},
+};
 
 use signal_hook::consts::*;
 
 use super::{
     event::{EventRegistry, Process, StopReason},
+    io_util::was_interrupted,
     terminate_process, ExitReason, HandleSigchld,
 };
 use crate::{
     exec::{handle_sigchld, opt_fmt, signal_fmt},
     log::{dev_error, dev_info, dev_warn},
     system::{
-        close_the_universe, getpgid, getpgrp,
+        fork, getpgid, getpgrp,
         interface::ProcessId,
         kill, killpg,
         poll::PollEvent,
         signal::{Signal, SignalAction, SignalHandler, SignalNumber},
         term::{Terminal, UserTerm},
         wait::WaitOptions,
+        FileCloser, ForkResult,
     },
 };
 
@@ -29,30 +36,53 @@ pub(crate) fn exec_no_pty(
     // FIXME: block signals directly instead of using the manager.
     let signal_handler = SignalHandler::new()?;
 
+    let mut file_closer = FileCloser::new();
+
     // FIXME (ogsudo): Some extra config happens here if selinux is available.
 
-    // Close every file that's not the IO streams before execution.
-    #[allow(unsafe_code)]
-    unsafe {
-        command.pre_exec(close_the_universe)
+    // Use a pipe to get the IO error if `exec` fails.
+    let (mut errpipe_tx, errpipe_rx) = UnixStream::pair()?;
+
+    // Don't close the error pipe as we need it to retrieve the error code if the command execution
+    // fails.
+    file_closer.except(&errpipe_tx);
+
+    let ForkResult::Parent(command_pid) = fork().map_err(|err| {
+        dev_warn!("unable to fork command process: {err}");
+        err
+    })?
+    else {
+        file_closer.close_the_universe()?;
+
+        let err = command.exec();
+
+        dev_warn!("failed to execute command: {err}");
+        // If `exec` returns, it means that executing the command failed. Send the error to the
+        // monitor using the pipe.
+        if let Some(error_code) = err.raw_os_error() {
+            errpipe_tx.write_all(&error_code.to_ne_bytes()).ok();
+        }
+        drop(errpipe_tx);
+        // FIXME: Calling `exit` doesn't run any destructors, clean everything up.
+        exit(1)
     };
 
-    let command = command.spawn().map_err(|err| {
-        dev_error!("cannot spawn command: {err}");
-        err
-    })?;
-
-    let command_pid = command.id() as ProcessId;
     dev_info!("executed command with pid {command_pid}");
 
     let mut registry = EventRegistry::new();
 
-    let mut closure = ExecClosure::new(command_pid, sudo_pid, signal_handler, &mut registry);
+    let mut closure = ExecClosure::new(
+        command_pid,
+        sudo_pid,
+        errpipe_rx,
+        signal_handler,
+        &mut registry,
+    );
 
     // FIXME: restore signal mask here.
 
     let exit_reason = match registry.event_loop(&mut closure) {
-        StopReason::Break(reason) => match reason {},
+        StopReason::Break(err) => return Err(err),
         StopReason::Exit(reason) => reason,
     };
 
@@ -63,6 +93,7 @@ struct ExecClosure {
     command_pid: Option<ProcessId>,
     sudo_pid: ProcessId,
     parent_pgrp: ProcessId,
+    errpipe_rx: UnixStream,
     signal_handler: SignalHandler,
 }
 
@@ -70,13 +101,16 @@ impl ExecClosure {
     fn new(
         command_pid: ProcessId,
         sudo_pid: ProcessId,
+        errpipe_rx: UnixStream,
         signal_handler: SignalHandler,
         registry: &mut EventRegistry<Self>,
     ) -> Self {
         registry.register_event(&signal_handler, PollEvent::Readable, |_| ExecEvent::Signal);
+        registry.register_event(&errpipe_rx, PollEvent::Readable, |_| ExecEvent::ErrPipe);
 
         Self {
             command_pid: Some(command_pid),
+            errpipe_rx,
             sudo_pid,
             parent_pgrp: getpgrp(),
             signal_handler,
@@ -214,16 +248,29 @@ impl ExecClosure {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExecEvent {
     Signal,
+    ErrPipe,
 }
 
 impl Process for ExecClosure {
     type Event = ExecEvent;
-    type Break = std::convert::Infallible;
+    type Break = io::Error;
     type Exit = ExitReason;
 
     fn on_event(&mut self, event: Self::Event, registry: &mut EventRegistry<Self>) {
         match event {
             ExecEvent::Signal => self.on_signal(registry),
+            ExecEvent::ErrPipe => {
+                let mut buf = 0i32.to_ne_bytes();
+                match self.errpipe_rx.read_exact(&mut buf) {
+                    Err(err) if was_interrupted(&err) => { /* Retry later */ }
+                    Err(err) => registry.set_break(err),
+                    Ok(_) => {
+                        // Received error code from the command, forward it to the parent.
+                        let error_code = i32::from_ne_bytes(buf);
+                        registry.set_break(io::Error::from_raw_os_error(error_code));
+                    }
+                }
+            }
         }
     }
 }

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -16,13 +16,13 @@ use crate::{
 use crate::{
     exec::{handle_sigchld, terminate_process, HandleSigchld},
     system::{
-        fork, getpgid, getpgrp,
+        close_the_universe, fork, getpgid, getpgrp,
         interface::ProcessId,
         kill, setpgid, setsid,
         signal::{Signal, SignalHandler},
         term::{PtyFollower, Terminal},
         wait::{Wait, WaitError, WaitOptions},
-        ForkResult, close_the_universe,
+        ForkResult,
     },
 };
 

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -22,7 +22,7 @@ use crate::{
         signal::{Signal, SignalHandler},
         term::{PtyFollower, Terminal},
         wait::{Wait, WaitError, WaitOptions},
-        ForkResult,
+        ForkResult, close_the_universe,
     },
 };
 
@@ -192,6 +192,11 @@ fn exec_command(mut command: Command, foreground: bool, pty_follower: PtyFollowe
 
     // Done with the pty follower.
     drop(pty_follower);
+
+    // Close every file that's not the IO streams before execution.
+    if let Err(err) = close_the_universe() {
+        return err;
+    }
 
     command.exec()
 }

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -11,12 +11,12 @@ use crate::{
         use_pty::{SIGCONT_BG, SIGCONT_FG},
     },
     log::{dev_error, dev_info, dev_warn},
-    system::{poll::PollEvent, signal::SignalAction},
+    system::{poll::PollEvent, signal::SignalAction, FileCloser},
 };
 use crate::{
     exec::{handle_sigchld, terminate_process, HandleSigchld},
     system::{
-        close_the_universe, fork, getpgid, getpgrp,
+        fork, getpgid, getpgrp,
         interface::ProcessId,
         kill, setpgid, setsid,
         signal::{Signal, SignalHandler},
@@ -43,6 +43,7 @@ pub(super) fn exec_monitor(
     command: Command,
     foreground: bool,
     backchannel: &mut MonitorBackchannel,
+    mut file_closer: FileCloser,
 ) -> io::Result<()> {
     // FIXME (ogsudo): Any file descriptor not used by the monitor are closed here.
 
@@ -68,6 +69,10 @@ pub(super) fn exec_monitor(
     // Use a pipe to get the IO error if `exec_command` fails.
     let (mut errpipe_tx, errpipe_rx) = UnixStream::pair()?;
 
+    // Don't close the error pipe as we need it to retrieve the error code if the command execution
+    // fails.
+    file_closer.except(&errpipe_tx);
+
     // Wait for the parent to give us green light before spawning the command. This avoids race
     // conditions when the command exits quickly.
     let event = retry_while_interrupted(|| backchannel.recv()).map_err(|err| {
@@ -83,10 +88,11 @@ pub(super) fn exec_monitor(
     let ForkResult::Parent(command_pid) = fork().map_err(|err| {
         dev_warn!("unable to fork command process: {err}");
         err
-    })? else {
+    })?
+    else {
         drop(errpipe_rx);
 
-        let err = exec_command(command, foreground, pty_follower);
+        let err = exec_command(command, foreground, pty_follower, file_closer);
         dev_warn!("failed to execute command: {err}");
         // If `exec_command` returns, it means that executing the command failed. Send the error to
         // the monitor using the pipe.
@@ -176,7 +182,12 @@ pub(super) fn exec_monitor(
 }
 
 // FIXME: This should return `io::Result<!>` but `!` is not stable yet.
-fn exec_command(mut command: Command, foreground: bool, pty_follower: PtyFollower) -> io::Error {
+fn exec_command(
+    mut command: Command,
+    foreground: bool,
+    pty_follower: PtyFollower,
+    file_closer: FileCloser,
+) -> io::Error {
     // FIXME (ogsudo): Do any additional configuration that needs to be run after `fork` but before `exec`
     let command_pid = std::process::id() as ProcessId;
 
@@ -193,8 +204,7 @@ fn exec_command(mut command: Command, foreground: bool, pty_follower: PtyFollowe
     // Done with the pty follower.
     drop(pty_follower);
 
-    // Close every file that's not the IO streams before execution.
-    if let Err(err) = close_the_universe() {
+    if let Err(err) = file_closer.close_the_universe() {
         return err;
     }
 

--- a/test-framework/sudo-compliance-tests/src/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/misc.rs
@@ -36,7 +36,6 @@ fn user_not_in_passwd_database_cannot_use_sudo() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh308"]
 fn closes_open_file_descriptors() -> Result<()> {
     let script_path = "/tmp/script.bash";
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD)

--- a/test-framework/sudo-compliance-tests/src/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/misc.rs
@@ -37,7 +37,12 @@ fn user_not_in_passwd_database_cannot_use_sudo() -> Result<()> {
 
 fn closes_open_file_descriptors(tty: bool) -> Result<()> {
     let script_path = "/tmp/script.bash";
-    let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
+    let defaults = if tty {
+        "Defaults use_pty"
+    } else {
+        "Defaults !use_pty"
+    };
+    let env = Env([SUDOERS_ALL_ALL_NOPASSWD, defaults])
         .file(
             script_path,
             include_str!("misc/read-parents-open-file-descriptor.bash"),

--- a/test-framework/sudo-compliance-tests/src/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/misc.rs
@@ -35,8 +35,7 @@ fn user_not_in_passwd_database_cannot_use_sudo() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn closes_open_file_descriptors() -> Result<()> {
+fn closes_open_file_descriptors(tty: bool) -> Result<()> {
     let script_path = "/tmp/script.bash";
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
         .file(
@@ -45,7 +44,10 @@ fn closes_open_file_descriptors() -> Result<()> {
         )
         .build()?;
 
-    let output = Command::new("bash").arg(script_path).output(&env)?;
+    let output = Command::new("bash")
+        .arg(script_path)
+        .tty(tty)
+        .output(&env)?;
 
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
@@ -53,6 +55,22 @@ fn closes_open_file_descriptors() -> Result<()> {
     assert_contains!(output.stderr(), "42: Bad file descriptor");
 
     Ok(())
+}
+
+#[test]
+#[ignore = "gh622"]
+fn closes_open_file_descriptors_with_tty() -> Result<()> {
+    // FIXME: not clear why ogsudo can't deal with this either
+    if sudo_test::is_original_sudo() {
+        return Ok(());
+    }
+
+    closes_open_file_descriptors(true)
+}
+
+#[test]
+fn closes_open_file_descriptors_without_tty() -> Result<()> {
+    closes_open_file_descriptors(false)
 }
 
 #[test]

--- a/test-framework/sudo-compliance-tests/src/use_pty.rs
+++ b/test-framework/sudo-compliance-tests/src/use_pty.rs
@@ -106,9 +106,8 @@ fn process_state() -> Result<()> {
 // FIXME: this is a temporary fix. We still need to figure out how to avoid these errors.
 fn filter_profile_errors(stdout: &str) -> String {
     stdout
-        .trim()
         .lines()
-        .filter(|line| !line.starts_with("LLVM Profile Warning"))
+        .filter(|line| !line.starts_with("LLVM Profile"))
         .collect::<Vec<_>>()
         .join("\r\n")
 }
@@ -126,7 +125,7 @@ fn terminal_is_restored() -> Result<()> {
 
     assert_contains!(stdout, "hello");
     let (before, after) = stdout.split_once("hello").unwrap();
-    assert_eq!(before.trim(), filter_profile_errors(after));
+    assert_eq!(before.trim(), filter_profile_errors(after).trim());
 
     Ok(())
 }
@@ -140,7 +139,7 @@ fn pty_owner() -> Result<()> {
         .tty(true)
         .output(&env)?
         .stdout()?;
-    assert_eq!(filter_profile_errors(&stdout), "root tty");
+    assert_eq!(filter_profile_errors(&stdout).trim(), "root tty");
 
     Ok(())
 }
@@ -155,7 +154,7 @@ fn stdin_pipe() -> Result<()> {
         .output(&env)?
         .stdout()?;
 
-    assert_eq!(filter_profile_errors(&stdout), "hello");
+    assert_eq!(filter_profile_errors(&stdout).trim(), "hello");
 
     Ok(())
 }
@@ -170,7 +169,7 @@ fn stdout_pipe() -> Result<()> {
         .output(&env)?
         .stdout()?;
 
-    assert_eq!(filter_profile_errors(&stdout), "hello");
+    assert_eq!(filter_profile_errors(&stdout).trim(), "hello");
 
     Ok(())
 }


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR introduces a new `FileCloser` type with a `FileCloser::close_the_universe` method able to close every file that's not `stdin/out/err` or explicitly preserved using `FileCloser::except`.

`close_the_universe` is called just before `Command::exec` is run. The only files preserved using `except` are the pipe used for error reporting if `Command::exec` fails and the `dup`ed versions of the follower side of the pty.

The `exec::no_pty` module was refactored to use `fork` + `Command::exec` instead of `Command::spawn` to be able to call `close_the_universe` without interfering with `Command::spawn`'s inner workings.

Additionally the calls to `exit`  were replaced by `_exit` in an attempt to fix the spurious errors about `*.profraw` files being corrupt.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will fix issue #308 where a proper discussion about a solution has taken place.
