### PR TITLE
replace `unsafe` CStr construction with a macro that compile time checks CStr invariants

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,3 +45,15 @@ macro_rules! print {
         compiler_error!("do not use `print!`; use the `write!` macro instead")
     };
 }
+
+macro_rules! cstr {
+    ($lit:literal) => {{
+        // this `const` item produces compile time errors = it performs the checks at compile time
+        const CS: &'static std::ffi::CStr =
+            match std::ffi::CStr::from_bytes_with_nul(concat!($lit, "\0").as_bytes()) {
+                Ok(x) => x,
+                Err(_) => panic!("string literal did not pass CStr checks"),
+            };
+        CS
+    }};
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,7 +50,7 @@ macro_rules! cstr {
     ($lit:literal) => {{
         // this `const` item produces compile time errors = it performs the checks at compile time
         const CS: &'static std::ffi::CStr =
-            match std::ffi::CStr::from_bytes_with_nul(concat!($lit, "\0").as_bytes()) {
+            match std::ffi::CStr::from_bytes_until_nul(concat!($lit, "\0").as_bytes()) {
                 Ok(x) => x,
                 Err(_) => panic!("string literal did not pass CStr checks"),
             };

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -2,7 +2,7 @@ mod cli;
 mod help;
 
 use std::{
-    ffi::{CStr, CString, OsString},
+    ffi::{CString, OsString},
     fs::{File, Permissions},
     io::{self, Read, Seek, Write},
     os::unix::prelude::{MetadataExt, OsStringExt, PermissionsExt},
@@ -302,12 +302,7 @@ fn editor_path_fallback() -> io::Result<PathBuf> {
 }
 
 fn create_temporary_dir() -> io::Result<PathBuf> {
-    // SAFETY: the required safety checks (last byte is NULL; no inner NULLs) are performed at
-    // compile time by the const-constructor
-    const TEMPLATE: &CStr =
-        unsafe { CStr::from_bytes_with_nul_unchecked(b"/tmp/sudoers-XXXXXX\0") };
-
-    let template = TEMPLATE.to_owned();
+    let template = cstr!("/tmp/sudoers-XXXXXX").to_owned();
 
     let ptr = unsafe { libc::mkdtemp(template.into_raw()) };
 


### PR DESCRIPTION
co-authored by @rnijveld 

extracted this out of a WIP branch that addresses #748 