### PR TITLE
Various fixes for `visudo`

### DIFF
--- a/src/system/timestamp.rs
+++ b/src/system/timestamp.rs
@@ -125,7 +125,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
     fn init(&mut self, offset: u64, must_lock: bool) -> io::Result<()> {
         // lock the file to indicate that we are currently writing to it
         if must_lock {
-            self.io.lock_exclusive()?;
+            self.io.lock_exclusive(false)?;
         }
         self.io.set_len(0)?;
         self.io.rewind()?;
@@ -194,7 +194,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
     /// valid at this time.
     pub fn touch(&mut self, scope: RecordScope, auth_user: UserId) -> io::Result<TouchResult> {
         // lock the file to indicate that we are currently in a writing operation
-        self.io.lock_exclusive()?;
+        self.io.lock_exclusive(false)?;
         self.seek_to_first_record()?;
         while let Some(record) = self.next_record()? {
             // only touch if record is enabled
@@ -232,7 +232,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
     /// given then only records with the given scope that are targetting that
     /// specific user will be disabled.
     pub fn disable(&mut self, scope: RecordScope, auth_user: Option<UserId>) -> io::Result<()> {
-        self.io.lock_exclusive()?;
+        self.io.lock_exclusive(false)?;
         self.seek_to_first_record()?;
         while let Some(record) = self.next_record()? {
             let must_disable = auth_user
@@ -252,7 +252,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
     /// then that record will be updated.
     pub fn create(&mut self, scope: RecordScope, auth_user: UserId) -> io::Result<CreateResult> {
         // lock the file to indicate that we are currently writing to it
-        self.io.lock_exclusive()?;
+        self.io.lock_exclusive(false)?;
         self.seek_to_first_record()?;
         while let Some(record) = self.next_record()? {
             if record.matches(&scope, auth_user) {

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::{File, OpenOptions},
-    io::{self, BufRead, Read, Seek, Write},
+    io::{self, BufRead, IsTerminal, Read, Seek, Write},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -68,6 +68,11 @@ fn visudo_process() -> io::Result<()> {
 
             let stdin = io::stdin();
             let stdout = io::stdout();
+
+            if !stdout.is_terminal() {
+                eprintln!("syntax error");
+                return Ok(());
+            }
 
             let mut stdin_handle = stdin.lock();
             let mut stdout_handle = stdout.lock();

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -47,6 +47,7 @@ fn visudo_process() -> io::Result<()> {
 
         loop {
             Command::new(&editor_path)
+                .arg("--")
                 .arg(&tmp_path)
                 .spawn()?
                 .wait_with_output()?;

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -18,7 +18,6 @@ const EDITOR_TRUE: &str = "#!/bin/sh
 true";
 
 #[test]
-#[ignore = "gh657"]
 fn default_editor_is_usr_bin_editor() -> Result<()> {
     let expected = "default editor was called";
     let env = Env("")

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -67,7 +67,6 @@ fn creates_sudoers_file_with_default_ownership_and_perms_if_it_doesnt_exist() ->
 }
 
 #[test]
-#[ignore = "gh657"]
 fn errors_if_currently_being_edited() -> Result<()> {
     let env = Env("")
         .file(

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -98,7 +98,6 @@ sleep 3",
 }
 
 #[test]
-#[ignore = "gh657"]
 fn passes_temporary_file_to_editor() -> Result<()> {
     let env = Env("")
         .file(

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -198,7 +198,6 @@ fn stderr_message_when_file_is_not_modified() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh657"]
 fn does_not_save_the_file_if_there_are_syntax_errors() -> Result<()> {
     let expected = SUDOERS_ALL_ALL_NOPASSWD;
     let env = Env(expected)

--- a/test-framework/sudo-compliance-tests/src/visudo/what_now_prompt.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/what_now_prompt.rs
@@ -54,7 +54,6 @@ fn on_e_re_edits() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh657"]
 fn on_x_closes_without_saving_changes() -> Result<()> {
     let expected = SUDOERS_ALL_ALL_NOPASSWD;
     let env = Env(expected)

--- a/test-framework/sudo-test/src/ours.Dockerfile
+++ b/test-framework/sudo-test/src/ours.Dockerfile
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/usr/src/sudo/target cargo build --locked --featur
 # set setuid on install
 RUN install --mode 4755 build/sudo /usr/bin/sudo
 RUN install --mode 4755 build/su /usr/bin/su
-RUN install --mode 755 build/su /usr/sbin/visudo
+RUN install --mode 755 build/visudo /usr/sbin/visudo
 # remove build dependencies
 RUN apt-get autoremove -y clang libclang-dev
 # set the default working directory to somewhere world writable so sudo / su can create .profraw files there


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR does a couple fixes to `visudo`:
- Lock the sudoers file in nonblocking mode.
- Use `/usr/bin/editor` as the default editor:
  - Check the `SUDO_EDITOR`, `VISUAL` and `EDITOR` env vars if the default editor is not available.
  - Use `vi` otherwise (this is temporary as my OS doesn't set `/usr/bin/editor` and compiles `visudo` with `vi` as the default editor).
- Invoke the command passing the temporary file after `--`.
- Avoid showing the "What now?" message and waiting for input if stdout is not a terminal.

It also fixes a small mistake in the Dockerfile where `su` was being installed as `visudo`.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will fix parts of #657 where a proper discussion about a solution has taken place.
