### PR TITLE
visudo-rs: Improve the error message

### DIFF
--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -243,7 +243,7 @@ fn edit_sudoers_file(
             break;
         }
 
-        writeln!(stderr, "Come on... you can do better than that.\n")?;
+        writeln!(stderr, "The provided sudoers file format is not recognized or contains syntax errors. Please review:\n")?;
 
         for crate::sudoers::Error(_position, message) in errors {
             writeln!(stderr, "syntax error: {message}")?;


### PR DESCRIPTION
```
$ visudo-rs                                                                                                                                         
Come on... you can do better than that.

syntax error: expected parameter
syntax error: expected host name

What now? e(x)it without saving / (e)dit again:
```

"Come on... you can do better than that." is too informal