### PR TITLE
fix UB technicality in pre-exec

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -89,15 +89,12 @@ fn run_command_internal(options: &impl RunOptions, env: Environment) -> io::Resu
     if let Some(path) = path {
         let is_chdir = options.chdir().is_some();
 
+        let bytes = path.as_os_str().as_bytes();
+        let c_path = CString::new(bytes).expect("nul byte found in provided directory path");
+
         unsafe {
             command.pre_exec(move || {
-                let bytes = path.as_os_str().as_bytes();
-
-                let c_path =
-                    CString::new(bytes).expect("nul byte found in provided directory path");
-
                 if let Err(err) = crate::system::chdir(&c_path) {
-                    user_error!("unable to change directory to {}: {}", path.display(), err);
                     if is_chdir {
                         return Err(err);
                     }


### PR DESCRIPTION
pre-exec runs after fork, so allocations are forbidden. Move the allocation/deallocation outside of the closure.

Practically, I don't think anything _particularly_ bad can happen, but deadlock in multithreaded programs is a very real possibility!

What could happen is:

* thread A takes a global mutex guarding the allocator on the slow path
* thread B forks out an address space with the mutex in the locked state
* the forked process allocates (in CString::new) and gets stuck.
* thread B gets stuck waiting on the pipe to this new process

So, move both the allocation and deallocation out of pre_exec closure. I am actually not sure if the latter is necessary (maybe memory is safely leaked on both ok and err paths), but better safe than unsound!