### PR TITLE
Delete temporary directory when visudo is terminated

### DIFF
--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -59,7 +59,7 @@ impl Sudoers {
 
     pub fn read<R: io::Read, P: AsRef<Path>>(
         reader: R,
-        path: &P,
+        path: P,
     ) -> Result<(Sudoers, Vec<Error>), io::Error> {
         let sudoers = read_sudoers(reader)?;
         Ok(analyze(path.as_ref(), sudoers))

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -163,7 +163,7 @@ fn run(file_arg: Option<&str>, perms: bool, owner: bool) -> io::Result<()> {
 
             drop(handlers);
 
-            std::process::exit(0)
+            std::process::exit(1)
         });
     }
 

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -163,7 +163,7 @@ fn run(file_arg: Option<&str>, perms: bool, owner: bool) -> io::Result<()> {
 
             drop(handlers);
 
-            std::process::exit(1)
+            std::process::exit(0)
         });
     }
 

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -337,3 +337,57 @@ cp $2 {LOGS_PATH}"
 
     Ok(())
 }
+
+#[test]
+fn temporary_file_is_deleted_when_done() -> Result<()> {
+    let expected = SUDOERS_ALL_ALL_NOPASSWD;
+    let env = Env(expected)
+        .file(DEFAULT_EDITOR, TextFile(EDITOR_TRUE).chmod(CHMOD_EXEC))
+        .build()?;
+
+    Command::new("visudo").output(&env)?.assert_success()?;
+
+    let output = Command::new("find")
+        .args(["/tmp", "-name", "sudoers-*"])
+        .output(&env)?
+        .stdout()?;
+
+    assert!(output.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn temporary_file_is_deleted_when_terminated_by_signal() -> Result<()> {
+    let kill_visudo = "/root/kill-visudo.sh";
+    let expected = SUDOERS_ALL_ALL_NOPASSWD;
+    let env = Env(expected)
+        .file(
+            DEFAULT_EDITOR,
+            TextFile(
+                "#!/bin/sh
+sleep 2",
+            )
+            .chmod(CHMOD_EXEC),
+        )
+        .file(kill_visudo, include_str!("visudo/kill-visudo.sh"))
+        .build()?;
+
+    let child = Command::new("visudo").spawn(&env)?;
+
+    Command::new("sh")
+        .args([kill_visudo, "-TERM"])
+        .output(&env)?
+        .assert_success()?;
+
+    assert!(!child.wait()?.status().success());
+
+    let output = Command::new("find")
+        .args(["/tmp", "-name", "sudoers-*"])
+        .output(&env)?
+        .stdout()?;
+
+    assert!(output.is_empty());
+
+    Ok(())
+}

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -381,7 +381,7 @@ sleep 2",
         .output(&env)?
         .assert_success()?;
 
-    assert!(child.wait()?.status().success());
+    assert!(!child.wait()?.status().success());
 
     let output = Command::new("find")
         .args(["/tmp", "-name", "sudoers-*"])

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -366,6 +366,7 @@ fn temporary_file_is_deleted_when_terminated_by_signal() -> Result<()> {
             DEFAULT_EDITOR,
             TextFile(
                 "#!/bin/sh
+touch /tmp/barrier
 sleep 2",
             )
             .chmod(CHMOD_EXEC),

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -380,7 +380,7 @@ sleep 2",
         .output(&env)?
         .assert_success()?;
 
-    assert!(!child.wait()?.status().success());
+    assert!(child.wait()?.status().success());
 
     let output = Command::new("find")
         .args(["/tmp", "-name", "sudoers-*"])

--- a/test-framework/sudo-compliance-tests/src/visudo/kill-visudo.sh
+++ b/test-framework/sudo-compliance-tests/src/visudo/kill-visudo.sh
@@ -1,0 +1,5 @@
+visudopid=$(pidof visudo | sort -gr | cut -f 1 -d ' ')
+
+if [ -n "$visudopid" ]; then
+    kill $1 "$visudopid"
+fi

--- a/test-framework/sudo-compliance-tests/src/visudo/kill-visudo.sh
+++ b/test-framework/sudo-compliance-tests/src/visudo/kill-visudo.sh
@@ -1,8 +1,9 @@
+until [ -f /tmp/barrier ]; do 
+    sleep 0.1
+done
+
 visudopid=$(pidof visudo | sort -gr | cut -f 1 -d ' ')
 
 if [ -n "$visudopid" ]; then
-    until [ -f /tmp/barrier ]; do 
-        sleep 0.1
-    done
     kill $1 "$visudopid"
 fi

--- a/test-framework/sudo-compliance-tests/src/visudo/kill-visudo.sh
+++ b/test-framework/sudo-compliance-tests/src/visudo/kill-visudo.sh
@@ -1,5 +1,6 @@
 visudopid=$(pidof visudo | sort -gr | cut -f 1 -d ' ')
 
 if [ -n "$visudopid" ]; then
+    sleep 0.1
     kill $1 "$visudopid"
 fi

--- a/test-framework/sudo-compliance-tests/src/visudo/kill-visudo.sh
+++ b/test-framework/sudo-compliance-tests/src/visudo/kill-visudo.sh
@@ -1,6 +1,6 @@
 visudopid=$(pidof visudo | sort -gr | cut -f 1 -d ' ')
 
 if [ -n "$visudopid" ]; then
-    sleep 0.1
+    sleep 1
     kill $1 "$visudopid"
 fi

--- a/test-framework/sudo-compliance-tests/src/visudo/kill-visudo.sh
+++ b/test-framework/sudo-compliance-tests/src/visudo/kill-visudo.sh
@@ -1,6 +1,8 @@
 visudopid=$(pidof visudo | sort -gr | cut -f 1 -d ' ')
 
 if [ -n "$visudopid" ]; then
-    sleep 1
+    until [ -f /tmp/barrier ]; do 
+        sleep 0.1
+    done
     kill $1 "$visudopid"
 fi


### PR DESCRIPTION
This PR changes visudo so it deletes the temporary directory once visudo exits or is terminated by a signal
