### PR TITLE
`sudoers/@include`: expand `%h` to hostname

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -2,7 +2,7 @@
 use std::{collections::HashMap, ffi::OsString};
 
 pub use command::CommandAndArguments;
-pub use context::Context;
+pub use context::{Context, SystemContext};
 pub use error::Error;
 
 pub mod command;

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
 use crate::cli::{help, SudoAction, SudoOptions};
-use crate::common::{resolve::resolve_current_user, Context, Error};
+use crate::common::{resolve::resolve_current_user, Context, Error, SystemContext};
 use crate::log::dev_info;
 use crate::system::timestamp::RecordScope;
 use crate::system::{time::Duration, timestamp::SessionRecordFile, Process};
@@ -35,10 +35,10 @@ impl PolicyPlugin for SudoersPolicy {
     type PreJudgementPolicy = crate::sudoers::Sudoers;
     type Policy = crate::sudoers::Judgement;
 
-    fn init(&mut self) -> Result<Self::PreJudgementPolicy, Error> {
+    fn init(&mut self, system_context: &SystemContext) -> Result<Self::PreJudgementPolicy, Error> {
         let sudoers_path = candidate_sudoers_file();
 
-        let (sudoers, syntax_errors) = crate::sudoers::Sudoers::open(sudoers_path)
+        let (sudoers, syntax_errors) = crate::sudoers::Sudoers::open(system_context, sudoers_path)
             .map_err(|e| Error::Configuration(format!("{e}")))?;
 
         for crate::sudoers::Error(pos, error) in syntax_errors {

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, ops::ControlFlow, path::Path};
 
 use crate::{
     cli::{SudoAction, SudoOptions},
-    common::{Context, Error},
+    common::{Context, Error, SystemContext},
     pam::CLIConverser,
     sudo::{pam::PamAuthenticator, SudoersPolicy},
     sudoers::{Authorization, ListRequest, Policy, Request, Sudoers},
@@ -28,8 +28,9 @@ impl Pipeline<SudoersPolicy, PamAuthenticator<CLIConverser>> {
             panic!("called `Pipeline::run_list` with a SudoAction other than `List`")
         };
 
-        let sudoers = self.policy.init()?;
-        let context = super::build_context(cmd_opts, &sudoers)?;
+        let system_context = SystemContext::new()?;
+        let sudoers = self.policy.init(&system_context)?;
+        let context = super::build_context(system_context, cmd_opts, &sudoers)?;
 
         if original_command.is_some() && !context.command.resolved {
             return Err(Error::CommandNotFound(context.command.command));

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -13,6 +13,29 @@ fn dummy_cksum(name: &str) -> u32 {
     }
 }
 
+fn analyze(
+    path: &Path,
+    sudoers: impl IntoIterator<Item = basic_parser::Parsed<Sudo>>,
+) -> (Sudoers, Vec<Error>) {
+    super::analyze(
+        &SystemContext {
+            hostname: String::from("host"),
+            current_user: crate::system::User {
+                uid: 1,
+                gid: 1,
+                name: String::from("ferris"),
+                gecos: String::from("gecos"),
+                home: PathBuf::from("/home/ferris"),
+                shell: PathBuf::from("/bin/bash"),
+                passwd: String::from("passwd"),
+                groups: vec![0],
+            },
+        },
+        path,
+        sudoers,
+    )
+}
+
 impl UnixUser for Named {
     fn has_name(&self, name: &str) -> bool {
         self.0 == name

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/include.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/include.rs
@@ -241,7 +241,6 @@ fn ownership_check_not_fatal() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh676"]
 fn hostname_expansion() -> Result<()> {
     let hostname = "ship";
     let env = Env("@include /etc/sudoers.%h")


### PR DESCRIPTION
We don't want to compute the hostname each time, as it may change
between invocations.

This needs a small refactor: the hostname is computed in `Context`, but by
this time the sudoers file is already parsed and analyzed:

```rs
let sudoers = self.policy.init()?; <- can't put context here
let context = super::build_context(cmd_opts, &sudoers)?;
```

But things like the hostname and the current user don't depend on
sudoers and command line opts. Split these out into another context,
`SystemContext`, and pass them when analyzing the sudoers file.

Fixes https://github.com/memorysafety/sudo-rs/issues/676