### PR TITLE
Use correct value for `arg0` in symlink

### DIFF
--- a/src/common/command.rs
+++ b/src/common/command.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::system::escape_os_str_lossy;
 
-use super::resolve::resolve_path;
+use super::resolve::{canonicalize, resolve_path};
 
 #[derive(Debug, Default)]
 #[cfg_attr(test, derive(PartialEq))]
@@ -83,7 +83,7 @@ impl CommandAndArguments {
 
             // resolve symlinks, even if the command was obtained through a PATH or SHELL
             // once again, failure to canonicalize should not stop the pipeline
-            match std::fs::canonicalize(&command) {
+            match canonicalize(&command) {
                 Ok(canon_path) => command = canon_path,
                 Err(_) => resolved = false,
             }

--- a/src/common/resolve.rs
+++ b/src/common/resolve.rs
@@ -1,7 +1,7 @@
 use crate::cli::SudoOptions;
 use crate::system::{Group, User};
 use std::{
-    env, fs,
+    env, fs, io,
     os::unix::prelude::MetadataExt,
     path::{Path, PathBuf},
     str::FromStr,
@@ -276,4 +276,28 @@ mod tests {
         assert_eq!(user.name, current_user.name);
         assert_eq!(group.gid, current_user.gid);
     }
+}
+
+/// Resolve symlinks in all the directories leading up to a file, but
+/// not the file itself; this alles sudo to specify a precise policy with
+/// tools like busybox or pgrep (which is a symlink to pgrep on systems)
+pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
+    let path = path.as_ref();
+    let Some(parent) = path.parent() else {
+        // path is "/" or a prefix
+        return Ok(path.to_path_buf());
+    };
+
+    let canon_path = fs::canonicalize(parent)?;
+
+    let reconstructed_path = if let Some(file_name) = path.file_name() {
+        canon_path.join(file_name)
+    } else {
+        canon_path
+    };
+
+    // access the object to generate the regular error if it does not exist
+    let _ = fs::metadata(&reconstructed_path)?;
+
+    Ok(reconstructed_path)
 }

--- a/src/common/resolve.rs
+++ b/src/common/resolve.rs
@@ -301,3 +301,24 @@ pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 
     Ok(reconstructed_path)
 }
+
+#[cfg(test)]
+mod test {
+    use super::canonicalize;
+    use std::path::Path;
+
+    #[test]
+    fn canonicalization() {
+        assert_eq!(canonicalize("/").unwrap(), Path::new("/"));
+        assert_eq!(canonicalize("").unwrap(), Path::new(""));
+        assert_eq!(
+            canonicalize("/usr/bin/pkill").unwrap(),
+            Path::new("/usr/bin/pkill")
+        );
+        // this assumes /bin is a symlink on /usr/bin, like it is on modern Debian/Ubuntu
+        assert_eq!(
+            canonicalize("/bin/pkill").unwrap(),
+            Path::new("/usr/bin/pkill")
+        );
+    }
+}

