### PR TITLE
Protect calls to ttyname and isatty

### DIFF
--- a/src/cutils/mod.rs
+++ b/src/cutils/mod.rs
@@ -113,5 +113,23 @@ mod test {
             File::open("/bin/sh").unwrap().as_raw_fd()
         ));
         assert!(!super::safe_isatty(-837492));
+        let (mut leader, mut follower) = Default::default();
+        assert!(
+            unsafe {
+                libc::openpty(
+                    &mut leader,
+                    &mut follower,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                )
+            } == 0
+        );
+        assert!(super::safe_isatty(leader));
+        assert!(super::safe_isatty(follower));
+        unsafe {
+            libc::close(follower);
+            libc::close(leader);
+        }
     }
 }

--- a/src/cutils/mod.rs
+++ b/src/cutils/mod.rs
@@ -109,9 +109,6 @@ mod test {
     fn test_tty() {
         use std::fs::File;
         use std::os::fd::AsRawFd;
-        assert!(super::safe_isatty(
-            File::open("/dev/tty").unwrap().as_raw_fd()
-        ));
         assert!(!super::safe_isatty(
             File::open("/bin/sh").unwrap().as_raw_fd()
         ));

--- a/src/cutils/mod.rs
+++ b/src/cutils/mod.rs
@@ -62,6 +62,29 @@ pub unsafe fn os_string_from_ptr(ptr: *const libc::c_char) -> OsString {
     }
 }
 
+/// Rust's standard library IsTerminal just directly calls isatty, which
+/// we don't want since this performs IOCTL calls on them and file descriptors are under
+/// the control of the user; so this checks if they are a character device first.
+pub fn safe_isatty(fildes: libc::c_int) -> bool {
+    // The Rust standard library doesn't have FileTypeExt on Std{in,out,err}, so we
+    // can't just use FileTypeExt::is_char_device and have to resort to libc::fstat.
+    let mut maybe_stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(fildes, maybe_stat.as_mut_ptr()) } == 0 {
+        let mode = unsafe { maybe_stat.assume_init() }.st_mode;
+
+        // To complicate matters further, the S_ISCHR macro isn't in libc as well.
+        let is_char_device = (mode & libc::S_IFMT) == libc::S_IFCHR;
+
+        if is_char_device {
+            unsafe { libc::isatty(fildes) != 0 }
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{os_string_from_ptr, string_from_ptr};
@@ -80,5 +103,14 @@ mod test {
         assert_eq!(strp(std::ptr::null()), "");
         assert_eq!(strp("\0".as_ptr() as *const libc::c_char), "");
         assert_eq!(strp("hello\0".as_ptr() as *const libc::c_char), "hello");
+    }
+
+    #[test]
+    fn test_tty() {
+        use std::os::fd::AsRawFd;
+        use std::fs::File;
+        assert!(super::safe_isatty( File::open("/dev/tty").unwrap().as_raw_fd()));
+        assert!(!super::safe_isatty( File::open("/bin/sh").unwrap().as_raw_fd()));
+        assert!(!super::safe_isatty(-837492));
     }
 }

--- a/src/cutils/mod.rs
+++ b/src/cutils/mod.rs
@@ -107,10 +107,14 @@ mod test {
 
     #[test]
     fn test_tty() {
-        use std::os::fd::AsRawFd;
         use std::fs::File;
-        assert!(super::safe_isatty( File::open("/dev/tty").unwrap().as_raw_fd()));
-        assert!(!super::safe_isatty( File::open("/bin/sh").unwrap().as_raw_fd()));
+        use std::os::fd::AsRawFd;
+        assert!(super::safe_isatty(
+            File::open("/dev/tty").unwrap().as_raw_fd()
+        ));
+        assert!(!super::safe_isatty(
+            File::open("/bin/sh").unwrap().as_raw_fd()
+        ));
         assert!(!super::safe_isatty(-837492));
     }
 }

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::ffi::c_int;
-use std::io::{self, IsTerminal};
+use std::io;
 use std::process::{exit, Command, Stdio};
 
 use signal_hook::consts::*;
@@ -20,7 +20,7 @@ use crate::log::{dev_error, dev_info, dev_warn};
 use crate::system::poll::PollEvent;
 use crate::system::signal::{Signal, SignalHandler};
 use crate::system::signal::{SignalAction, SignalNumber};
-use crate::system::term::{Pty, PtyFollower, PtyLeader, Terminal, UserTerm};
+use crate::system::term::{IsTerminalForSudo, Pty, PtyFollower, PtyLeader, Terminal, UserTerm};
 use crate::system::wait::WaitOptions;
 use crate::system::{chown, fork, getpgrp, kill, killpg, FileCloser, ForkResult, Group, User};
 use crate::system::{getpgid, interface::ProcessId};

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -20,7 +20,7 @@ use crate::log::{dev_error, dev_info, dev_warn};
 use crate::system::poll::PollEvent;
 use crate::system::signal::{Signal, SignalHandler};
 use crate::system::signal::{SignalAction, SignalNumber};
-use crate::system::term::{IsTerminalForSudo, Pty, PtyFollower, PtyLeader, Terminal, UserTerm};
+use crate::system::term::{Pty, PtyFollower, PtyLeader, Terminal, UserTerm};
 use crate::system::wait::WaitOptions;
 use crate::system::{chown, fork, getpgrp, kill, killpg, FileCloser, ForkResult, Group, User};
 use crate::system::{getpgid, interface::ProcessId};

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -154,6 +154,10 @@ impl<F: AsRawFd> Terminal for F {
 
         let mut buf: [libc::c_char; 1024] = [0; 1024];
 
+        if !safe_isatty(self.as_raw_fd()) {
+            return Err(io::ErrorKind::Unsupported.into());
+        }
+
         cerr(unsafe { libc::ttyname_r(self.as_raw_fd(), buf.as_mut_ptr() as _, buf.len()) })?;
         Ok(unsafe { os_string_from_ptr(buf.as_ptr()) })
     }


### PR DESCRIPTION
This checks of the file is  a character special device before firing calls on them that result in IOCTL's (as a mitigation for stuff like CVE-2023-2002)