### PR TITLE
Use a random temporary file name for `visudo`

### DIFF
--- a/test-framework/sudo-compliance-tests/src/snapshots/visudo/flag_file/passes_temporary_file_to_editor.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/visudo/flag_file/passes_temporary_file_to_editor.snap
@@ -1,0 +1,5 @@
+---
+source: sudo-compliance-tests/src/visudo/flag_file.rs
+expression: args
+---
+-- /tmp/[mkdtemp]/sudoers

--- a/test-framework/sudo-compliance-tests/src/snapshots/visudo/passes_temporary_file_to_editor.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/visudo/passes_temporary_file_to_editor.snap
@@ -2,4 +2,4 @@
 source: sudo-compliance-tests/src/visudo.rs
 expression: args
 ---
--- /tmp/sudoers-[hex].tmp
+-- /tmp/[mkdtemp]/sudoers

--- a/test-framework/sudo-compliance-tests/src/snapshots/visudo/passes_temporary_file_to_editor.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/visudo/passes_temporary_file_to_editor.snap
@@ -1,0 +1,5 @@
+---
+source: sudo-compliance-tests/src/visudo.rs
+expression: args
+---
+-- /tmp/sudoers-[hex].tmp

--- a/test-framework/sudo-compliance-tests/src/snapshots/visudo/stderr_message_when_file_is_not_modified.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/visudo/stderr_message_when_file_is_not_modified.snap
@@ -1,0 +1,5 @@
+---
+source: sudo-compliance-tests/src/visudo.rs
+expression: stderr
+---
+visudo: /tmp/sudoers-[hex].tmp unchanged

--- a/test-framework/sudo-compliance-tests/src/snapshots/visudo/stderr_message_when_file_is_not_modified.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/visudo/stderr_message_when_file_is_not_modified.snap
@@ -2,4 +2,4 @@
 source: sudo-compliance-tests/src/visudo.rs
 expression: stderr
 ---
-visudo: /tmp/sudoers-[hex].tmp unchanged
+visudo: /tmp/[mkdtemp]/sudoers unchanged

--- a/test-framework/sudo-compliance-tests/src/snapshots/visudo/temporary_file_is_deleted_during_edition.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/visudo/temporary_file_is_deleted_during_edition.snap
@@ -1,0 +1,5 @@
+---
+source: sudo-compliance-tests/src/visudo.rs
+expression: stderr
+---
+visudo: unable to re-open temporary file (/tmp/sudoers-[hex].tmp), /etc/sudoers unchanged

--- a/test-framework/sudo-compliance-tests/src/snapshots/visudo/temporary_file_is_deleted_during_edition.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/visudo/temporary_file_is_deleted_during_edition.snap
@@ -2,4 +2,4 @@
 source: sudo-compliance-tests/src/visudo.rs
 expression: stderr
 ---
-visudo: unable to re-open temporary file (/tmp/sudoers-[hex].tmp), /etc/sudoers unchanged
+visudo: unable to re-open temporary file (/tmp/[mkdtemp]/sudoers), /etc/sudoers unchanged: No such file or directory (os error 2)

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -14,6 +14,18 @@ mod flag_version;
 mod sudoers;
 mod what_now_prompt;
 
+macro_rules! assert_snapshot {
+    ($($tt:tt)*) => {
+        insta::with_settings!({
+            filters => vec![(r"[a-f0-9]{16}", "[hex]")],
+            prepend_module_to_snapshot => false,
+            snapshot_path => "snapshots/visudo",
+        }, {
+            insta::assert_snapshot!($($tt)*)
+        });
+    };
+}
+
 const TMP_SUDOERS: &str = "/tmp/sudoers";
 const ETC_SUDOERS: &str = "/etc/sudoers";
 const DEFAULT_EDITOR: &str = "/usr/bin/editor";
@@ -118,22 +130,31 @@ echo "$@" > {LOGS_PATH}"#
 
     let args = Command::new("cat").arg(LOGS_PATH).output(&env)?.stdout()?;
 
