### PR TITLE
Fix `-f` tests for `visudo`

### DIFF
--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -38,7 +38,7 @@ impl PolicyPlugin for SudoersPolicy {
     fn init(&mut self) -> Result<Self::PreJudgementPolicy, Error> {
         let sudoers_path = candidate_sudoers_file();
 
-        let (sudoers, syntax_errors) = crate::sudoers::Sudoers::new(sudoers_path)
+        let (sudoers, syntax_errors) = crate::sudoers::Sudoers::open(sudoers_path)
             .map_err(|e| Error::Configuration(format!("{e}")))?;
 
         for crate::sudoers::Error(pos, error) in syntax_errors {

--- a/src/visudo/cli.rs
+++ b/src/visudo/cli.rs
@@ -172,8 +172,11 @@ impl VisudoOptions {
                     }
                 }
             } else {
-                // If the arg doesn't start with a `-` it must be a file argument.
-                options.file = Some(arg);
+                // If the arg doesn't start with a `-` it must be a file argument. However `-f`
+                // must take precedence
+                if options.file.is_none() {
+                    options.file = Some(arg);
+                }
             }
         }
 

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
@@ -174,10 +174,9 @@ echo "$@" > {LOGS_PATH}"#
 }
 
 #[test]
-#[ignore = "gh657"]
 fn regular_user_can_create_file() -> Result<()> {
     let env = Env("")
-        .file(DEFAULT_EDITOR, TextFile(EDITOR_TRUE).chmod(CHMOD_EXEC))
+        .file(DEFAULT_EDITOR, TextFile(EDITOR_TRUE).chmod("111"))
         .user(USERNAME)
         .build()?;
 

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
@@ -199,7 +199,6 @@ fn regular_user_can_create_file() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh657"]
 fn regular_user_can_update_a_file_they_own() -> Result<()> {
     let expected = SUDOERS_ALL_ALL_NOPASSWD;
     let unexpected = SUDOERS_ROOT_ALL;

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 
 #[test]
-#[ignore = "gh657"]
 fn creates_sudoers_file_with_default_ownership_and_perms_if_it_doesnt_exist() -> Result<()> {
     let env = Env("")
         .file(DEFAULT_EDITOR, TextFile(EDITOR_TRUE).chmod(CHMOD_EXEC))

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
@@ -84,7 +84,6 @@ echo '{expected}' > $2"#
 }
 
 #[test]
-#[ignore = "gh657"]
 fn flag_has_precedence_over_positional_argument() -> Result<()> {
     let expected = SUDOERS_ALL_ALL_NOPASSWD;
     let original = SUDOERS_ROOT_ALL;


### PR DESCRIPTION
- Fix the `flag_file::creates_sudoers_file_with_default_ownership_and_perms_if_it_doesnt_exist` test
- Fix the `flag_file::flag_has_precedence_over_positional_argument` test
- Add API to parse sudoers from a reader directly
- Fix permissions for `flag_file::regular_user_can_create_file`

**Describe the changes done on this pull request**
This PR changes `visudo` so it passes all the compliance tests with the exception of the `regular_user_cannot_update_a_file_they_dont_own` because it deserves a deeper look.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will partially fix https://github.com/memorysafety/sudo-rs/issues/657 where a proper discussion about a solution has taken place.
