### PR TITLE
bump CI timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
 
   compliance-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       SUDO_TEST_PROFRAW_DIR: /tmp/profraw
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1


### PR DESCRIPTION
there are more compliance tests now. on a cache miss the compliance test suite can sometimes take more than 15 minutes to complete.