### PR TITLE
change signature of `chown` to not accept `Option`s

### DIFF
--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -269,7 +269,9 @@ fn get_pty() -> io::Result<Pty> {
         err
     })?;
 
-    chown(&pty.path, User::effective_uid(), tty_gid).map_err(|err| {
+    let euid = User::effective_uid();
+    let gid = tty_gid.unwrap_or(User::effective_gid());
+    chown(&pty.path, euid, gid).map_err(|err| {
         dev_error!("cannot change owner for pty: {err}");
         err
     })?;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -334,7 +334,7 @@ impl User {
         unsafe { libc::geteuid() }
     }
 
-    pub fn effective_gid() -> UserId {
+    pub fn effective_gid() -> GroupId {
         unsafe { libc::getegid() }
     }
 

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -242,12 +242,12 @@ pub fn setpgid(pid: ProcessId, pgid: ProcessId) -> io::Result<()> {
 
 pub fn chown<S: AsRef<CStr>>(
     path: &S,
-    uid: impl Into<Option<UserId>>,
-    gid: impl Into<Option<GroupId>>,
+    uid: impl Into<UserId>,
+    gid: impl Into<GroupId>,
 ) -> io::Result<()> {
     let path = path.as_ref().as_ptr();
-    let uid = uid.into().unwrap_or(UserId::MAX);
-    let gid = gid.into().unwrap_or(GroupId::MAX);
+    let uid = uid.into();
+    let gid = gid.into();
 
     cerr(unsafe { libc::chown(path, uid, gid) }).map(|_| ())
 }
@@ -332,6 +332,10 @@ impl User {
 
     pub fn effective_uid() -> UserId {
         unsafe { libc::geteuid() }
+    }
+
+    pub fn effective_gid() -> UserId {
+        unsafe { libc::getegid() }
     }
 
     pub fn real_uid() -> UserId {


### PR DESCRIPTION
`get_pty` now uses either "tty"'s gid or the effective group ID