### PR TITLE
Fix builds on arm by changing from i8 to c_char.

### DIFF
--- a/src/pam/mod.rs
+++ b/src/pam/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     ffi::{CStr, CString, OsStr, OsString},
+    os::raw::c_char,
     os::unix::prelude::OsStrExt,
 };
 
@@ -214,7 +215,7 @@ impl<C: Converser> PamContext<C> {
         }
 
         // unsafe conversion to cstr
-        let cstr = unsafe { CStr::from_ptr(data as *const i8) };
+        let cstr = unsafe { CStr::from_ptr(data as *const c_char) };
 
         Ok(cstr.to_str()?.to_owned())
     }


### PR DESCRIPTION
When I built on arm (aarch64), I got this compiler error:

```
   Compiling sudo-rs v0.2.0-dev.20230703 (/sudo-rs)
error[E0308]: mismatched types
   --> src/pam/mod.rs:217:44
    |
217 |         let cstr = unsafe { CStr::from_ptr(data as *const i8) };
    |                             -------------- ^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
    |                             |
    |                             arguments to this function are incorrect
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
note: associated function defined here
   --> /home/build/rustc-1.70.0-src/library/core/src/ffi/c_str.rs:260:25

For more information about this error, try `rustc --explain E0308`.
```

After some research, I learned that this is an architecture issue - on many platforms char is mapped to i8, but not on aarch64. Here's a source: https://github.com/fede1024/rust-rdkafka/issues/121

With this change it now builds successfully on arm!