### PR TITLE
Handle `SIGWINCH` with `use_pty` enabled

### DIFF
--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -254,9 +254,9 @@ impl ExecClosure {
         match info.signal() {
             SIGCHLD => handle_sigchld(self, registry, "command", command_pid),
             signal => {
-                if signal == SIGWINCH {
-                    // FIXME: check `handle_sigwinch_no_pty`.
-                }
+                // FIXME: we should handle SIGWINCH here if we want to support I/O plugins that
+                // react on window change events.
+
                 // Skip the signal if it was sent by the user and it is self-terminating.
                 if info.is_user_signaled() && self.is_self_terminating(info.pid()) {
                     return;

--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/change-size.sh
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/change-size.sh
@@ -1,0 +1,4 @@
+# Wait for `print-sizes.sh` to write to `/tmp/tty_path`
+sleep 0.1
+# Resize the terminal
+stty -F$(cat /tmp/tty_path) rows 42 cols 69

--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/kill-sudo.sh
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/kill-sudo.sh
@@ -4,15 +4,9 @@ for _ in $(seq 1 20); do
     # when sudo runs with `use_pty` there are two sudo processes as sudo spawns
     # a monitor process. We want the PID of the sudo process so we assume it
     # must be the smallest of the returned PIDs. 
-    sudopid="-1"
-	pids="$(pidof sudo)"
-    for pid in $pids; do
-        if [ $pid -le $sudopid ] || [ $sudopid -eq -1 ]; then
-            sudopid=$pid
-        fi
-    done
+    sudopid=$(pidof sudo | sort -gr | cut -f 1 -d ' ')
 
-	if [ $sudopid -ne -1 ]; then
+	if [ -n "$sudopid" ]; then
         # give `expects-signal.sh ` some time to execute the `trap` command
         # otherwise it'll be terminated before the signal handler is installed
 		sleep 0.1

--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/mod.rs
@@ -2,8 +2,8 @@ use pretty_assertions::assert_eq;
 use sudo_test::{Command, Env};
 
 use crate::{
-    filter_profile_errors, Result, SUDOERS_ALL_ALL_NOPASSWD, SUDOERS_NOT_USE_PTY,
-    SUDOERS_ROOT_ALL_NOPASSWD, SUDOERS_USER_ALL_NOPASSWD, SUDOERS_USE_PTY, USERNAME,
+    Result, SUDOERS_ALL_ALL_NOPASSWD, SUDOERS_NOT_USE_PTY, SUDOERS_ROOT_ALL_NOPASSWD,
+    SUDOERS_USER_ALL_NOPASSWD, SUDOERS_USE_PTY, USERNAME,
 };
 
 macro_rules! dup {
@@ -238,7 +238,7 @@ fn sigwinch_works(use_pty: bool) -> Result<()> {
         .output(&env)?
         .assert_success()?;
 
-    let output = filter_profile_errors(&child.wait()?.stdout()?);
+    let output = child.wait()?.stdout()?;
 
     let lines: Vec<_> = output.lines().collect();
     assert_eq!(lines.len(), 3);

--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/mod.rs
@@ -2,7 +2,8 @@ use pretty_assertions::assert_eq;
 use sudo_test::{Command, Env};
 
 use crate::{
-    Result, SUDOERS_ALL_ALL_NOPASSWD, SUDOERS_USER_ALL_NOPASSWD, SUDOERS_USE_PTY, USERNAME,
+    filter_profile_errors, Result, SUDOERS_ALL_ALL_NOPASSWD, SUDOERS_NOT_USE_PTY,
+    SUDOERS_ROOT_ALL_NOPASSWD, SUDOERS_USER_ALL_NOPASSWD, SUDOERS_USE_PTY, USERNAME,
 };
 
 macro_rules! dup {
@@ -212,4 +213,50 @@ fn sigchld_is_ignored(tty: bool) -> Result<()> {
 
     assert_eq!(expected, actual);
 
-    Ok(())}
+    Ok(())
+}
+
+fn sigwinch_works(use_pty: bool) -> Result<()> {
+    let print_sizes = "/root/print-sizes.sh";
+    let change_size = "/root/change-size.sh";
+    let env = Env([
+        SUDOERS_ROOT_ALL_NOPASSWD,
+        if use_pty {
+            SUDOERS_USE_PTY
+        } else {
+            SUDOERS_NOT_USE_PTY
+        },
+    ])
+    .file(print_sizes, include_str!("print-sizes.sh"))
+    .file(change_size, include_str!("change-size.sh"))
+    .build()?;
+
+    let child = Command::new("sh").arg(print_sizes).tty(true).spawn(&env)?;
+
+    Command::new("sh")
+        .arg(change_size)
+        .output(&env)?
+        .assert_success()?;
+
+    let output = filter_profile_errors(&child.wait()?.stdout()?);
+
+    let lines: Vec<_> = output.lines().collect();
+    assert_eq!(lines.len(), 3);
+    // Assert that the terminal size that sudo sees the first time matches the original terminal size.
+    assert_eq!(lines[0], lines[1]);
+    // ASsert that the terminal size that sudo sees the second time has actually changed to the
+    // value set by `change-size.sh`.
+    assert_eq!(lines[2].trim(), "42 69");
+
+    Ok(())
+}
+
+#[test]
+fn sigwinch_works_pty() -> Result<()> {
+    sigwinch_works(true)
+}
+
+#[test]
+fn sigwinch_works_no_pty() -> Result<()> {
+    sigwinch_works(false)
+}

--- a/test-framework/sudo-compliance-tests/src/child_process/signal_handling/print-sizes.sh
+++ b/test-framework/sudo-compliance-tests/src/child_process/signal_handling/print-sizes.sh
@@ -1,0 +1,6 @@
+# Save the name of the current tty so `change-size.sh` can read it.
+tty > /tmp/tty_path 
+# Print the current terminal size
+stty size
+# Print the terminal size, wait for `change-size.sh` to run and then print the terminal size again.
+sudo sh -c "stty size; sleep 1; stty size"

--- a/test-framework/sudo-compliance-tests/src/lib.rs
+++ b/test-framework/sudo-compliance-tests/src/lib.rs
@@ -79,12 +79,3 @@ impl fmt::Display for EnvList {
         f.write_str(s)
     }
 }
-
-// FIXME: this is a temporary fix. We still need to figure out how to avoid these errors.
-fn filter_profile_errors(stdout: &str) -> String {
-    stdout
-        .lines()
-        .filter(|line| !line.starts_with("LLVM Profile"))
-        .collect::<Vec<_>>()
-        .join("\r\n")
-}

--- a/test-framework/sudo-compliance-tests/src/lib.rs
+++ b/test-framework/sudo-compliance-tests/src/lib.rs
@@ -61,6 +61,7 @@ const SUDO_ENV_DEFAULT_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
 const SUDO_ENV_DEFAULT_TERM: &str = "unknown";
 
 const SUDOERS_USE_PTY: &str = "Defaults use_pty";
+const SUDOERS_NOT_USE_PTY: &str = "Defaults !use_pty";
 
 const ENV_PATH: &str = "/usr/bin/env";
 
@@ -77,4 +78,13 @@ impl fmt::Display for EnvList {
         };
         f.write_str(s)
     }
+}
+
+// FIXME: this is a temporary fix. We still need to figure out how to avoid these errors.
+fn filter_profile_errors(stdout: &str) -> String {
+    stdout
+        .lines()
+        .filter(|line| !line.starts_with("LLVM Profile"))
+        .collect::<Vec<_>>()
+        .join("\r\n")
 }

--- a/test-framework/sudo-compliance-tests/src/use_pty.rs
+++ b/test-framework/sudo-compliance-tests/src/use_pty.rs
@@ -2,7 +2,7 @@ use sudo_test::{Command, Env};
 
 use crate::{
     helpers::{self, PsAuxEntry},
-    Result, SUDOERS_ALL_ALL_NOPASSWD,
+    Result, SUDOERS_ALL_ALL_NOPASSWD, filter_profile_errors,
 };
 
 fn fixture() -> Result<Vec<PsAuxEntry>> {

--- a/test-framework/sudo-compliance-tests/src/use_pty.rs
+++ b/test-framework/sudo-compliance-tests/src/use_pty.rs
@@ -2,7 +2,7 @@ use sudo_test::{Command, Env};
 
 use crate::{
     helpers::{self, PsAuxEntry},
-    Result, SUDOERS_ALL_ALL_NOPASSWD, filter_profile_errors,
+    Result, SUDOERS_ALL_ALL_NOPASSWD,
 };
 
 fn fixture() -> Result<Vec<PsAuxEntry>> {


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR updates the `use_pty` behavior so it can handle `SIGWINCH` correctly.

I couldn't find a way to write a compliance test for this as `stty` doesn't send `SIGWINCH` when used to update the terminal size.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
