### PR TITLE
Implement `--owner` and `--perms`

### DIFF
--- a/src/system/file/chown.rs
+++ b/src/system/file/chown.rs
@@ -1,0 +1,26 @@
+use std::{fs::File, io, os::fd::AsRawFd};
+
+use crate::{
+    cutils::cerr,
+    system::interface::{GroupId, UserId},
+};
+
+mod sealed {
+    use std::fs::File;
+
+    pub(crate) trait Sealed {}
+
+    impl Sealed for File {}
+}
+
+pub(crate) trait Chown: sealed::Sealed {
+    fn chown(&self, uid: UserId, gid: GroupId) -> io::Result<()>;
+}
+
+impl Chown for File {
+    fn chown(&self, owner: UserId, group: GroupId) -> io::Result<()> {
+        let fd = self.as_raw_fd();
+
+        cerr(unsafe { libc::fchown(fd, owner, group) }).map(|_| ())
+    }
+}

--- a/src/system/file/lock.rs
+++ b/src/system/file/lock.rs
@@ -109,3 +109,4 @@ mod tests {
         assert!(f.unlock().is_ok());
     }
 }
+

--- a/src/system/file/mod.rs
+++ b/src/system/file/mod.rs
@@ -1,0 +1,5 @@
+mod chown;
+mod lock;
+
+pub(crate) use lock::Lockable;
+pub(crate) use chown::Chown;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -331,6 +331,10 @@ impl User {
         unsafe { libc::getuid() }
     }
 
+    pub fn real_gid() -> GroupId {
+        unsafe { libc::getgid() }
+    }
+
     pub fn real() -> std::io::Result<Option<User>> {
         Self::from_uid(Self::real_uid())
     }

--- a/src/visudo/cli.rs
+++ b/src/visudo/cli.rs
@@ -4,6 +4,8 @@ pub(crate) struct VisudoOptions {
     pub(crate) includes: bool,
     pub(crate) quiet: bool,
     pub(crate) strict: bool,
+    pub(crate) owner: bool,
+    pub(crate) perms: bool,
     pub(crate) action: VisudoAction,
 }
 
@@ -14,6 +16,8 @@ impl Default for VisudoOptions {
             includes: true,
             quiet: false,
             strict: false,
+            owner: false,
+            perms: false,
             action: VisudoAction::Run,
         }
     }
@@ -98,6 +102,24 @@ impl VisudoOptions {
             takes_argument: false,
             set: |options, _| {
                 options.action = VisudoAction::Version;
+                Ok(())
+            },
+        },
+        VisudoOption {
+            short: 'O',
+            long: "owner",
+            takes_argument: false,
+            set: |options, _| {
+                options.owner = true;
+                Ok(())
+            },
+        },
+        VisudoOption {
+            short: 'P',
+            long: "perms",
+            takes_argument: false,
+            set: |options, _| {
+                options.perms = true;
                 Ok(())
             },
         },

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -45,7 +45,7 @@ pub fn main() {
             eprintln!("check is unimplemented");
             std::process::exit(1);
         }
-        cli::VisudoAction::Run => match run_visudo(options.file.as_deref()) {
+        cli::VisudoAction::Run => match run_visudo(options.file.as_deref(), options.perms) {
             Ok(()) => {}
             Err(error) => {
                 eprintln!("visudo: {error}");
@@ -55,7 +55,7 @@ pub fn main() {
     }
 }
 
-fn run_visudo(file_arg: Option<&str>) -> io::Result<()> {
+fn run_visudo(file_arg: Option<&str>, perms: bool) -> io::Result<()> {
     let sudoers_path = Path::new(file_arg.unwrap_or("/etc/sudoers"));
 
     let (mut sudoers_file, existed) = if sudoers_path.exists() {
@@ -81,6 +81,10 @@ fn run_visudo(file_arg: Option<&str>) -> io::Result<()> {
             err
         }
     })?;
+
+    if perms {
+        sudoers_file.set_permissions(Permissions::from_mode(0o440))?;
+    }
 
     let result: io::Result<()> = (|| {
         let tmp_path = create_temporary_dir()?.join("sudoers");

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -94,7 +94,7 @@ fn run_visudo(file_arg: Option<&str>, perms: bool, owner: bool) -> io::Result<()
         sudoers_file.set_permissions(Permissions::from_mode(0o440))?;
     }
 
-    if owner {
+    if owner || file_arg.is_none() {
         sudoers_file.chown(User::real_uid(), User::real_gid())?;
     }
 

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -72,13 +72,11 @@ fn run_visudo(file_arg: Option<&str>, perms: bool, owner: bool) -> io::Result<()
     } else {
         // Create a sudoers file if it doesn't exist.
         let file = File::create(sudoers_path)?;
-        // ogvisudo sets the permissions of the file based on whether the `-f` argument was passed
-        // or not:
-        // - If `-f` was passed, the file can be read and written by the user.
-        // - If `-f` was not passed, the file can only be read by the user.
-        // In both cases, the file can be read by the group.
-        let mode = if file_arg.is_some() { 0o640 } else { 0o440 };
-        file.set_permissions(Permissions::from_mode(mode))?;
+        // ogvisudo sets the permissions of the file so it can be read and written by the user and
+        // read by the group if the `-f` argument was passed.
+        if file_arg.is_some() {
+            file.set_permissions(Permissions::from_mode(0o640))?;
+        }
         (file, false)
     };
 

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -82,7 +82,7 @@ fn run_visudo(file_arg: Option<&str>, perms: bool) -> io::Result<()> {
         }
     })?;
 
-    if perms {
+    if perms || file_arg.is_none() {
         sudoers_file.set_permissions(Permissions::from_mode(0o440))?;
     }
 

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_owner.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_owner.rs
@@ -52,7 +52,6 @@ fn when_absent_ownership_is_preserved() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh657"]
 fn etc_sudoers_ownership_is_always_changed() -> Result<()> {
     let file_path = ETC_SUDOERS;
     let env = Env(TextFile("").chown(format!("{USERNAME}:users")).chmod("777"))

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_owner.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_owner.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 
 #[test]
-#[ignore = "gh657"]
 fn when_present_changes_ownership_of_existing_file() -> Result<()> {
     let file_path = TMP_SUDOERS;
     let env = Env("")

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_perms.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_perms.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 
 #[test]
-#[ignore = "gh657"]
 fn when_present_changes_perms_of_existing_file() -> Result<()> {
     let file_path = TMP_SUDOERS;
     let env = Env("")

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_perms.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_perms.rs
@@ -52,7 +52,6 @@ fn when_absent_perms_are_preserved() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh657"]
 fn etc_sudoers_perms_are_always_changed() -> Result<()> {
     let file_path = ETC_SUDOERS;
     let env = Env(TextFile("").chmod("777"))


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR adds the required logic to implement the `--owner/-O` and `--perms/-P` flags for `visudo`.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request will partially issue https://github.com/memorysafety/sudo-rs/issues/657 where a proper discussion about a solution has taken place.