-    assert_eq!("-- /etc/sudoers.tmp", args);
+    if sudo_test::is_original_sudo() {
+        assert_eq!("-- /etc/sudoers.tmp", args);
+    } else {
+        assert_snapshot!(args);
+    }
 
     Ok(())
 }
 
 #[test]
 fn temporary_file_owner_and_perms() -> Result<()> {
-    let env = Env("")
-        .file(
-            DEFAULT_EDITOR,
-            TextFile(format!(
-                r#"#!/bin/sh
+    let editor_script = if sudo_test::is_original_sudo() {
+        format!(
+            r#"#!/bin/sh
 ls -l /etc/sudoers.tmp > {LOGS_PATH}"#
-            ))
-            .chmod(CHMOD_EXEC),
         )
+    } else {
+        format!(
+            r#"#!/bin/sh
+ls -l /tmp/sudoers-*.tmp > {LOGS_PATH}"#
+        )
+    };
+
+    let env = Env("")
+        .file(DEFAULT_EDITOR, TextFile(editor_script).chmod(CHMOD_EXEC))
         .build()?;
 
     Command::new("visudo").output(&env)?.assert_success()?;
@@ -186,7 +207,12 @@ fn stderr_message_when_file_is_not_modified() -> Result<()> {
     let output = Command::new("visudo").output(&env)?;
 
     assert!(output.status().success());
-    assert_eq!(output.stderr(), "visudo: /etc/sudoers.tmp unchanged");
+    let stderr = output.stderr();
+    if sudo_test::is_original_sudo() {
+        assert_eq!(output.stderr(), "visudo: /etc/sudoers.tmp unchanged");
+    } else {
+        assert_snapshot!(stderr);
+    }
 
     let actual = Command::new("cat")
         .arg(ETC_SUDOERS)
@@ -274,10 +300,14 @@ rm $2",
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
     let stderr = output.stderr();
-    assert_contains!(
-        stderr,
-        "visudo: unable to re-open temporary file (/etc/sudoers.tmp), /etc/sudoers unchanged"
-    );
+    if sudo_test::is_original_sudo() {
+        assert_contains!(
+            stderr,
+            "visudo: unable to re-open temporary file (/etc/sudoers.tmp), /etc/sudoers unchanged"
+        );
+    } else {
+        assert_snapshot!(stderr);
+    }
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -17,7 +17,7 @@ mod what_now_prompt;
 macro_rules! assert_snapshot {
     ($($tt:tt)*) => {
         insta::with_settings!({
-            filters => vec![(r"[a-f0-9]{16}", "[hex]")],
+            filters => vec![(r"sudoers-[a-zA-Z0-9]{6}", "[mkdtemp]")],
             prepend_module_to_snapshot => false,
             snapshot_path => "snapshots/visudo",
         }, {
@@ -149,7 +149,7 @@ ls -l /etc/sudoers.tmp > {LOGS_PATH}"#
     } else {
         format!(
             r#"#!/bin/sh
-ls -l /tmp/sudoers-*.tmp > {LOGS_PATH}"#
+ls -l /tmp/sudoers-*/sudoers > {LOGS_PATH}"#
         )
     };
 

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
@@ -5,6 +5,18 @@ use crate::{
     Result, SUDOERS_ALL_ALL_NOPASSWD, SUDOERS_ROOT_ALL, USERNAME,
 };
 
+macro_rules! assert_snapshot {
+    ($($tt:tt)*) => {
+        insta::with_settings!({
+            filters => vec![(r"sudoers-[a-zA-Z0-9]{6}", "[mkdtemp]")],
+            prepend_module_to_snapshot => false,
+            snapshot_path => "../snapshots/visudo/flag_file",
+        }, {
+            insta::assert_snapshot!($($tt)*)
+        });
+    };
+}
+
 #[test]
 #[ignore = "gh657"]
 fn creates_sudoers_file_with_default_ownership_and_perms_if_it_doesnt_exist() -> Result<()> {
@@ -170,7 +182,11 @@ echo "$@" > {LOGS_PATH}"#
 
     let args = Command::new("cat").arg(LOGS_PATH).output(&env)?.stdout()?;
 
-    assert_eq!(format!("-- {file_path}.tmp"), args);
+    if sudo_test::is_original_sudo() {
+        assert_eq!(format!("-- {file_path}.tmp"), args);
+    } else {
+        assert_snapshot!(args);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR uses a random name for the temporary file created by `visudo`. This file is put in the `/tmp` directory.

It also updates the tests that involve the name of this file to use snapshots so we can filter the random part of the filename from it.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
