### PR TITLE
test that su respects /etc/resource/limits

### DIFF
--- a/test-framework/sudo-compliance-tests/src/su.rs
+++ b/test-framework/sudo-compliance-tests/src/su.rs
@@ -12,6 +12,7 @@ mod flag_pty;
 mod flag_shell;
 mod flag_supp_group;
 mod flag_whitelist_environment;
+mod limits;
 mod pam;
 mod syslog;
 

--- a/test-framework/sudo-compliance-tests/src/su/limits.rs
+++ b/test-framework/sudo-compliance-tests/src/su/limits.rs
@@ -1,0 +1,45 @@
+use sudo_test::{Command, Env, User};
+
+use crate::{Result, PASSWORD, USERNAME};
+
+#[test]
+fn etc_security_limits_rules_apply_according_to_the_target_user() -> Result<()> {
+    let target_user = "ghost";
+    let original = "2048";
+    let expected = "1024";
+    let limits = format!(
+        "{USERNAME} hard locks {original}
+{target_user} hard locks {expected}"
+    );
+    let env = Env("")
+        .file("/etc/security/limits.d/50-test.conf", limits)
+        .user(USERNAME)
+        .user(User(target_user).password(PASSWORD).shell("/bin/bash"))
+        .build()?;
+
+    // this appears to ignore the `limits` rules, perhaps because of docker
+    // in any case, the assertion below and the rule above should be enough to check that the
+    // *target* user's, and not the invoking user's, limits apply when su is involved
+    // let normal_limit = Command::new("bash")
+    //     .args(["-c", "ulimit -x"])
+    //     .as_user(USERNAME)
+    //     .output(&env)?
+    //     .stdout()?;
+
+    // assert_eq!(original, normal_limit);
+
+    // check that limits apply even when root is the invoking user
+    let users = ["root", USERNAME];
+    for invoking_user in users {
+        let su_limit = Command::new("su")
+            .args(["-c", "ulimit -x", target_user])
+            .stdin(PASSWORD)
+            .as_user(invoking_user)
+            .output(&env)?
+            .stdout()?;
+
+        assert_eq!(expected, su_limit);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
util-linux su appears to do the same as ogsudo so adding this test as a compliance test. util-linux su does not set core dump file size to 0 like ogsudo does so I'm leaving that test out. if we want to implement that core dump file size behavior in su-rs, the tests for that should go in the `e2e-tests` package.

closes #629 