### PR TITLE
Papercut fix: null bytes starting whitespace in sudoers files

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -132,7 +132,7 @@ pub enum Sudo {
 
 impl Parse for Identifier {
     fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
-        if accept_if(|c| c == '#', stream).is_ok() {
+        if accept_if(|c| c == '#', stream).is_some() {
             let Digits(guid) = expect_nonterminal(stream)?;
             make(Identifier::ID(guid))
         } else {
@@ -211,15 +211,15 @@ impl Parse for Meta<Identifier> {
 /// ```
 impl Parse for UserSpecifier {
     fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
-        let userspec = if accept_if(|c| c == '%', stream).is_ok() {
-            let ctor = if accept_if(|c| c == ':', stream).is_ok() {
+        let userspec = if accept_if(|c| c == '%', stream).is_some() {
+            let ctor = if accept_if(|c| c == ':', stream).is_some() {
                 UserSpecifier::NonunixGroup
             } else {
                 UserSpecifier::Group
             };
             // in this case we must fail 'hard', since input has been consumed
             ctor(expect_nonterminal(stream)?)
-        } else if accept_if(|c| c == '+', stream).is_ok() {
+        } else if accept_if(|c| c == '+', stream).is_some() {
             // TODO Netgroups
             unrecoverable!(stream, "netgroups are not supported yet");
         } else {
@@ -406,7 +406,7 @@ impl Parse for Sudo {
     // but accept:
     //   "user, User_Alias machine = command"; this does the same
     fn parse(stream: &mut impl CharStream) -> Parsed<Sudo> {
-        if accept_if(|c| c == '@', stream).is_ok() {
+        if accept_if(|c| c == '@', stream).is_some() {
             return parse_include(stream);
         }
 
@@ -429,7 +429,7 @@ impl Parse for Sudo {
                 // the failed "try_nonterminal::<Identifier>" will have consumed the '#'
                 // the most ignominious part of sudoers: having to parse bits of comments
                 parse_include(stream).or_else(|_| {
-                    while accept_if(|c| c != '\n', stream).is_ok() {}
+                    while accept_if(|c| c != '\n', stream).is_some() {}
                     make(Sudo::LineComment)
                 })
             };
@@ -459,7 +459,7 @@ impl Parse for Sudo {
 
 fn parse_include(stream: &mut impl CharStream) -> Parsed<Sudo> {
     fn get_path(stream: &mut impl CharStream) -> Parsed<String> {
-        if accept_if(|c| c == '"', stream).is_ok() {
+        if accept_if(|c| c == '"', stream).is_some() {
             let QuotedInclude(path) = expect_nonterminal(stream)?;
             expect_syntax('"', stream)?;
             make(path)
@@ -552,7 +552,7 @@ impl Parse for (String, ConfigValue) {
 
         // Parse multiple entries enclosed in quotes (for list-like Defaults-settings)
         let parse_vars = |stream: &mut _| -> Parsed<Vec<String>> {
-            if accept_if(|c| c == '"', stream).is_ok() {
+            if accept_if(|c| c == '"', stream).is_some() {
                 let mut result = Vec::new();
                 while let Some(EnvVar(name)) = try_nonterminal(stream)? {
                     result.push(name);
@@ -589,7 +589,7 @@ impl Parse for (String, ConfigValue) {
 
         // Parse a text parameter
         let text_item = |stream: &mut _| {
-            if accept_if(|c| c == '"', stream).is_ok() {
+            if accept_if(|c| c == '"', stream).is_some() {
                 let QuotedText(text) = expect_nonterminal(stream)?;
                 expect_syntax('"', stream)?;
                 make(text)

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -222,7 +222,7 @@ pub trait Token: Sized {
         Self::accept(c)
     }
 
-    const ESCAPE: char = '\0';
+    const ALLOW_ESCAPE: bool = false;
     fn escaped(_: char) -> bool {
         false
     }
@@ -235,11 +235,12 @@ impl<T: Token> Parse for T {
             pred: fn(char) -> bool,
             stream: &mut impl CharStream,
         ) -> Parsed<char> {
-            if accept_if(|c| c == T::ESCAPE, stream).is_ok() {
+            const ESCAPE: char = '\\';
+            if T::ALLOW_ESCAPE && accept_if(|c| c == ESCAPE, stream).is_ok() {
                 if let Ok(c) = accept_if(T::escaped, stream) {
                     Ok(c)
-                } else if pred(T::ESCAPE) {
-                    Ok(T::ESCAPE)
+                } else if pred(ESCAPE) {
+                    Ok(ESCAPE)
                 } else {
                     unrecoverable!(stream, "illegal escape sequence")
                 }

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -252,7 +252,7 @@ impl<T: Token> Parse for T {
 
         let start_pos = stream.get_pos();
         let mut str = accept_escaped::<T>(T::accept_1st, stream)?.to_string();
-        while let Ok(c) = accept_escaped::<T>(T::accept, stream) {
+        while let Some(c) = maybe(accept_escaped::<T>(T::accept, stream))? {
             if str.len() >= T::MAX_LEN {
                 unrecoverable!(stream, "token exceeds maximum length")
             }

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -83,19 +83,18 @@ pub trait Parse {
         Self: Sized;
 }
 
-/// Primitive function (that also adheres to the Parse trait contract): accepts one character
-/// that satisfies `predicate`. This is used in the majority of all the other `Parse`
-/// implementations instead of interfacing with the iterator directly (this can facilitate an easy
-/// switch to a different method of stream representation in the future). Unlike most `Parse`
-/// implementations this *does not* consume trailing whitespace.
-/// NOTE: Guaranteed not to give an unrecoverable error.
-pub fn accept_if(predicate: impl Fn(char) -> bool, stream: &mut impl CharStream) -> Parsed<char> {
-    let c = stream.peek().ok_or(Status::Reject)?;
+/// Primitive function: accepts one character that satisfies `predicate`. This is used in the majority
+/// of all the other `Parse` implementations instead of interfacing with the iterator directly
+/// (this can facilitate an easy switch to a different method of stream representation in the future).
+/// Unlike `Parse` implementations this *does not* consume trailing whitespace.
+/// This function is modelled on `next_if` on `std::Peekable`.
+pub fn accept_if(predicate: impl Fn(char) -> bool, stream: &mut impl CharStream) -> Option<char> {
+    let c = stream.peek()?;
     if predicate(c) {
         stream.advance();
-        make(c)
+        Some(c)
     } else {
-        reject()
+        None
     }
 }
 
@@ -114,7 +113,7 @@ struct Comment;
 impl Parse for LeadingWhitespace {
     fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
         let eat_space = |stream: &mut _| accept_if(|c| "\t ".contains(c), stream);
-        while eat_space(stream).is_ok() {}
+        while eat_space(stream).is_some() {}
 
         if stream.peek().is_some() {
             make(LeadingWhitespace {})
@@ -133,9 +132,9 @@ impl Parse for TrailingWhitespace {
             let _ = LeadingWhitespace::parse(stream); // don't propagate any errors
 
             // line continuations
-            if accept_if(|c| c == '\\', stream).is_ok() {
+            if accept_if(|c| c == '\\', stream).is_some() {
                 // do the equivalent of expect_syntax('\n', stream)?, without recursion
-                if accept_if(|c| c == '\n', stream).is_err() {
+                if accept_if(|c| c == '\n', stream).is_none() {
                     unrecoverable!(stream, "stray escape sequence")
                 }
             } else {
@@ -150,8 +149,8 @@ impl Parse for TrailingWhitespace {
 /// Parses a comment
 impl Parse for Comment {
     fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
-        accept_if(|c| c == '#', stream)?;
-        while accept_if(|c| c != '\n', stream).is_ok() {}
+        accept_if(|c| c == '#', stream).ok_or(Status::Reject)?;
+        while accept_if(|c| c != '\n', stream).is_some() {}
         make(Comment {})
     }
 }
@@ -163,7 +162,7 @@ fn skip_trailing_whitespace(stream: &mut impl CharStream) -> Parsed<()> {
 
 /// Adheres to the contract of the [Parse] trait, accepts one character and consumes trailing whitespace.
 pub fn try_syntax(syntax: char, stream: &mut impl CharStream) -> Parsed<()> {
-    accept_if(|c| c == syntax, stream)?;
+    accept_if(|c| c == syntax, stream).ok_or(Status::Reject)?;
     skip_trailing_whitespace(stream)?;
     make(())
 }
@@ -196,7 +195,7 @@ pub fn try_nonterminal<T: Parse>(stream: &mut impl CharStream) -> Parsed<T> {
 }
 
 /// Interface for working with types that implement the [Parse] trait; this expects to parse
-/// the given type or aborts parsing if not.
+/// the given type or gives a fatal parse error if this did not succeed.
 use super::ast_names::UserFriendly;
 
 pub fn expect_nonterminal<T: Parse + UserFriendly>(stream: &mut impl CharStream) -> Parsed<T> {
@@ -236,15 +235,15 @@ impl<T: Token> Parse for T {
             stream: &mut impl CharStream,
         ) -> Parsed<char> {
             const ESCAPE: char = '\\';
-            if T::ALLOW_ESCAPE && accept_if(|c| c == ESCAPE, stream).is_ok() {
-                if let Ok(c) = accept_if(T::escaped, stream) {
+            if T::ALLOW_ESCAPE && accept_if(|c| c == ESCAPE, stream).is_some() {
+                if let Some(c) = accept_if(T::escaped, stream) {
                     Ok(c)
                 } else if pred(ESCAPE) {
                     Ok(ESCAPE)
                 } else {
                     unrecoverable!(stream, "illegal escape sequence")
                 }
-            } else if let Ok(c) = accept_if(pred, stream) {
+            } else if let Some(c) = accept_if(pred, stream) {
                 Ok(c)
             } else {
                 reject()
@@ -327,7 +326,7 @@ where
         result.push(item);
 
         let _ = maybe(Comment::parse(stream));
-        if accept_if(|c| c == '\n', stream).is_err() {
+        if accept_if(|c| c == '\n', stream).is_none() {
             if parsed_item_ok {
                 let msg = if stream.peek().is_none() {
                     "missing line terminator at end of file"
@@ -337,7 +336,7 @@ where
                 let error = |stream: &mut Stream| unrecoverable!(stream, "{msg}");
                 result.push(error(stream));
             }
-            while accept_if(|c| c != '\n', stream).is_ok() {}
+            while accept_if(|c| c != '\n', stream).is_some() {}
         }
     }
 

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -416,6 +416,11 @@ fn include_regression() {
 }
 
 #[test]
+fn nullbyte_regression() {
+    if let Sudo::Spec(PermissionSpec { .. }) = parse_line("ferris ALL=(ALL:ferris\0) ALL") {};
+}
+
+#[test]
 #[should_panic]
 fn alias_all_regression() {
     parse_line("User_Alias ALL = sudouser");

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -416,6 +416,7 @@ fn include_regression() {
 }
 
 #[test]
+#[should_panic]
 fn nullbyte_regression() {
     if let Sudo::Spec(PermissionSpec { .. }) = parse_line("ferris ALL=(ALL:ferris\0) ALL") {};
 }

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -108,7 +108,7 @@ impl<T: Token> Token for Meta<T> {
         T::accept_1st(c) || c.is_uppercase()
     }
 
-    const ESCAPE: char = T::ESCAPE;
+    const ALLOW_ESCAPE: bool = T::ALLOW_ESCAPE;
 
     fn escaped(c: char) -> bool {
         T::escaped(c)
@@ -196,7 +196,7 @@ impl Token for Command {
         !Self::escaped(c) && !c.is_control()
     }
 
-    const ESCAPE: char = '\\';
+    const ALLOW_ESCAPE: bool = true;
     fn escaped(c: char) -> bool {
         matches!(c, '\\' | ',' | ':' | '=' | '#')
     }
@@ -227,7 +227,7 @@ impl Token for EnvVar {
         !c.is_control() && !c.is_whitespace() && !Self::escaped(c)
     }
 
-    const ESCAPE: char = '\\';
+    const ALLOW_ESCAPE: bool = true;
     fn escaped(c: char) -> bool {
         matches!(c, '\\' | '=' | '#' | '"')
     }
@@ -246,7 +246,7 @@ impl Token for QuotedText {
         !Self::escaped(c)
     }
 
-    const ESCAPE: char = '\\';
+    const ALLOW_ESCAPE: bool = true;
     fn escaped(c: char) -> bool {
         matches!(c, '\\' | '"') || c.is_control()
     }
@@ -267,7 +267,7 @@ impl Token for QuotedInclude {
         !Self::escaped(c)
     }
 
-    const ESCAPE: char = '\\';
+    const ALLOW_ESCAPE: bool = true;
     fn escaped(c: char) -> bool {
         matches!(c, '"') || c.is_control()
     }
@@ -286,7 +286,7 @@ impl Token for IncludePath {
         !c.is_control() && !Self::escaped(c)
     }
 
-    const ESCAPE: char = '\\';
+    const ALLOW_ESCAPE: bool = true;
     fn escaped(c: char) -> bool {
         matches!(c, '\\' | '"' | ' ')
     }
@@ -306,7 +306,7 @@ impl Token for StringParameter {
         !c.is_control() && !Self::escaped(c)
     }
 
-    const ESCAPE: char = '\\';
+    const ALLOW_ESCAPE: bool = true;
     fn escaped(c: char) -> bool {
         matches!(c, '\\' | '"' | ' ' | '#' | ',')
     }
@@ -341,7 +341,7 @@ impl Token for ChDir {
         "~/*".contains(c)
     }
 
-    const ESCAPE: char = '\\';
+    const ALLOW_ESCAPE: bool = true;
     fn escaped(c: char) -> bool {
         matches!(c, '\\' | '"' | ' ')
     }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/run_as.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/run_as.rs
@@ -496,7 +496,11 @@ fn null_byte_terminated_username() -> Result<()> {
         .output(&env)?;
 
     assert!(!output.status().success());
-    assert_contains!(output.stderr(), "syntax error");
+    if sudo_test::is_original_sudo() {
+        assert_contains!(output.stderr(), "syntax error");
+    } else {
+        assert_contains!(output.stderr(), "expecting ')' but found '\0'");
+    }
 
     Ok(())
 }
@@ -513,7 +517,11 @@ fn null_byte_terminated_groupname() -> Result<()> {
         .output(&env)?;
 
     assert!(!output.status().success());
-    assert_contains!(output.stderr(), "syntax error");
+    if sudo_test::is_original_sudo() {
+        assert_contains!(output.stderr(), "syntax error");
+    } else {
+        assert_contains!(output.stderr(), "expecting ')' but found '\0'");
+    }
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/run_as.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/run_as.rs
@@ -484,7 +484,6 @@ fn minus_1_uid() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "gh749"]
 #[test]
 fn null_byte_terminated_username() -> Result<()> {
     let env = Env("ferris ALL=(root\0:ALL) NOPASSWD: ALL")
@@ -502,7 +501,6 @@ fn null_byte_terminated_username() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "gh749"]
 #[test]
 fn null_byte_terminated_groupname() -> Result<()> {
     let env = Env("ferris ALL=(ALL:root\0) NOPASSWD: ALL")

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
@@ -408,7 +408,6 @@ fn user_alias_keywords() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "gh749"]
 #[test]
 fn null_byte_terminated_username() -> Result<()> {
     let env = Env("ferris\0 ALL=(ALL:ALL) NOPASSWD: ALL")

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
@@ -420,7 +420,11 @@ fn null_byte_terminated_username() -> Result<()> {
         .output(&env)?;
 
     assert!(!output.status().success());
-    assert_contains!(output.stderr(), "syntax error");
+    if sudo_test::is_original_sudo() {
+        assert_contains!(output.stderr(), "syntax error");
+    } else {
+        assert_contains!(output.stderr(), "expected host name");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This is perhaps best reviewed commit by commit.
- First commit unignores the compliance tests
- Second commit fixes the spot where the "illegal escape" error was hidden (which made it harder to find the bug)
- Third commit changes the error into the correct one (escape character is now hardcoded `\`, no need for a sentinel)
- Fourth commit seems a bit unrelated, but changes the contract of `accept_if`, which was the only function for which you could rely on an `Err` result to not have consumed input (which `accept_escaped` then followed incorrectly) to prevent similar mistakes in the future.