### PR TITLE
Ignore `SIGCHLD` if there are no status updates

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -152,12 +152,12 @@ fn handle_sigchld<T: HandleSigchld>(
             // This only happens if we receive `SIGCHLD` but there's no status update from the
             // monitor.
             Err(WaitError::Io(err)) => {
-                dev_info!("cannot wait for {child_pid} ({child_name}): {err}")
+                return dev_info!("cannot wait for {child_pid} ({child_name}): {err}");
             }
             // This only happens if the monitor exited and any process already waited for the
             // monitor.
             Err(WaitError::NotReady) => {
-                dev_info!("{child_pid} ({child_name}) has no status report")
+                return dev_info!("{child_pid} ({child_name}) has no status report");
             }
             Ok((_pid, status)) => break status,
         }


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR fixes a bug where sending an artificial `SIGCHLD` signal to sudo caused it to get stuck until the command exits.

It also adds a test to prevent this from happening in the future

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will fix one item of #521 where a proper discussion about a solution has taken place.
