### PR TITLE
Simplify signal formatting

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -181,11 +181,14 @@ fn handle_sigchld<T: HandleSigchld>(
 }
 
 fn signal_fmt(signal: SignalNumber) -> Cow<'static, str> {
-    signal_name(signal)
-        .or_else(|| (signal == SIGCONT_FG).then_some("SIGCONT_FG"))
-        .or_else(|| (signal == SIGCONT_BG).then_some("SIGCONT_BG"))
-        .map(|name| name.into())
-        .unwrap_or_else(|| format!("unknown signal #{}", signal).into())
+    match signal_name(signal) {
+        name @ Cow::Owned(_) => match signal {
+            SIGCONT_BG => "SIGCONT_BG".into(),
+            SIGCONT_FG => "SIGCONT_FG".into(),
+            _ => name,
+        },
+        name => name,
+    }
 }
 
 const fn cond_fmt<'a>(cond: bool, true_s: &'a str, false_s: &'a str) -> &'a str {

--- a/src/system/signal/handler.rs
+++ b/src/system/signal/handler.rs
@@ -28,7 +28,7 @@ impl SignalHandler {
         if Self::FORBIDDEN.contains(&signal) {
             panic!(
                 "the {} signal action cannot be overriden",
-                signal_name(signal).unwrap()
+                signal_name(signal)
             );
         }
 
@@ -56,9 +56,7 @@ impl Drop for SignalHandler {
         if let Err(err) = self.original_action.register(signal) {
             dev_warn!(
                 "cannot restore original action for {}: {err}",
-                signal_name(signal)
-                    .map(Cow::Borrowed)
-                    .unwrap_or_else(|| Cow::Owned(format!("unknown signal {signal}"))),
+                signal_name(signal),
             )
         }
     }

--- a/src/system/signal/mod.rs
+++ b/src/system/signal/mod.rs
@@ -8,6 +8,8 @@ pub(crate) use handler::{SignalHandler, SignalHandlerBehavior};
 pub(crate) use set::SignalSet;
 pub(crate) use stream::{register_handlers, SignalStream};
 
+use std::borrow::Cow;
+
 pub(crate) type SignalNumber = libc::c_int;
 
 macro_rules! define_consts {
@@ -16,10 +18,10 @@ macro_rules! define_consts {
             pub(crate) use libc::{$($signal,)*};
         }
 
-        pub(crate) fn signal_name(signal: SignalNumber) -> Option<&'static str> {
+        pub(crate) fn signal_name(signal: SignalNumber) -> Cow<'static, str> {
             match signal {
-                $(consts::$signal => Some(stringify!($signal)),)*
-                _ => None,
+                $(consts::$signal => stringify!($signal).into(),)*
+                _ => format!("unknown signal ({signal})").into(),
             }
         }
     };

--- a/src/system/signal/stream.rs
+++ b/src/system/signal/stream.rs
@@ -86,7 +86,7 @@ pub(crate) fn register_handlers<const N: usize>(
         *handler = SignalHandler::register(*signal, SignalHandlerBehavior::Stream)
             .map(MaybeUninit::new)
             .map_err(|err| {
-                let name = signal_name(*signal).unwrap_or("unknown signal");
+                let name = signal_name(*signal);
                 dev_error!("cannot setup handler for {name}: {err}");
                 err
             })?;

--- a/src/system/wait.rs
+++ b/src/system/wait.rs
@@ -116,17 +116,9 @@ impl std::fmt::Debug for WaitStatus {
         if let Some(exit_status) = self.exit_status() {
             write!(f, "ExitStatus({exit_status})")
         } else if let Some(signal) = self.term_signal() {
-            write!(
-                f,
-                "TermSignal({})",
-                signal_name(signal).unwrap_or("unknown")
-            )
+            write!(f, "TermSignal({})", signal_name(signal))
         } else if let Some(signal) = self.stop_signal() {
-            write!(
-                f,
-                "StopSignal({})",
-                signal_name(signal).unwrap_or("unknown")
-            )
+            write!(f, "StopSignal({})", signal_name(signal))
         } else if self.did_continue() {
             write!(f, "Continued")
         } else {


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR removes some code duplication that formats signals in logs.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
