### PR TITLE
sudoers/@include: error out when encountering `%h`

### DIFF
--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -639,6 +639,13 @@ fn analyze(
                         ),
 
                         Sudo::IncludeDir(path) => {
+                            if path.contains("%h") {
+                                diagnostics.push(Error(
+                                    None,
+                                    format!("cannot open sudoers file {path}: percent escape %h in includedir is unsupported")));
+                                continue;
+                            }
+
                             let path = resolve_relative(cur_path, path);
                             let Ok(files) = std::fs::read_dir(&path) else {
                                 diagnostics.push(Error(

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -400,6 +400,19 @@ fn gh674_at_include_quoted_backslash() {
 }
 
 #[test]
+fn gh676_percent_h_escape_unsupported() {
+    let (_, errs) = analyze(
+        Path::new("/etc/fakesudoers"),
+        sudoer!(r#"@includedir "/etc/%h" "#),
+    );
+    assert_eq!(errs.len(), 1);
+    assert_eq!(
+        errs[0].1,
+        "cannot open sudoers file /etc/%h: percent escape %h in includedir is unsupported"
+    )
+}
+
+#[test]
 #[should_panic]
 fn hashsign_error() {
     let Sudo::Include(_) = parse_line("#include foo bar") else {


### PR DESCRIPTION
It looks like there's not much use of this feature, and implementing it adds complexity my making the interpretation of a sudoers file "dynamic" instead of "static".

Fixes #676 