### PR TITLE
Add CI only tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,7 +259,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: miri
-          args: test --workspace --all-features miri
+          args: test --workspace --all-features miri -- --include-ignored
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,7 +221,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: llvm-cov
-          args: --workspace --all-features --all-targets --release --lcov --output-path lcov.info
+          args: --workspace --all-features --all-targets --release --lcov --output-path lcov.info -- --include-ignored
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v3

--- a/src/common/resolve.rs
+++ b/src/common/resolve.rs
@@ -205,6 +205,7 @@ mod tests {
 
     // this test is platform specific -> should be changed when targetting different platforms
     #[test]
+    #[ignore = "ci"]
     fn test_resolve_path() {
         let path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
         assert_eq!(

--- a/src/su/context.rs
+++ b/src/su/context.rs
@@ -265,6 +265,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "ci"]
     fn group_as_non_root() {
         let options = get_options(&["-g", "root"]);
         let result = SuContext::from_env(options);

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -108,6 +108,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[ignore = "ci"]
     fn secure_open_is_predictable() {
         // /etc/hosts should be readable and "secure" (if this test fails, you have been compromised)
         assert!(std::fs::File::open("/etc/hosts").is_ok());
@@ -121,6 +122,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "ci"]
     fn test_secure_open_cookie_file() {
         assert!(secure_open_cookie_file("/etc/hosts").is_err());
     }

--- a/src/system/interface.rs
+++ b/src/system/interface.rs
@@ -80,6 +80,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "ci"]
     fn test_unix_user() {
         let user = |name| User::from_name(name).unwrap().unwrap();
         test_user(user("root"), "root", 0);
@@ -87,6 +88,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "ci"]
     fn test_unix_group() {
         let group = |name| Group::from_name(name).unwrap().unwrap();
         test_group(group("root"), "root", 0);

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -658,6 +658,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "ci"]
     fn test_get_user_and_group_by_id() {
         let fixed_users = &[(0, "root"), (1, "daemon")];
         for &(id, name) in fixed_users {


### PR DESCRIPTION
This resolves issue #708.
Any test that requires being run on the CI server is marked with ```#[ignore = ci]```. 
I added ```-- --ignored``` to both the miri and build-and-test jobs.
Opened as a draft because I don't know if anyone will have a problem with this solution.