--- a/src/exec/interface.rs
+++ b/src/exec/interface.rs
@@ -7,6 +7,7 @@ use crate::system::{Group, User};
 pub trait RunOptions {
     fn command(&self) -> io::Result<&PathBuf>;
     fn arguments(&self) -> &Vec<String>;
+    fn arg0(&self) -> Option<&PathBuf>;
     fn chdir(&self) -> Option<&PathBuf>;
     fn is_login(&self) -> bool;
     fn user(&self) -> &User;
@@ -27,6 +28,10 @@ impl RunOptions for Context {
 
     fn arguments(&self) -> &Vec<String> {
         &self.command.arguments
+    }
+
+    fn arg0(&self) -> Option<&PathBuf> {
+        self.command.arg0.as_ref()
     }
 
     fn chdir(&self) -> Option<&PathBuf> {

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -58,6 +58,11 @@ fn run_command_internal(options: &impl RunOptions, env: Environment) -> io::Resu
     let mut command = Command::new(qualified_path);
     // reset env and set filtered environment
     command.args(options.arguments()).env_clear().envs(env);
+    // set the arg0 to the requested string
+    // TODO: this mechanism could perhaps also be used to set the arg0 for login shells, as below
+    if let Some(arg0) = options.arg0() {
+        command.arg0(arg0);
+    }
     // Decide if the pwd should be changed. `--chdir` takes precedence over `-i`.
     let path = options.chdir().cloned().or_else(|| {
         options.is_login().then(|| {

--- a/src/su/context.rs
+++ b/src/su/context.rs
@@ -213,6 +213,10 @@ impl RunOptions for SuContext {
         &self.arguments
     }
 
+    fn arg0(&self) -> Option<&PathBuf> {
+        None
+    }
+
     fn chdir(&self) -> Option<&std::path::PathBuf> {
         None
     }

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -75,7 +75,8 @@ fn ambiguous_spec() {
 fn permission_test() {
     let root = || (&Named("root"), &Named("root"));
 
-    let realpath = |path: &Path| std::fs::canonicalize(path).unwrap_or(path.to_path_buf());
+    let realpath =
+        |path: &Path| crate::common::resolve::canonicalize(path).unwrap_or(path.to_path_buf());
 
     macro_rules! FAIL {
         ([$($sudo:expr),*], $user:expr => $req:expr, $server:expr; $command:expr) => {

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -172,7 +172,7 @@ impl Token for Command {
         };
 
         // canonicalize path (if possible)
-        if let Ok(real_cmd) = std::fs::canonicalize(&cmd) {
+        if let Ok(real_cmd) = crate::common::resolve::canonicalize(&cmd) {
             cmd = real_cmd
                 .to_str()
                 .ok_or("non-UTF8 characters in filesystem")?

--- a/test-framework/sudo-compliance-tests/src/macros.rs
+++ b/test-framework/sudo-compliance-tests/src/macros.rs
@@ -21,3 +21,15 @@ macro_rules! assert_not_contains {
         )
     };
 }
+
+macro_rules! assert_starts_with {
+    ($haystack:expr, $needle:expr) => {
+        let haystack = &$haystack;
+        let needle = &$needle;
+
+        assert!(
+            haystack.starts_with(needle),
+            "{haystack:?} did not start with {needle:?}"
+        )
+    };
+}

--- a/test-framework/sudo-compliance-tests/src/sudo/path_search.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/path_search.rs
@@ -148,6 +148,7 @@ fn arg0_native_is_resolved_from_commandline() -> Result<()> {
 }
 
 #[test]
+#[ignore = "gh735"]
 fn arg0_script_is_passed_from_commandline() -> Result<()> {
     let path = "/bin/my-script";
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD)

--- a/test-framework/sudo-compliance-tests/src/sudo/path_search.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/path_search.rs
@@ -112,3 +112,37 @@ fn paths_are_matched_using_realpath_in_arguments() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn arg0_is_passed_from_commandline() -> Result<()> {
+    let path = "/bin/my-script";
+    let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
+        .file(path, TextFile("#!/bin/sh\necho $0").chmod("777"))
+        .build()?;
+
+    let output = Command::new("sh")
+        .args(["-c", &format!("ln -s {path} /bin/foo; sudo /bin/foo")])
+        .output(&env)?;
+
+    let stdout = output.stdout()?;
+    assert_eq!(stdout, "/bin/foo");
+
+    Ok(())
+}
+
+#[test]
+fn arg0_is_resolved_from_commandline() -> Result<()> {
+    let path = "/bin/my-script";
+    let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
+        .file(path, TextFile("#!/bin/sh\necho $0").chmod("777"))
+        .build()?;
+
+    let output = Command::new("sh")
+        .args(["-c", &format!("ln -s {path} /bin/foo; sudo foo")])
+        .output(&env)?;
+
+    let stdout = output.stdout()?;
+    assert_eq!(stdout, "/usr/bin/foo");
+
+    Ok(())
+}


### PR DESCRIPTION
The proposed fix in 8c03c8c does solve the issue for binaries (such as `pkill` which is symlinked with `pgrep`), but not for shell scripts (as in the provided compliance test case)