### PR TITLE
Appease fmt and clippy

### DIFF
--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -71,7 +71,9 @@ mod test {
     fn check() {
         macro_rules! test {
             ($name:ident => $value:pat) => {
-                let Some(foo@$value) = sudo_default(stringify!($name)) else { unreachable!() };
+                let Some(foo @ $value) = sudo_default(stringify!($name)) else {
+                    unreachable!()
+                };
                 if let SudoDefault::Enum(OptTuple { default, negated }) = foo {
                     assert!(default
                         .possible_values

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -528,7 +528,9 @@ fn get_directive(
     use super::ast::Meta::*;
     use super::ast::Qualified::*;
     use super::ast::UserSpecifier::*;
-    let Allow(Only(User(Identifier::Name(keyword)))) = perhaps_keyword else { return reject() };
+    let Allow(Only(User(Identifier::Name(keyword)))) = perhaps_keyword else {
+        return reject();
+    };
 
     match keyword.as_str() {
         "User_Alias" => make(UserAlias(expect_nonterminal(stream)?)),

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -401,8 +401,12 @@ mod test {
         assert_eq!(input("hello\n   world\n"), vec![s("hello"), s("world")]);
         assert_eq!(input("hello\nworld  \n"), vec![s("hello"), s("world")]);
         assert_eq!(input("hello\nworld")[0..2], vec![s("hello"), s("world")]);
-        let Err(_) = input("hello\nworld")[2] else { panic!() };
-        let Err(_) = input("hello\nworld:\n")[2] else { panic!() };
+        let Err(_) = input("hello\nworld")[2] else {
+            panic!()
+        };
+        let Err(_) = input("hello\nworld:\n")[2] else {
+            panic!()
+        };
     }
     #[test]
     fn whitespace_test() {

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -651,7 +651,10 @@ fn analyze(
                         Sudo::IncludeDir(path) => {
                             let path = resolve_relative(cur_path, path);
                             let Ok(files) = std::fs::read_dir(&path) else {
-                                diagnostics.push(Error(None, format!("cannot open sudoers file {}", path.display())));
+                                diagnostics.push(Error(
+                                    None,
+                                    format!("cannot open sudoers file {}", path.display()),
+                                ));
                                 continue;
                             };
                             let mut safe_files = files
@@ -755,8 +758,11 @@ fn sanitize_alias_table<T>(table: &Vec<Def<T>>, diagnostics: &mut Vec<Error>) ->
             if self.seen.insert(pos) {
                 let Def(_, members) = &self.table[pos];
                 for elem in members {
-                    let Meta::Alias(name) = remqualify(elem) else { break };
-                    let Some(dependency) = self.table.iter().position(|Def(id,_)| id==name) else {
+                    let Meta::Alias(name) = remqualify(elem) else {
+                        break;
+                    };
+                    let Some(dependency) = self.table.iter().position(|Def(id, _)| id == name)
+                    else {
                         self.complain(format!("undefined alias: '{name}'"));
                         continue;
                     };

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -68,7 +68,9 @@ fn parse_line(s: &str) -> Sudo {
 
 #[test]
 fn ambiguous_spec() {
-    let Sudo::Spec(_) = parse_eval::<ast::Sudo>("marc, User_Alias ALL = ALL") else { todo!() };
+    let Sudo::Spec(_) = parse_eval::<ast::Sudo>("marc, User_Alias ALL = ALL") else {
+        todo!()
+    };
 }
 
 #[test]
@@ -314,7 +316,9 @@ fn directive_test() {
     let y = parse_eval::<Spec<UserSpecifier>>;
     match parse_eval::<ast::Sudo>("User_Alias HENK = user1, user2") {
         Sudo::Decl(Directive::UserAlias(defs)) => {
-            let [Def(name, list)] = &defs[..] else { panic!("incorrectly parsed") };
+            let [Def(name, list)] = &defs[..] else {
+                panic!("incorrectly parsed")
+            };
             assert_eq!(name, "HENK");
             assert_eq!(*list, vec![y("user1"), y("user2")]);
         }
@@ -323,7 +327,9 @@ fn directive_test() {
 
     match parse_eval::<ast::Sudo>("Runas_Alias FOO = foo : BAR = bar") {
         Sudo::Decl(Directive::RunasAlias(defs)) => {
-            let [Def(name1, list1), Def(name2, list2)] = &defs[..] else { panic!("incorrectly parsed") };
+            let [Def(name1, list1), Def(name2, list2)] = &defs[..] else {
+                panic!("incorrectly parsed")
+            };
             assert_eq!(name1, "FOO");
             assert_eq!(*list1, vec![y("foo")]);
             assert_eq!(name2, "BAR");
@@ -336,41 +342,77 @@ fn directive_test() {
 #[test]
 // the overloading of '#' causes a lot of issues
 fn hashsign_test() {
-    let Sudo::Spec(_) = parse_line("#42 ALL=ALL") else { panic!() };
-    let Sudo::Spec(_) = parse_line("ALL ALL=(#42) ALL") else { panic!() };
-    let Sudo::Spec(_) = parse_line("ALL ALL=(%#42) ALL") else { panic!() };
-    let Sudo::Spec(_) = parse_line("ALL ALL=(:#42) ALL") else { panic!() };
-    let Sudo::Decl(_) = parse_line("User_Alias FOO=#42, %#0, #3") else { panic!() };
-    let Sudo::LineComment = parse_line("") else { panic!() };
-    let Sudo::LineComment = parse_line("#this is a comment") else { panic!() };
-    let Sudo::Include(_) = parse_line("#include foo") else { panic!() };
-    let Sudo::IncludeDir(_) = parse_line("#includedir foo") else { panic!() };
-    let Sudo::Include(x) = parse_line("#include \"foo bar\"") else { panic!() };
+    let Sudo::Spec(_) = parse_line("#42 ALL=ALL") else {
+        panic!()
+    };
+    let Sudo::Spec(_) = parse_line("ALL ALL=(#42) ALL") else {
+        panic!()
+    };
+    let Sudo::Spec(_) = parse_line("ALL ALL=(%#42) ALL") else {
+        panic!()
+    };
+    let Sudo::Spec(_) = parse_line("ALL ALL=(:#42) ALL") else {
+        panic!()
+    };
+    let Sudo::Decl(_) = parse_line("User_Alias FOO=#42, %#0, #3") else {
+        panic!()
+    };
+    let Sudo::LineComment = parse_line("") else {
+        panic!()
+    };
+    let Sudo::LineComment = parse_line("#this is a comment") else {
+        panic!()
+    };
+    let Sudo::Include(_) = parse_line("#include foo") else {
+        panic!()
+    };
+    let Sudo::IncludeDir(_) = parse_line("#includedir foo") else {
+        panic!()
+    };
+    let Sudo::Include(x) = parse_line("#include \"foo bar\"") else {
+        panic!()
+    };
     assert_eq!(x, "foo bar");
     // this is fine
-    let Sudo::LineComment = parse_line("#inlcudedir foo") else { panic!() };
-    let Sudo::Include(_) = parse_line("@include foo") else { panic!() };
-    let Sudo::IncludeDir(_) = parse_line("@includedir foo") else { panic!() };
-    let Sudo::Include(x) = parse_line("@include \"foo bar\"") else { panic!() };
+    let Sudo::LineComment = parse_line("#inlcudedir foo") else {
+        panic!()
+    };
+    let Sudo::Include(_) = parse_line("@include foo") else {
+        panic!()
+    };
+    let Sudo::IncludeDir(_) = parse_line("@includedir foo") else {
+        panic!()
+    };
+    let Sudo::Include(x) = parse_line("@include \"foo bar\"") else {
+        panic!()
+    };
     assert_eq!(x, "foo bar");
 }
 
 #[test]
 fn gh674_at_include_quoted_backslash() {
-    let Sudo::Include(_) = parse_line(r#"@include "/etc/sudo\ers" "#) else { panic!() };
-    let Sudo::IncludeDir(_) = parse_line(r#"@includedir "/etc/sudo\ers.d" "#) else { panic!() };
+    let Sudo::Include(_) = parse_line(r#"@include "/etc/sudo\ers" "#) else {
+        panic!()
+    };
+    let Sudo::IncludeDir(_) = parse_line(r#"@includedir "/etc/sudo\ers.d" "#) else {
+        panic!()
+    };
 }
 
 #[test]
 #[should_panic]
 fn hashsign_error() {
-    let Sudo::Include(_) = parse_line("#include foo bar") else { todo!() };
+    let Sudo::Include(_) = parse_line("#include foo bar") else {
+        todo!()
+    };
 }
 
 #[test]
 #[should_panic]
 fn include_regression() {
-    let Sudo::Include(_) = parse_line("#4,#include foo") else { todo!() };
+    let Sudo::Include(_) = parse_line("#4,#include foo") else {
+        todo!()
+    };
 }
 
 #[test]
@@ -387,8 +429,12 @@ fn defaults_regression() {
 
 #[test]
 fn useralias_underscore_regression() {
-    let Sudo::Spec(x) = parse_line("FOO_BAR ALL=ALL") else { todo!() };
-    let Qualified::Allow(Meta::Alias(_)) = x.users[0] else { panic!() };
+    let Sudo::Spec(x) = parse_line("FOO_BAR ALL=ALL") else {
+        todo!()
+    };
+    let Qualified::Allow(Meta::Alias(_)) = x.users[0] else {
+        panic!()
+    };
 }
 
 fn test_topo_sort(n: usize) {
@@ -407,7 +453,9 @@ fn test_topo_sort(n: usize) {
         let mut seen = HashSet::new();
         for Def(id, defns) in order.iter().map(|&i| &table[i]) {
             if defns.iter().any(|spec| {
-                let Qualified::Allow(Meta::Alias(id2)) = spec else { return false };
+                let Qualified::Allow(Meta::Alias(id2)) = spec else {
+                    return false;
+                };
                 !seen.contains(id2)
             }) {
                 panic!("forward reference encountered after sorting");
@@ -484,7 +532,9 @@ fn fuzz_topo_sort(siz: usize) {
         let mut seen = HashSet::new();
         for Def(id, defns) in order.iter().map(|&i| &table[i]) {
             if defns.iter().any(|spec| {
-                let Qualified::Allow(Meta::Alias(id2)) = spec else { return false };
+                let Qualified::Allow(Meta::Alias(id2)) = spec else {
+                    return false;
+                };
                 !seen.contains(id2)
             }) {
                 panic!("forward reference encountered after sorting");

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_login.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_login.rs
@@ -180,7 +180,7 @@ echo $@";
         .output(&env)?
         .stdout()?;
 
-    assert_eq!(r#"-c a 1 _ - $ $VAR $\{VAR\}"#, output);
+    assert_eq!(r"-c a 1 _ - $ $VAR $\{VAR\}", output);
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_shell.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_shell.rs
@@ -157,7 +157,7 @@ echo $@";
         .output(&env)?
         .stdout()?;
 
-    assert_eq!(r#"-c a 1 _ - $ $VAR $\{VAR\}"#, output);
+    assert_eq!(r"-c a 1 _ - $ $VAR $\{VAR\}", output);
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_shell.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_shell.rs
@@ -249,8 +249,12 @@ fn parse_getent_passwd_output(passwd: &str) -> Result<UserToShell> {
     const ERROR: &str = "malformed `getent passwd` output";
     let mut map = HashMap::new();
     for line in passwd.lines() {
-        let Some((user, _)) = line.split_once(':')  else { return Err(ERROR.into())};
-        let Some((_, shell)) = line.rsplit_once(':')  else { return Err(ERROR.into())};
+        let Some((user, _)) = line.split_once(':') else {
+            return Err(ERROR.into());
+        };
+        let Some((_, shell)) = line.rsplit_once(':') else {
+            return Err(ERROR.into());
+        };
 
         map.insert(user, shell);
     }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/include.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/include.rs
@@ -45,7 +45,7 @@ fn file_does_not_exist() -> Result<()> {
 
 #[test]
 fn whitespace_in_name_backslash() -> Result<()> {
-    let env = Env(r#"@include /etc/sudo\ ers"#)
+    let env = Env(r"@include /etc/sudo\ ers")
         .file("/etc/sudo ers", SUDOERS_ALL_ALL_NOPASSWD)
         .build()?;
 
@@ -81,8 +81,8 @@ fn old_pound_syntax() -> Result<()> {
 
 #[test]
 fn backslash_in_name() -> Result<()> {
-    let env = Env(r#"@include /etc/sudo\\ers"#)
-        .file(r#"/etc/sudo\ers"#, SUDOERS_ALL_ALL_NOPASSWD)
+    let env = Env(r"@include /etc/sudo\\ers")
+        .file(r"/etc/sudo\ers", SUDOERS_ALL_ALL_NOPASSWD)
         .build()?;
 
     Command::new("sudo")
@@ -94,7 +94,7 @@ fn backslash_in_name() -> Result<()> {
 #[test]
 fn backslash_in_name_double_quotes() -> Result<()> {
     let env = Env(r#"@include "/etc/sudo\ers" "#)
-        .file(r#"/etc/sudo\ers"#, SUDOERS_ALL_ALL_NOPASSWD)
+        .file(r"/etc/sudo\ers", SUDOERS_ALL_ALL_NOPASSWD)
         .build()?;
 
     Command::new("sudo")

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/includedir.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/includedir.rs
@@ -219,7 +219,7 @@ fn statements_prior_to_include_loop_are_evaluated() -> Result<()> {
 
 #[test]
 fn whitespace_in_name_escaped() -> Result<()> {
-    let env = Env(r#"@includedir /etc/sudo\ ers.d"#)
+    let env = Env(r"@includedir /etc/sudo\ ers.d")
         .directory(r#"/etc/sudo ers.d"#)
         .file(r#"/etc/sudo ers.d/a"#, SUDOERS_ALL_ALL_NOPASSWD)
         .build()?;
@@ -245,9 +245,9 @@ fn whitespace_in_name_double_quotes() -> Result<()> {
 
 #[test]
 fn backslash_in_name_escaped() -> Result<()> {
-    let env = Env(r#"@includedir /etc/sudo\\ers.d"#)
-        .directory(r#"/etc/sudo\ers.d"#)
-        .file(r#"/etc/sudo\ers.d/a"#, SUDOERS_ALL_ALL_NOPASSWD)
+    let env = Env(r"@includedir /etc/sudo\\ers.d")
+        .directory(r"/etc/sudo\ers.d")
+        .file(r"/etc/sudo\ers.d/a", SUDOERS_ALL_ALL_NOPASSWD)
         .build()?;
 
     Command::new("sudo")
@@ -259,8 +259,8 @@ fn backslash_in_name_escaped() -> Result<()> {
 #[test]
 fn backslash_in_name_double_quotes() -> Result<()> {
     let env = Env(r#"@includedir "/etc/sudo\ers.d""#)
-        .directory(r#"/etc/sudo\ers.d"#)
-        .file(r#"/etc/sudo\ers.d/a"#, SUDOERS_ALL_ALL_NOPASSWD)
+        .directory(r"/etc/sudo\ers.d")
+        .file(r"/etc/sudo\ers.d/a", SUDOERS_ALL_ALL_NOPASSWD)
         .build()?;
 
     Command::new("sudo")


### PR DESCRIPTION
The CI has updated its Rust toolchain; so PR's will get rejected until this one is merged.

- `rustfmt` now has support for `let .. else` constructs (finally)
- clippy complained about unnecessary `#` in raw strings in the test framework