### PR TITLE
sudoers/at_include: accept unescaped backslash

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -433,7 +433,7 @@ impl Parse for Sudo {
 fn parse_include(stream: &mut impl CharStream) -> Parsed<Sudo> {
     fn get_path(stream: &mut impl CharStream) -> Parsed<String> {
         if accept_if(|c| c == '"', stream).is_ok() {
-            let QuotedText(path) = expect_nonterminal(stream)?;
+            let QuotedInclude(path) = expect_nonterminal(stream)?;
             expect_syntax('"', stream)?;
             make(path)
         } else {

--- a/src/sudoers/ast_names.rs
+++ b/src/sudoers/ast_names.rs
@@ -69,6 +69,10 @@ mod names {
         const DESCRIPTION: &'static str = "non-empty string";
     }
 
+    impl UserFriendly for tokens::QuotedInclude {
+        const DESCRIPTION: &'static str = "non-empty string";
+    }
+
     impl UserFriendly for tokens::StringParameter {
         const DESCRIPTION: &'static str = tokens::QuotedText::DESCRIPTION;
     }

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -344,6 +344,12 @@ fn hashsign_test() {
 }
 
 #[test]
+fn gh674_at_include_quoted_backslash() {
+    let Sudo::Include(_) = parse_line(r#"@include "/etc/sudo\ers" "#) else { panic!() };
+    let Sudo::IncludeDir(_) = parse_line(r#"@includedir "/etc/sudo\ers.d" "#) else { panic!() };
+}
+
+#[test]
 #[should_panic]
 fn hashsign_error() {
     let Sudo::Include(_) = parse_line("#include foo bar") else { todo!() };

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -246,6 +246,27 @@ impl Token for QuotedText {
     }
 }
 
+// `@include "some/path"`
+//           ^^^^^^^^^^^
+pub struct QuotedInclude(pub String);
+
+impl Token for QuotedInclude {
+    const MAX_LEN: usize = 1024;
+
+    fn construct(s: String) -> Result<Self, String> {
+        Ok(QuotedInclude(s))
+    }
+
+    fn accept(c: char) -> bool {
+        !Self::escaped(c)
+    }
+
+    const ESCAPE: char = '\\';
+    fn escaped(c: char) -> bool {
+        matches!(c, '"') || c.is_control()
+    }
+}
+
 pub struct IncludePath(pub String);
 
 impl Token for IncludePath {

--- a/test-framework/sudo-compliance-tests/src/sudoers/include.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/include.rs
@@ -93,7 +93,6 @@ fn backslash_in_name() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh674"]
 fn backslash_in_name_double_quotes() -> Result<()> {
     let env = Env(r#"@include "/etc/sudo\ers" "#)
         .file(r#"/etc/sudo\ers"#, SUDOERS_ALL_ALL_NOPASSWD)


### PR DESCRIPTION
inside quotes

closes #674

I decided to create a new `QuoteInclude` token instead of allowing unescaped backslashes in `QuoteText` because the latter is used in several places and we don't have tests that verify that unescaped backslashes are accepted in other places.