### PR TITLE
Add mitigations against Rowhammer attacks

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -1,4 +1,5 @@
 use crate::cli::{SudoAction, SudoOptions};
+use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2};
 use crate::system::{hostname, Group, Process, User};
 use std::path::PathBuf;
 
@@ -28,10 +29,11 @@ pub struct Context {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[repr(u32)]
 pub enum LaunchType {
-    Direct,
-    Shell,
-    Login,
+    Direct = HARDENED_ENUM_VALUE_0,
+    Shell = HARDENED_ENUM_VALUE_1,
+    Login = HARDENED_ENUM_VALUE_2,
 }
 
 impl Context {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -12,3 +12,12 @@ pub mod error;
 pub mod resolve;
 
 pub type Environment = HashMap<OsString, OsString>;
+
+// Hardened enum values used for critical enums to mitigate attacks like Rowhammer.
+// See for example https://arxiv.org/pdf/2309.02545.pdf
+// The values are copied from https://github.com/sudo-project/sudo/commit/7873f8334c8d31031f8cfa83bd97ac6029309e4f#diff-b8ac7ab4c3c4a75aed0bb5f7c5fd38b9ea6c81b7557f775e46c6f8aa115e02cd
+pub const HARDENED_ENUM_VALUE_0: u32 = 0x52a2925; // 0101001010100010100100100101
+pub const HARDENED_ENUM_VALUE_1: u32 = 0xad5d6da; // 1010110101011101011011011010
+pub const HARDENED_ENUM_VALUE_2: u32 = 0x69d61fc8; // 1101001110101100001111111001000
+pub const HARDENED_ENUM_VALUE_3: u32 = 0x1629e037; // 0010110001010011110000000110111
+pub const HARDENED_ENUM_VALUE_4: u32 = 0x1fc8d3ac; // 11111110010001101001110101100

--- a/src/exec/event.rs
+++ b/src/exec/event.rs
@@ -6,6 +6,7 @@ use std::{
 
 use libc::{c_short, pollfd, POLLIN, POLLOUT};
 
+use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1};
 use crate::{cutils::cerr, log::dev_debug};
 
 pub(super) trait Process: Sized {
@@ -23,9 +24,10 @@ pub(super) trait Process: Sized {
     fn on_event(&mut self, event: Self::Event, registry: &mut EventRegistry<Self>);
 }
 
+#[repr(u32)]
 enum Status<T: Process> {
-    Continue,
-    Stop(StopReason<T>),
+    Continue = HARDENED_ENUM_VALUE_0,
+    Stop(StopReason<T>) = HARDENED_ENUM_VALUE_1,
 }
 
 impl<T: Process> Status<T> {

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -1,12 +1,17 @@
 use super::ast_names::UserFriendly;
 use super::basic_parser::*;
 use super::tokens::*;
+use crate::common::{
+    HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2, HARDENED_ENUM_VALUE_3,
+    HARDENED_ENUM_VALUE_4,
+};
 
 /// The Sudoers file allows negating items with the exclamation mark.
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+#[repr(u32)]
 pub enum Qualified<T> {
-    Allow(T),
-    Forbid(T),
+    Allow(T) = HARDENED_ENUM_VALUE_0,
+    Forbid(T) = HARDENED_ENUM_VALUE_1,
 }
 
 impl<T> Qualified<T> {
@@ -53,13 +58,14 @@ pub struct RunAs {
 // `sudo -l l` calls this the `authenticate` option
 #[derive(Copy, Clone, Default, PartialEq)]
 #[cfg_attr(test, derive(Debug, Eq))]
+#[repr(u32)]
 pub enum Authenticate {
     #[default]
-    None,
+    None = HARDENED_ENUM_VALUE_0,
     // PASSWD:
-    Passwd,
+    Passwd = HARDENED_ENUM_VALUE_1,
     // NOPASSWD:
-    Nopasswd,
+    Nopasswd = HARDENED_ENUM_VALUE_2,
 }
 
 /// Commands in /etc/sudoers can have attributes attached to them, such as NOPASSWD, NOEXEC, ...
@@ -91,12 +97,13 @@ pub type Defs<T> = Vec<Def<T>>;
 pub struct Def<T>(pub String, pub SpecList<T>);
 
 /// AST object for directive specifications (aliases, arguments, etc)
+#[repr(u32)]
 pub enum Directive {
-    UserAlias(Defs<UserSpecifier>),
-    HostAlias(Defs<Hostname>),
-    CmndAlias(Defs<Command>),
-    RunasAlias(Defs<UserSpecifier>),
-    Defaults(Vec<(String, ConfigValue)>),
+    UserAlias(Defs<UserSpecifier>) = HARDENED_ENUM_VALUE_0,
+    HostAlias(Defs<Hostname>) = HARDENED_ENUM_VALUE_1,
+    CmndAlias(Defs<Command>) = HARDENED_ENUM_VALUE_2,
+    RunasAlias(Defs<UserSpecifier>) = HARDENED_ENUM_VALUE_3,
+    Defaults(Vec<(String, ConfigValue)>) = HARDENED_ENUM_VALUE_4,
 }
 
 pub type TextEnum = crate::defaults::StrEnum<'static>;
@@ -109,19 +116,21 @@ pub enum ConfigValue {
     Enum(TextEnum),
 }
 
+#[repr(u32)]
 pub enum Mode {
-    Add,
-    Set,
-    Del,
+    Add = HARDENED_ENUM_VALUE_0,
+    Set = HARDENED_ENUM_VALUE_1,
+    Del = HARDENED_ENUM_VALUE_2,
 }
 
 /// The Sudoers file can contain permissions and directives
+#[repr(u32)]
 pub enum Sudo {
-    Spec(PermissionSpec),
-    Decl(Directive),
-    Include(String),
-    IncludeDir(String),
-    LineComment,
+    Spec(PermissionSpec) = HARDENED_ENUM_VALUE_0,
+    Decl(Directive) = HARDENED_ENUM_VALUE_1,
+    Include(String) = HARDENED_ENUM_VALUE_2,
+    IncludeDir(String) = HARDENED_ENUM_VALUE_3,
+    LineComment = HARDENED_ENUM_VALUE_4,
 }
 
 /// grammar:

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -1,6 +1,7 @@
 use super::Sudoers;
 
 use super::Judgement;
+use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1};
 use crate::system::time::Duration;
 /// Data types and traits that represent what the "terms and conditions" are after a succesful
 /// permission check.
@@ -29,9 +30,10 @@ pub trait Policy {
 
 #[must_use]
 #[cfg_attr(test, derive(Debug, PartialEq))]
+#[repr(u32)]
 pub enum Authorization {
-    Allowed(AuthorizationAllowed),
-    Forbidden,
+    Allowed(AuthorizationAllowed) = HARDENED_ENUM_VALUE_0,
+    Forbidden = HARDENED_ENUM_VALUE_1,
 }
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
@@ -43,9 +45,10 @@ pub struct AuthorizationAllowed {
 
 #[must_use]
 #[cfg_attr(test, derive(Debug, PartialEq))]
+#[repr(u32)]
 pub enum DirChange<'a> {
-    Strict(Option<&'a Path>),
-    Any,
+    Strict(Option<&'a Path>) = HARDENED_ENUM_VALUE_0,
+    Any = HARDENED_ENUM_VALUE_1,
 }
 
 impl Policy for Judgement {

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -1,6 +1,7 @@
 //! Various tokens
 
 use super::basic_parser::{Many, Token};
+use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2};
 
 #[cfg_attr(test, derive(Clone, PartialEq, Eq))]
 pub struct Username(pub String);
@@ -76,10 +77,11 @@ impl Many for Hostname {}
 /// This enum allows items to use the ALL wildcard or be specified with aliases, or directly.
 /// (Maybe this is better defined not as a Token but simply directly as an implementation of [crate::sudoers::basic_parser::Parse])
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+#[repr(u32)]
 pub enum Meta<T> {
-    All,
-    Only(T),
-    Alias(String),
+    All = HARDENED_ENUM_VALUE_0,
+    Only(T) = HARDENED_ENUM_VALUE_1,
+    Alias(String) = HARDENED_ENUM_VALUE_2,
 }
 
 impl<T: Token> Token for Meta<T> {


### PR DESCRIPTION
Critical enums are now represented using values that are very different. It's therefore much harder to circumvent authentication with a single bit flip.

Closes #763