### PR TITLE
reject wildcards in argument positions

### DIFF
--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -164,6 +164,9 @@ impl Token for Command {
                 // if the magic "" appears, no (further) arguments are allowed
                 args.pop();
             }
+            if args.iter().any(|arg| arg.chars().any(|c| "?*".contains(c))) {
+                return Err("wildcards are not allowed in command arguments".to_string());
+            }
             Some(args.into_boxed_slice())
         };
 


### PR DESCRIPTION
Closing #780

Also rejects '?'.