### PR TITLE
Delay exit as much as possible

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -10,7 +10,7 @@ use std::{
     io,
     os::unix::ffi::OsStrExt,
     os::unix::process::CommandExt,
-    process::{exit, Command},
+    process::Command,
     time::Duration,
 };
 
@@ -18,6 +18,7 @@ use crate::{
     common::Environment,
     log::dev_warn,
     system::{
+        _exit,
         interface::ProcessId,
         killpg,
         signal::{consts::*, signal_name},
@@ -46,7 +47,8 @@ use self::{
 pub fn run_command(options: &impl RunOptions, env: Environment) -> io::Result<ExecOutput> {
     match run_command_internal(options, env)? {
         ProcessOutput::SudoExit { output } => Ok(output),
-        ProcessOutput::ChildExit => exit(1),
+        // We call `_exit` instead of `exit` to avoid flushing the parent's IO streams by accident.
+        ProcessOutput::ChildExit => _exit(1),
     }
 }
 

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -36,6 +36,10 @@ pub mod term;
 
 pub mod wait;
 
+pub(crate) fn _exit(status: c_int) -> ! {
+    unsafe { libc::_exit(status) }
+}
+
 /// A type able to close every file descriptor except for the ones pased via [`FileCloser::except`]
 /// and the IO streams.
 pub(crate) struct FileCloser {


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR replaces all the individual calls to `exit` for child processes for a single call at the top of the `exec` module. This will guarantee that any internal value created by the `exec` module will be properly dropped.

It would be possible to move this call to `exit` upper so other parts of sudo can properly drop any values that should be dropped according to their internal logic.

It also replaces the calls to `exit` for `_exit` for three reasons:
- That's what ogsudo does.
- The child processes shouldn't try to flush the parent's IO streams.
- It seems to get rid of the spurious coverage errors at the cost of having 0% coverage in any forked process given that any `at_exit` callback is not run.

cc @japaric

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
