### PR TITLE
Add a log line for commands that will be executed

### DIFF
--- a/src/common/command.rs
+++ b/src/common/command.rs
@@ -1,4 +1,9 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fmt::Display,
+    path::{Path, PathBuf},
+};
+
+use crate::system::escape_os_str_lossy;
 
 use super::resolve::resolve_path;
 
@@ -8,6 +13,19 @@ pub struct CommandAndArguments {
     pub(crate) command: PathBuf,
     pub(crate) arguments: Vec<String>,
     pub(crate) resolved: bool,
+}
+
+impl Display for CommandAndArguments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let cmd = escape_os_str_lossy(self.command.as_os_str());
+        let args = self
+            .arguments
+            .iter()
+            .map(|a| a.escape_default().collect::<String>())
+            .collect::<Vec<_>>()
+            .join(" ");
+        write!(f, "{} {}", cmd, args)
+    }
 }
 
 // when -i and -s are used, the arguments given to sudo are escaped "except for alphanumerics, underscores, hyphens, and dollar signs."

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -609,6 +609,10 @@ fn read_proc_stat<T: FromStr>(pid: WithProcess, field_idx: isize) -> io::Result<
     })
 }
 
+pub fn escape_os_str_lossy(s: &std::ffi::OsStr) -> String {
+    s.to_string_lossy().escape_default().collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::{

--- a/test-framework/sudo-compliance-tests/src/syslog.rs
+++ b/test-framework/sudo-compliance-tests/src/syslog.rs
@@ -3,7 +3,6 @@ use sudo_test::{Command, Env};
 use crate::{helpers::Rsyslogd, Result, SUDOERS_ALL_ALL_NOPASSWD, SUDOERS_USER_ALL_ALL, USERNAME};
 
 #[test]
-#[ignore = "gh421"]
 fn sudo_logs_every_executed_command() -> Result<()> {
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD).build()?;
     let rsyslog = Rsyslogd::start(&env)?;


### PR DESCRIPTION
Fixes #421 

Note that the logging does some escaping and is possibly lossy for some inputs, but at least it should be safe from control character attacks into syslog