### PR TITLE
Allow escape character to serve dual purpose in token parser

### DIFF
--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -235,14 +235,14 @@ impl<T: Token> Parse for T {
             pred: fn(char) -> bool,
             stream: &mut impl CharStream,
         ) -> Parsed<char> {
-            if let Ok(c) = accept_if(pred, stream) {
-                Ok(c)
-            } else if accept_if(|c| c == T::ESCAPE, stream).is_ok() {
+            if accept_if(|c| c == T::ESCAPE, stream).is_ok() {
                 if let Ok(c) = accept_if(T::escaped, stream) {
                     Ok(c)
                 } else {
                     unrecoverable!(stream, "illegal escape sequence")
                 }
+            } else if let Ok(c) = accept_if(pred, stream) {
+                Ok(c)
             } else {
                 reject()
             }

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -238,6 +238,8 @@ impl<T: Token> Parse for T {
             if accept_if(|c| c == T::ESCAPE, stream).is_ok() {
                 if let Ok(c) = accept_if(T::escaped, stream) {
                     Ok(c)
+                } else if pred(T::ESCAPE) {
+                    Ok(T::ESCAPE)
                 } else {
                     unrecoverable!(stream, "illegal escape sequence")
                 }

--- a/test-framework/sudo-compliance-tests/src/sudoers/include.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoers/include.rs
@@ -104,6 +104,18 @@ fn backslash_in_name_double_quotes() -> Result<()> {
 }
 
 #[test]
+fn double_quote_in_name_double_quotes() -> Result<()> {
+    let env = Env(r#"@include "/etc/sudo\"ers" "#)
+        .file(r#"/etc/sudo"ers"#, SUDOERS_ALL_ALL_NOPASSWD)
+        .build()?;
+
+    Command::new("sudo")
+        .arg("true")
+        .output(&env)?
+        .assert_success()
+}
+
+#[test]
 fn include_loop_error_messages() -> Result<()> {
     let env = Env("@include /etc/sudoers2")
         .file(r#"/etc/sudoers2"#, "@include /etc/sudoers")


### PR DESCRIPTION
The tokenizer assumed that an escape character such as `\` was never serving a "dual purpose" (i.e. it's either an escape character or it's a normal character) #687 shows that apparently this assumption was wrong (and so it kind of defeated the purpose of having a `escaped` category in `QuotedInclude`. This PR fixes this. Submitting without an issue since it's really an esoteric point (who in their right mind uses ` "` in their filenames?!)