### PR TITLE
Replace `Lockable` by `Lock`

### DIFF
--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsStr;
-use std::fs::File;
 use std::process::exit;
 
 use crate::cli::SudoOptions;
@@ -257,14 +256,11 @@ fn determine_auth_status(
 
 struct AuthStatus<'a> {
     must_authenticate: bool,
-    record_file: Option<SessionRecordFile<'a, File>>,
+    record_file: Option<SessionRecordFile<'a>>,
 }
 
 impl<'a> AuthStatus<'a> {
-    fn new(
-        must_authenticate: bool,
-        record_file: Option<SessionRecordFile<'a, File>>,
-    ) -> AuthStatus<'a> {
+    fn new(must_authenticate: bool, record_file: Option<SessionRecordFile<'a>>) -> AuthStatus<'a> {
         AuthStatus {
             must_authenticate,
             record_file,

--- a/src/system/file/lock.rs
+++ b/src/system/file/lock.rs
@@ -1,24 +1,39 @@
-use std::{fs::File, io::Result, os::fd::AsRawFd};
+use std::{
+    fs::File,
+    io::Result,
+    os::fd::{AsRawFd, RawFd},
+};
 
 use crate::cutils::cerr;
 
-pub trait Lockable {
+pub(crate) struct FileLock {
+    fd: RawFd,
+}
+
+impl FileLock {
     /// Get an exclusive lock on the file, waits if there is currently a lock
-    /// on the file
-    fn lock_exclusive(&self, nonblocking: bool) -> Result<()>;
+    /// on the file if `nonblocking` is true.
+    pub(crate) fn exclusive(file: &File, nonblocking: bool) -> Result<Self> {
+        let fd = file.as_raw_fd();
+        flock(fd, LockOp::LockExclusive, nonblocking)?;
+        Ok(Self { fd })
+    }
 
-    /// Get a shared lock on the file, waits if there is currently an exclusive
-    /// lock on the file.
-    fn lock_shared(&self, nonblocking: bool) -> Result<()>;
+    /// Release the lock on the file.
+    pub(crate) fn unlock(self) -> Result<()> {
+        flock(self.fd, LockOp::Unlock, false)
+    }
+}
 
-    /// Release the lock on the file if there is any.
-    fn unlock(&self) -> Result<()>;
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        flock(self.fd, LockOp::Unlock, false).ok();
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
 enum LockOp {
     LockExclusive,
-    LockShared,
     Unlock,
 }
 
@@ -26,67 +41,24 @@ impl LockOp {
     fn as_flock_operation(self) -> libc::c_int {
         match self {
             LockOp::LockExclusive => libc::LOCK_EX,
-            LockOp::LockShared => libc::LOCK_SH,
             LockOp::Unlock => libc::LOCK_UN,
         }
     }
 }
 
-fn flock(fd: &impl AsRawFd, action: LockOp, nonblocking: bool) -> Result<()> {
+fn flock(fd: RawFd, action: LockOp, nonblocking: bool) -> Result<()> {
     let mut operation = action.as_flock_operation();
     if nonblocking {
         operation |= libc::LOCK_NB;
     }
 
-    cerr(unsafe { libc::flock(fd.as_raw_fd(), operation) })?;
+    cerr(unsafe { libc::flock(fd, operation) })?;
     Ok(())
-}
-
-impl Lockable for File {
-    fn lock_exclusive(&self, nonblocking: bool) -> Result<()> {
-        flock(self, LockOp::LockExclusive, nonblocking)
-    }
-
-    fn lock_shared(&self, nonblocking: bool) -> Result<()> {
-        flock(self, LockOp::LockShared, nonblocking)
-    }
-
-    fn unlock(&self) -> Result<()> {
-        flock(self, LockOp::Unlock, false)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    impl Lockable for std::io::Cursor<Vec<u8>> {
-        fn lock_exclusive(&self, _: bool) -> Result<()> {
-            Ok(())
-        }
-
-        fn lock_shared(&self, _: bool) -> Result<()> {
-            Ok(())
-        }
-
-        fn unlock(&self) -> Result<()> {
-            Ok(())
-        }
-    }
-
-    impl Lockable for std::io::Cursor<&mut Vec<u8>> {
-        fn lock_exclusive(&self, _: bool) -> Result<()> {
-            Ok(())
-        }
-
-        fn lock_shared(&self, _: bool) -> Result<()> {
-            Ok(())
-        }
-
-        fn unlock(&self) -> Result<()> {
-            Ok(())
-        }
-    }
 
     fn tempfile() -> std::io::Result<std::fs::File> {
         let timestamp = std::time::SystemTime::now()

--- a/src/system/file/lock.rs
+++ b/src/system/file/lock.rs
@@ -58,26 +58,14 @@ fn flock(fd: RawFd, action: LockOp, nonblocking: bool) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use crate::system::tests::tempfile;
+
     use super::*;
-
-    fn tempfile() -> std::io::Result<std::fs::File> {
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("Failed to get system time")
-            .as_nanos();
-        let pid = std::process::id();
-
-        let filename = format!("sudo_rs_test_{}_{}", pid, timestamp);
-        let path = std::path::PathBuf::from("/tmp").join(filename);
-        std::fs::File::create(path)
-    }
 
     #[test]
     fn test_locking_of_tmp_file() {
         let f = tempfile().unwrap();
-        assert!(f.lock_shared(false).is_ok());
-        assert!(f.unlock().is_ok());
-        assert!(f.lock_exclusive(false).is_ok());
-        assert!(f.unlock().is_ok());
+
+        FileLock::exclusive(&f, false).unwrap().unlock().unwrap();
     }
 }

--- a/src/system/file/mod.rs
+++ b/src/system/file/mod.rs
@@ -2,4 +2,4 @@ mod chown;
 mod lock;
 
 pub(crate) use chown::Chown;
-pub(crate) use lock::Lockable;
+pub(crate) use lock::FileLock;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -633,6 +633,22 @@ mod tests {
         ForkResult, Group, User, WithProcess,
     };
 
+    pub(super) fn tempfile() -> std::io::Result<std::fs::File> {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Failed to get system time")
+            .as_nanos();
+        let pid = std::process::id();
+
+        let filename = format!("sudo_rs_test_{}_{}", pid, timestamp);
+        let path = std::path::PathBuf::from("/tmp").join(filename);
+        std::fs::File::options()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(path)
+    }
+
     #[test]
     fn test_get_user_and_group_by_id() {
         let fixed_users = &[(0, "root"), (1, "daemon")];

--- a/src/system/timestamp.rs
+++ b/src/system/timestamp.rs
@@ -8,7 +8,7 @@ use crate::log::{auth_info, auth_warn};
 
 use super::{
     audit::secure_open_cookie_file,
-    file::Lockable,
+    file::FileLock,
     interface::UserId,
     time::{Duration, SystemTime},
     Process, WithProcess,
@@ -35,23 +35,21 @@ const SIZE_OF_BOOL: i64 = std::mem::size_of::<BoolStorage>() as i64;
 const MOD_OFFSET: i64 = SIZE_OF_TS + SIZE_OF_BOOL;
 
 #[derive(Debug)]
-pub struct SessionRecordFile<'u, IO> {
-    io: IO,
+pub struct SessionRecordFile<'u> {
+    file: File,
     timeout: Duration,
     for_user: &'u str,
 }
 
-impl<'u> SessionRecordFile<'u, File> {
+impl<'u> SessionRecordFile<'u> {
     const BASE_PATH: &str = "/var/run/sudo-rs/ts";
 
-    pub fn open_for_user(user: &'u str, timeout: Duration) -> io::Result<SessionRecordFile<File>> {
+    pub fn open_for_user(user: &'u str, timeout: Duration) -> io::Result<Self> {
         let mut path = PathBuf::from(Self::BASE_PATH);
         path.push(user);
         SessionRecordFile::new(user, secure_open_cookie_file(&path)?, timeout)
     }
-}
 
-impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, IO> {
     const FILE_VERSION: u16 = 1;
     const MAGIC_NUM: u16 = 0x50D0;
     const VERSION_OFFSET: u64 = Self::MAGIC_NUM.to_le_bytes().len() as u64;
@@ -61,9 +59,9 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
     /// Create a new SessionRecordFile from the given i/o stream.
     /// Timestamps in this file are considered valid if they were created or
     /// updated at most `timeout` time ago.
-    pub fn new(for_user: &'u str, io: IO, timeout: Duration) -> io::Result<SessionRecordFile<IO>> {
+    pub fn new(for_user: &'u str, io: File, timeout: Duration) -> io::Result<Self> {
         let mut session_records = SessionRecordFile {
-            io,
+            file: io,
             timeout,
             for_user,
         };
@@ -76,7 +74,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
                     auth_info!("Session records file for user '{for_user}' is invalid, resetting");
                 }
 
-                session_records.init(Self::VERSION_OFFSET, true)?;
+                session_records.init(Self::VERSION_OFFSET)?;
             }
         }
 
@@ -92,7 +90,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
                     );
                 }
 
-                session_records.init(Self::FIRST_RECORD_OFFSET, true)?;
+                session_records.init(Self::FIRST_RECORD_OFFSET)?;
             }
         }
 
@@ -103,7 +101,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
     /// Read the magic number from the input stream
     fn read_magic(&mut self) -> io::Result<Option<u16>> {
         let mut magic_bytes = [0; std::mem::size_of::<u16>()];
-        match self.io.read_exact(&mut magic_bytes) {
+        match self.file.read_exact(&mut magic_bytes) {
             Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => Ok(None),
             Err(e) => Err(e),
             Ok(()) => Ok(Some(u16::from_le_bytes(magic_bytes))),
@@ -113,7 +111,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
     /// Read the version number from the input stream
     fn read_version(&mut self) -> io::Result<Option<u16>> {
         let mut version_bytes = [0; std::mem::size_of::<u16>()];
-        match self.io.read_exact(&mut version_bytes) {
+        match self.file.read_exact(&mut version_bytes) {
             Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => Ok(None),
             Err(e) => Err(e),
             Ok(()) => Ok(Some(u16::from_le_bytes(version_bytes))),
@@ -122,19 +120,18 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
 
     /// Initialize a new empty stream. If the stream/file was already filled
     /// before it will be truncated.
-    fn init(&mut self, offset: u64, must_lock: bool) -> io::Result<()> {
+    fn init(&mut self, offset: u64) -> io::Result<()> {
         // lock the file to indicate that we are currently writing to it
-        if must_lock {
-            self.io.lock_exclusive(false)?;
-        }
-        self.io.set_len(0)?;
-        self.io.rewind()?;
-        self.io.write_all(&Self::MAGIC_NUM.to_le_bytes())?;
-        self.io.write_all(&Self::FILE_VERSION.to_le_bytes())?;
-        self.io.seek(io::SeekFrom::Start(offset))?;
-        if must_lock {
-            self.io.unlock()?;
-        }
+        let lock = FileLock::exclusive(&self.file, false)?;
+
+        self.file.set_len(0)?;
+        self.file.rewind()?;
+        self.file.write_all(&Self::MAGIC_NUM.to_le_bytes())?;
+        self.file.write_all(&Self::FILE_VERSION.to_le_bytes())?;
+        self.file.seek(io::SeekFrom::Start(offset))?;
+
+        lock.unlock()?;
+
         Ok(())
     }
 
@@ -145,10 +142,10 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
         // record the position at which this record starts (including size bytes)
         let mut record_length_bytes = [0; std::mem::size_of::<u16>()];
 
-        let curr_pos = self.io.stream_position()?;
+        let curr_pos = self.file.stream_position()?;
 
         // if eof occurs here we assume we reached the end of the file
-        let record_length = match self.io.read_exact(&mut record_length_bytes) {
+        let record_length = match self.file.read_exact(&mut record_length_bytes) {
             Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
             Err(e) => return Err(e),
             Ok(()) => u16::from_le_bytes(record_length_bytes),
@@ -163,11 +160,11 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
         }
 
         let mut buf = vec![0; record_length as usize];
-        match self.io.read_exact(&mut buf) {
+        match self.file.read_exact(&mut buf) {
             Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
                 // there was half a record here, we clear the rest of the file
                 auth_info!("Found incomplete record in session records file for {}, clearing rest of the file", self.for_user);
-                self.io.set_len(curr_pos as usize)?;
+                self.file.set_len(curr_pos)?;
                 return Ok(None);
             }
             Err(e) => return Err(e),
@@ -181,7 +178,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
                 // onwards, so we clear the file up to the start of this record
                 auth_info!("Found invalid record in session records file for {}, clearing rest of the file", self.for_user);
 
-                self.io.set_len(curr_pos as usize)?;
+                self.file.set_len(curr_pos)?;
                 Ok(None)
             }
             Ok(record) => Ok(Some(record)),
@@ -194,7 +191,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
     /// valid at this time.
     pub fn touch(&mut self, scope: RecordScope, auth_user: UserId) -> io::Result<TouchResult> {
         // lock the file to indicate that we are currently in a writing operation
-        self.io.lock_exclusive(false)?;
+        let lock = FileLock::exclusive(&self.file, false)?;
         self.seek_to_first_record()?;
         while let Some(record) = self.next_record()? {
             // only touch if record is enabled
@@ -202,21 +199,21 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
                 let now = SystemTime::now()?;
                 if record.written_between(now - self.timeout, now) {
                     // move back to where the timestamp is and overwrite with the latest time
-                    self.io.seek(io::SeekFrom::Current(-MOD_OFFSET))?;
+                    self.file.seek(io::SeekFrom::Current(-MOD_OFFSET))?;
                     let new_time = SystemTime::now()?;
-                    new_time.encode(&mut self.io)?;
+                    new_time.encode(&mut self.file)?;
 
                     // make sure we can still go to the end of the record
-                    self.io.seek(io::SeekFrom::Current(SIZE_OF_BOOL))?;
+                    self.file.seek(io::SeekFrom::Current(SIZE_OF_BOOL))?;
 
                     // writing is done, unlock and return
-                    self.io.unlock()?;
+                    lock.unlock()?;
                     return Ok(TouchResult::Updated {
                         old_time: record.timestamp,
                         new_time,
                     });
                 } else {
-                    self.io.unlock()?;
+                    lock.unlock()?;
                     return Ok(TouchResult::Outdated {
                         time: record.timestamp,
                     });
@@ -224,7 +221,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
             }
         }
 
-        self.io.unlock()?;
+        lock.unlock()?;
         Ok(TouchResult::NotFound)
     }
 
@@ -232,18 +229,18 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
     /// given then only records with the given scope that are targetting that
     /// specific user will be disabled.
     pub fn disable(&mut self, scope: RecordScope, auth_user: Option<UserId>) -> io::Result<()> {
-        self.io.lock_exclusive(false)?;
+        let lock = FileLock::exclusive(&self.file, false)?;
         self.seek_to_first_record()?;
         while let Some(record) = self.next_record()? {
             let must_disable = auth_user
                 .map(|tu| record.matches(&scope, tu))
                 .unwrap_or_else(|| record.scope == scope);
             if must_disable {
-                self.io.seek(io::SeekFrom::Current(-SIZE_OF_BOOL))?;
-                write_bool(false, &mut self.io)?;
+                self.file.seek(io::SeekFrom::Current(-SIZE_OF_BOOL))?;
+                write_bool(false, &mut self.file)?;
             }
         }
-        self.io.unlock()?;
+        lock.unlock()?;
         Ok(())
     }
 
@@ -252,15 +249,15 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
     /// then that record will be updated.
     pub fn create(&mut self, scope: RecordScope, auth_user: UserId) -> io::Result<CreateResult> {
         // lock the file to indicate that we are currently writing to it
-        self.io.lock_exclusive(false)?;
+        let lock = FileLock::exclusive(&self.file, false)?;
         self.seek_to_first_record()?;
         while let Some(record) = self.next_record()? {
             if record.matches(&scope, auth_user) {
-                self.io.seek(io::SeekFrom::Current(-MOD_OFFSET))?;
+                self.file.seek(io::SeekFrom::Current(-MOD_OFFSET))?;
                 let new_time = SystemTime::now()?;
-                new_time.encode(&mut self.io)?;
-                write_bool(true, &mut self.io)?;
-                self.io.unlock()?;
+                new_time.encode(&mut self.file)?;
+                write_bool(true, &mut self.file)?;
+                lock.unlock()?;
                 return Ok(CreateResult::Updated {
                     old_time: record.timestamp,
                     new_time,
@@ -272,10 +269,10 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
         let record = SessionRecord::new(scope, auth_user)?;
 
         // make sure we really are at the end of the file
-        self.io.seek(io::SeekFrom::End(0))?;
+        self.file.seek(io::SeekFrom::End(0))?;
 
         self.write_record(&record)?;
-        self.io.unlock()?;
+        lock.unlock()?;
 
         Ok(CreateResult::Created {
             time: record.timestamp,
@@ -284,7 +281,7 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
 
     /// Completely resets the entire file and removes all records.
     pub fn reset(&mut self) -> io::Result<()> {
-        self.init(0, true)
+        self.init(0)
     }
 
     /// Write a new record at the current position in the file.
@@ -301,15 +298,15 @@ impl<'u, IO: Read + Write + Seek + SetLength + Lockable> SessionRecordFile<'u, I
         let record_length = record_length as u16; // store as u16
 
         // write the record
-        self.io.write_all(&record_length.to_le_bytes())?;
-        self.io.write_all(&bytes)?;
+        self.file.write_all(&record_length.to_le_bytes())?;
+        self.file.write_all(&bytes)?;
 
         Ok(())
     }
 
     /// Move to where the first record starts.
     fn seek_to_first_record(&mut self) -> io::Result<()> {
-        self.io
+        self.file
             .seek(io::SeekFrom::Start(Self::FIRST_RECORD_OFFSET))?;
         Ok(())
     }


### PR DESCRIPTION
**Describe the changes done on this pull request**
This PR removes the `Lockable` trait and adds a `FileLock` type that unlocks the file when dropped. Some generics that are not used were also removed.

**Pull Request Checklist**
- [x] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [ ] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
