### PR TITLE
refactor: add SudoString and SudoPath

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,8 @@
 
 use std::path::PathBuf;
 
+use crate::common::{SudoPath, SudoString};
+
 pub mod help;
 
 #[cfg(test)]
@@ -24,17 +26,17 @@ pub enum SudoAction {
 pub struct SudoOptions {
     pub background: bool,
     pub chroot: Option<PathBuf>,
-    pub directory: Option<PathBuf>,
-    pub group: Option<String>,
+    pub directory: Option<SudoPath>,
+    pub group: Option<SudoString>,
     pub host: Option<String>,
     pub login: bool,
     pub non_interactive: bool,
-    pub other_user: Option<String>,
+    pub other_user: Option<SudoString>,
     pub preserve_env: Vec<String>,
     pub preserve_groups: bool,
     pub shell: bool,
     pub stdin: bool,
-    pub user: Option<String>,
+    pub user: Option<SudoString>,
     // additional environment
     pub env_var_list: Vec<(String, String)>,
     // resulting action enum
@@ -316,13 +318,13 @@ impl SudoOptions {
                 },
                 SudoArg::Argument(option, value) => match option.as_str() {
                     "-D" | "--chdir" => {
-                        options.directory = Some(PathBuf::from(value));
+                        options.directory = Some(SudoPath::from_cli_string(value));
                     }
                     "-E" | "--preserve-env" => {
                         options.preserve_env = value.split(',').map(str::to_string).collect()
                     }
                     "-g" | "--group" => {
-                        options.group = Some(value);
+                        options.group = Some(SudoString::from_cli_string(value));
                     }
                     "-h" | "--host" => {
                         options.host = Some(value);
@@ -331,10 +333,10 @@ impl SudoOptions {
                         options.chroot = Some(PathBuf::from(value));
                     }
                     "-U" | "--other-user" => {
-                        options.other_user = Some(value);
+                        options.other_user = Some(SudoString::from_cli_string(value));
                     }
                     "-u" | "--user" => {
-                        options.user = Some(value);
+                        options.user = Some(SudoString::from_cli_string(value));
                     }
                     _option => {
                         Err("invalid option provided")?;

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use crate::common::SudoPath;
+
 use super::{SudoAction, SudoOptions};
 use pretty_assertions::assert_eq;
 
@@ -216,13 +218,13 @@ fn shell() {
 #[test]
 fn directory() {
     let cmd = SudoOptions::try_parse_from(["sudo", "-D/some/path"]).unwrap();
-    assert_eq!(cmd.directory, Some(PathBuf::from("/some/path")));
+    assert_eq!(cmd.directory, Some(SudoPath::from("/some/path")));
 
     let cmd = SudoOptions::try_parse_from(["sudo", "--chdir", "/some/path"]).unwrap();
-    assert_eq!(cmd.directory, Some(PathBuf::from("/some/path")));
+    assert_eq!(cmd.directory, Some(SudoPath::from("/some/path")));
 
     let cmd = SudoOptions::try_parse_from(["sudo", "--chdir=/some/path"]).unwrap();
-    assert_eq!(cmd.directory, Some(PathBuf::from("/some/path")));
+    assert_eq!(cmd.directory, Some(SudoPath::from("/some/path")));
 }
 
 #[test]

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -1,8 +1,8 @@
 use crate::cli::{SudoAction, SudoOptions};
 use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2};
 use crate::system::{hostname, Group, Process, User};
-use std::path::PathBuf;
 
+use super::path::SudoPath;
 use super::{
     command::CommandAndArguments,
     resolve::{resolve_current_user, resolve_launch_and_shell, resolve_target_user_and_group},
@@ -13,7 +13,7 @@ use super::{
 pub struct Context {
     // cli options
     pub launch: LaunchType,
-    pub chdir: Option<PathBuf>,
+    pub chdir: Option<SudoPath>,
     pub command: CommandAndArguments,
     pub target_user: User,
     pub target_group: Group,

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -1,20 +1,22 @@
 use crate::pam::PamError;
 use std::{borrow::Cow, fmt, path::PathBuf};
 
+use super::{SudoPath, SudoString};
+
 #[derive(Debug)]
 pub enum Error {
     Silent,
     NotAllowed {
-        username: String,
+        username: SudoString,
         command: Cow<'static, str>,
         hostname: String,
-        other_user: Option<String>,
+        other_user: Option<SudoString>,
     },
     SelfCheck,
     CommandNotFound(PathBuf),
     InvalidCommand(PathBuf),
     ChDirNotAllowed {
-        chdir: PathBuf,
+        chdir: SudoPath,
         command: PathBuf,
     },
     UserNotFound(String),
@@ -25,6 +27,8 @@ pub enum Error {
     Pam(PamError),
     IoError(Option<PathBuf>, std::io::Error),
     MaxAuthAttempts(usize),
+    PathValidation(PathBuf),
+    StringValidation(String),
 }
 
 impl fmt::Display for Error {
@@ -76,6 +80,12 @@ impl fmt::Display for Error {
                 chdir.display(),
                 command.display()
             ),
+            Error::StringValidation(string) => {
+                write!(f, "invalid string: {string:?}")
+            }
+            Error::PathValidation(path) => {
+                write!(f, "invalid path: {path:?}")
+            }
         }
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -4,12 +4,16 @@ use std::{collections::HashMap, ffi::OsString};
 pub use command::CommandAndArguments;
 pub use context::Context;
 pub use error::Error;
+pub use path::SudoPath;
+pub use string::SudoString;
 
 pub mod bin_serde;
 pub mod command;
 pub mod context;
 pub mod error;
+mod path;
 pub mod resolve;
+mod string;
 
 pub type Environment = HashMap<OsString, OsString>;
 

--- a/src/common/path.rs
+++ b/src/common/path.rs
@@ -1,0 +1,105 @@
+use std::{
+    ffi::OsString,
+    ops,
+    os::unix::prelude::OsStrExt,
+    path::{Path, PathBuf},
+    str,
+};
+
+use super::{Error, SudoString};
+
+/// A `PathBuf` guaranteed to not contain null bytes and be UTF-8 encoded
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(test, derive(Eq))]
+pub struct SudoPath {
+    inner: String,
+}
+
+impl SudoPath {
+    pub fn new(path: PathBuf) -> Result<Self, Error> {
+        let bytes = path.as_os_str().as_bytes();
+        if bytes.contains(&0) {
+            return Err(Error::PathValidation(path));
+        }
+
+        // check this through a reference so we can return `path` in the error case
+        if str::from_utf8(bytes).is_err() {
+            return Err(Error::PathValidation(path));
+        }
+
+        Ok(Self {
+            // NOTE(unwrap): UTF-8 encoding is checked above
+            inner: path.into_os_string().into_string().unwrap(),
+        })
+    }
+
+    pub fn from_cli_string(cli_string: impl Into<String>) -> Self {
+        Self::new(cli_string.into().into())
+            .expect("strings that come in from CLI should not have interior null bytes")
+    }
+
+    /// Resolve the use of a '~' that occurs in this `SudoPathBuf`; based on the sudoers context
+    pub fn expand_tilde_in_path(&self, default_username: &SudoString) -> Result<SudoPath, Error> {
+        if let Some(prefix) = self.inner.strip_prefix('~') {
+            let (username, relpath) = prefix.split_once('/').unwrap_or((prefix, ""));
+
+            let username = if username.is_empty() {
+                default_username.clone()
+            } else {
+                SudoString::new(username.to_string()).unwrap()
+            };
+
+            let home_dir = crate::system::User::from_name(username.as_cstr())
+                .ok()
+                .flatten()
+                .ok_or(Error::UserNotFound(username.to_string()))?
+                .home;
+            let path = home_dir.join(relpath);
+
+            Self::new(path)
+        } else {
+            Ok(self.clone())
+        }
+    }
+}
+
+impl From<SudoPath> for PathBuf {
+    fn from(value: SudoPath) -> Self {
+        value.inner.into()
+    }
+}
+
+impl AsRef<Path> for SudoPath {
+    fn as_ref(&self) -> &Path {
+        self.inner.as_ref()
+    }
+}
+
+impl ops::Deref for SudoPath {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl TryFrom<String> for SudoPath {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value.into())
+    }
+}
+
+impl From<SudoPath> for OsString {
+    fn from(value: SudoPath) -> Self {
+        value.inner.into()
+    }
+}
+
+#[cfg(test)]
+impl From<&'_ str> for SudoPath {
+    fn from(value: &'_ str) -> Self {
+        Self::new(value.into()).unwrap()
+    }
+}

--- a/src/common/resolve.rs
+++ b/src/common/resolve.rs
@@ -7,16 +7,17 @@ use std::{
     str::FromStr,
 };
 
+use super::SudoString;
 use super::{context::LaunchType, Error};
 
 #[derive(PartialEq, Debug)]
 enum NameOrId<'a, T: FromStr> {
-    Name(&'a str),
+    Name(&'a SudoString),
     Id(T),
 }
 
 impl<'a, T: FromStr> NameOrId<'a, T> {
-    pub fn parse(input: &'a str) -> Option<Self> {
+    pub fn parse(input: &'a SudoString) -> Option<Self> {
         if input.is_empty() {
             None
         } else if let Some(stripped) = input.strip_prefix('#') {
@@ -52,25 +53,33 @@ pub(super) fn resolve_launch_and_shell(
 }
 
 pub(crate) fn resolve_target_user_and_group(
-    target_user_name_or_id: &Option<String>,
-    target_group_name_or_id: &Option<String>,
+    target_user_name_or_id: &Option<SudoString>,
+    target_group_name_or_id: &Option<SudoString>,
     current_user: &User,
 ) -> Result<(User, Group), Error> {
     // resolve user name or #<id> to a user
-    let mut target_user =
-        match NameOrId::parse(target_user_name_or_id.as_deref().unwrap_or_default()) {
-            Some(NameOrId::Name(name)) => User::from_name(name)?,
-            Some(NameOrId::Id(uid)) => User::from_uid(uid)?,
-            _ => None,
-        };
+    let mut target_user = target_user_name_or_id
+        .as_ref()
+        .and_then(|input| {
+            match NameOrId::parse(input)? {
+                NameOrId::Name(name) => User::from_name(name.as_cstr()),
+                NameOrId::Id(uid) => User::from_uid(uid),
+            }
+            .transpose()
+        })
+        .transpose()?;
 
     // resolve group name or #<id> to a group
-    let mut target_group =
-        match NameOrId::parse(target_group_name_or_id.as_deref().unwrap_or_default()) {
-            Some(NameOrId::Name(name)) => Group::from_name(name)?,
-            Some(NameOrId::Id(gid)) => Group::from_gid(gid)?,
-            _ => None,
-        };
+    let mut target_group = target_group_name_or_id
+        .as_ref()
+        .and_then(|input| {
+            match NameOrId::parse(input)? {
+                NameOrId::Name(name) => Group::from_name(name.as_cstr()),
+                NameOrId::Id(gid) => Group::from_gid(gid),
+            }
+            .transpose()
+        })
+        .transpose()?;
 
     match (&target_user_name_or_id, &target_group_name_or_id) {
         // when -g is specified, but -u is not specified default -u to the current user
@@ -85,8 +94,8 @@ pub(crate) fn resolve_target_user_and_group(
         }
         // when no -u or -g is specified, default to root:root
         (None, None) => {
-            target_user = User::from_name("root")?;
-            target_group = Group::from_name("root")?;
+            target_user = User::from_name(cstr!("root"))?;
+            target_group = Group::from_name(cstr!("root"))?;
         }
         _ => {}
     }
@@ -171,31 +180,6 @@ pub(crate) fn resolve_path(command: &Path, path: &str) -> Option<PathBuf> {
         })
 }
 
-/// Resolve the use of a '~' that occurs in a PathBuf; based on the sudoers context
-pub(crate) fn expand_tilde_in_path(
-    default_user: &str,
-    mut path: PathBuf,
-) -> Result<PathBuf, Error> {
-    let mut iter = path.iter();
-    if let Some(mut user_name) = iter
-        .next()
-        .and_then(|s| s.to_str())
-        .and_then(|s| s.strip_prefix('~'))
-    {
-        if user_name.is_empty() {
-            user_name = default_user
-        }
-        let home_dir = crate::system::User::from_name(user_name)
-            .ok()
-            .flatten()
-            .ok_or(Error::UserNotFound(user_name.to_string()))?
-            .home;
-        path = home_dir.join(iter.collect::<std::path::PathBuf>())
-    }
-
-    Ok(path)
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -230,11 +214,20 @@ mod tests {
 
     #[test]
     fn test_name_or_id() {
-        assert_eq!(NameOrId::<u32>::parse(""), None);
-        assert_eq!(NameOrId::<u32>::parse("mies"), Some(NameOrId::Name("mies")));
-        assert_eq!(NameOrId::<u32>::parse("1337"), Some(NameOrId::Name("1337")));
-        assert_eq!(NameOrId::<u32>::parse("#1337"), Some(NameOrId::Id(1337)));
-        assert_eq!(NameOrId::<u32>::parse("#-1"), None);
+        assert_eq!(NameOrId::<u32>::parse(&"".into()), None);
+        assert_eq!(
+            NameOrId::<u32>::parse(&"mies".into()),
+            Some(NameOrId::Name(&"mies".into()))
+        );
+        assert_eq!(
+            NameOrId::<u32>::parse(&"1337".into()),
+            Some(NameOrId::Name(&"1337".into()))
+        );
+        assert_eq!(
+            NameOrId::<u32>::parse(&"#1337".into()),
+            Some(NameOrId::Id(1337))
+        );
+        assert_eq!(NameOrId::<u32>::parse(&"#-1".into()), None);
     }
 
     #[test]
@@ -247,34 +240,25 @@ mod tests {
         assert_eq!(group.name, "root");
 
         // unknown user
-        let result = resolve_target_user_and_group(
-            &Some("non_existing_ghost".to_string()),
-            &None,
-            &current_user,
-        );
+        let result =
+            resolve_target_user_and_group(&Some("non_existing_ghost".into()), &None, &current_user);
         assert!(result.is_err());
 
         // unknown user
-        let result = resolve_target_user_and_group(
-            &None,
-            &Some("non_existing_ghost".to_string()),
-            &current_user,
-        );
+        let result =
+            resolve_target_user_and_group(&None, &Some("non_existing_ghost".into()), &current_user);
         assert!(result.is_err());
 
         // fallback to current user when different group specified
         let (user, group) =
-            resolve_target_user_and_group(&None, &Some("root".to_string()), &current_user).unwrap();
+            resolve_target_user_and_group(&None, &Some("root".into()), &current_user).unwrap();
         assert_eq!(user.name, current_user.name);
         assert_eq!(group.name, "root");
 
         // fallback to current users group when no group specified
-        let (user, group) = resolve_target_user_and_group(
-            &Some(current_user.name.to_string()),
-            &None,
-            &current_user,
-        )
-        .unwrap();
+        let (user, group) =
+            resolve_target_user_and_group(&Some(current_user.name.clone()), &None, &current_user)
+                .unwrap();
         assert_eq!(user.name, current_user.name);
         assert_eq!(group.gid, current_user.gid);
     }

--- a/src/common/string.rs
+++ b/src/common/string.rs
@@ -1,0 +1,150 @@
+use core::fmt;
+use std::{
+    ffi::{CStr, OsString},
+    ops,
+};
+
+use crate::common::Error;
+
+const NULL_BYTE: char = '\0';
+const NULL_BYTE_UTF8_LEN: usize = NULL_BYTE.len_utf8();
+
+/// A UTF-8 encoded string with no interior null bytes
+///
+/// This type can be converted into a C (null-terminated) string at no cost
+#[derive(Clone, PartialEq, Eq)]
+pub struct SudoString {
+    inner: String,
+}
+
+impl SudoString {
+    pub fn new(mut string: String) -> Result<Self, Error> {
+        if string.as_bytes().contains(&0) {
+            return Err(Error::StringValidation(string));
+        }
+
+        string.push(NULL_BYTE);
+
+        Ok(Self { inner: string })
+    }
+
+    pub fn from_cli_string(cli_string: impl Into<String>) -> Self {
+        Self::new(cli_string.into())
+            .expect("strings that come in from CLI should not have interior null bytes")
+    }
+
+    pub fn as_cstr(&self) -> &CStr {
+        CStr::from_bytes_with_nul(self.inner.as_bytes()).unwrap()
+    }
+
+    pub fn as_str(&self) -> &str {
+        self
+    }
+}
+
+impl Default for SudoString {
+    fn default() -> Self {
+        Self {
+            inner: NULL_BYTE.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl From<&'_ str> for SudoString {
+    fn from(value: &'_ str) -> Self {
+        SudoString::try_from(value.to_string()).unwrap()
+    }
+}
+
+impl TryFrom<String> for SudoString {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<SudoString> for String {
+    fn from(value: SudoString) -> Self {
+        let mut s = value.inner;
+        s.pop();
+        s
+    }
+}
+
+impl From<SudoString> for OsString {
+    fn from(value: SudoString) -> Self {
+        let mut s = value.inner;
+        s.pop();
+        OsString::from(s)
+    }
+}
+
+impl ops::Deref for SudoString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        let num_bytes = self.inner.as_bytes().len();
+        &self.inner[..num_bytes - NULL_BYTE_UTF8_LEN]
+    }
+}
+
+impl fmt::Debug for SudoString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s: &str = self;
+        fmt::Debug::fmt(s, f)
+    }
+}
+
+impl fmt::Display for SudoString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self)
+    }
+}
+
+impl PartialEq<str> for SudoString {
+    fn eq(&self, other: &str) -> bool {
+        let s: &str = self;
+        s == other
+    }
+}
+
+impl PartialEq<&'_ str> for SudoString {
+    fn eq(&self, other: &&str) -> bool {
+        let s: &str = self;
+        s == *other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+
+    use super::*;
+
+    #[test]
+    fn null_byte_is_utf8_encoded_as_a_single_byte() {
+        assert_eq!(1, NULL_BYTE_UTF8_LEN)
+    }
+
+    #[test]
+    fn sanity_check() {
+        let expected = "hello";
+        let s = SudoString::new("hello".to_string()).unwrap();
+        assert_eq!(expected, &*s);
+    }
+
+    #[test]
+    fn cstr_conversion() {
+        let expected = "hello";
+        let cstr = CString::from_vec_with_nul((expected.to_string() + "\0").into_bytes()).unwrap();
+        let s = SudoString::new(expected.to_string()).unwrap();
+        assert_eq!(&*cstr, s.as_cstr());
+    }
+
+    #[test]
+    fn rejects_string_that_contains_interior_null() {
+        assert!(SudoString::new("he\0llo".to_string()).is_err());
+    }
+}

--- a/src/env/tests.rs
+++ b/src/env/tests.rs
@@ -80,7 +80,8 @@ fn create_test_context(sudo_options: &SudoOptions) -> Context {
     let current_user = User {
         uid: 1000,
         gid: 1000,
-        name: "test".to_string(),
+
+        name: "test".into(),
         gecos: String::new(),
         home: "/home/test".into(),
         shell: "/bin/sh".into(),
@@ -98,7 +99,7 @@ fn create_test_context(sudo_options: &SudoOptions) -> Context {
     let root_user = User {
         uid: 0,
         gid: 0,
-        name: "root".to_string(),
+        name: "root".into(),
         gecos: String::new(),
         home: "/root".into(),
         shell: "/bin/bash".into(),

--- a/src/exec/interface.rs
+++ b/src/exec/interface.rs
@@ -1,14 +1,17 @@
 use std::io::{self, ErrorKind};
 use std::path::PathBuf;
 
-use crate::common::{context::LaunchType, Context};
-use crate::system::{Group, User};
+use crate::common::SudoPath;
+use crate::{
+    common::{context::LaunchType, Context},
+    system::{Group, User},
+};
 
 pub trait RunOptions {
     fn command(&self) -> io::Result<&PathBuf>;
     fn arguments(&self) -> &Vec<String>;
     fn arg0(&self) -> Option<&PathBuf>;
-    fn chdir(&self) -> Option<&PathBuf>;
+    fn chdir(&self) -> Option<&SudoPath>;
     fn is_login(&self) -> bool;
     fn user(&self) -> &User;
     fn requesting_user(&self) -> &User;
@@ -34,7 +37,7 @@ impl RunOptions for Context {
         self.command.arg0.as_ref()
     }
 
-    fn chdir(&self) -> Option<&PathBuf> {
+    fn chdir(&self) -> Option<&SudoPath> {
         self.chdir.as_ref()
     }
 

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -260,7 +260,7 @@ pub(in crate::exec) fn exec_pty(
 }
 
 fn get_pty() -> io::Result<Pty> {
-    let tty_gid = Group::from_name("tty")
+    let tty_gid = Group::from_name(cstr!("tty"))
         .unwrap_or(None)
         .map(|group| group.gid);
 

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -18,7 +18,8 @@ impl Pipeline<SudoersPolicy, PamAuthenticator<CLIConverser>> {
             .other_user
             .as_ref()
             .map(|username| {
-                User::from_name(username)?.ok_or_else(|| Error::UserNotFound(username.clone()))
+                User::from_name(username.as_cstr())?
+                    .ok_or_else(|| Error::UserNotFound(username.clone().into()))
             })
             .transpose()?;
 

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -1,6 +1,7 @@
 use super::ast_names::UserFriendly;
 use super::basic_parser::*;
 use super::tokens::*;
+use crate::common::SudoString;
 use crate::common::{
     HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2, HARDENED_ENUM_VALUE_3,
     HARDENED_ENUM_VALUE_4,
@@ -37,7 +38,7 @@ pub type SpecList<T> = Vec<Spec<T>>;
 /// An identifier is a name or a #number
 #[cfg_attr(test, derive(Clone, Debug, PartialEq, Eq))]
 pub enum Identifier {
-    Name(String),
+    Name(SudoString),
     ID(u32),
 }
 
@@ -190,7 +191,7 @@ impl<T: Many> Many for Qualified<T> {
 
 fn parse_meta<T: Parse>(
     stream: &mut impl CharStream,
-    embed: impl FnOnce(String) -> T,
+    embed: impl FnOnce(SudoString) -> T,
 ) -> Parsed<Meta<T>> {
     if let Some(meta) = try_nonterminal(stream)? {
         make(match meta {

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -431,7 +431,7 @@ impl<'a> WithInfo for (Tag, &'a Spec<Command>) {
 fn match_user(user: &impl UnixUser) -> impl Fn(&UserSpecifier) -> bool + '_ {
     move |spec| match spec {
         UserSpecifier::User(id) => match_identifier(user, id),
-        UserSpecifier::Group(Identifier::Name(name)) => user.in_group_by_name(name),
+        UserSpecifier::Group(Identifier::Name(name)) => user.in_group_by_name(name.as_cstr()),
         UserSpecifier::Group(Identifier::ID(num)) => user.in_group_by_gid(*num),
         _ => todo!(), // nonunix-groups, netgroups, etc.
     }
@@ -444,7 +444,7 @@ fn in_group(user: &impl UnixUser, group: &impl UnixGroup) -> bool {
 fn match_group(group: &impl UnixGroup) -> impl Fn(&Identifier) -> bool + '_ {
     move |id| match id {
         Identifier::ID(num) => group.as_gid() == *num,
-        Identifier::Name(name) => group.try_as_name().map_or(false, |s| s == name),
+        Identifier::Name(name) => group.try_as_name().map_or(false, |s| name == s),
     }
 }
 

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -1,7 +1,7 @@
 use super::Sudoers;
 
 use super::Judgement;
-use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1};
+use crate::common::{SudoPath, HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1};
 use crate::system::time::Duration;
 /// Data types and traits that represent what the "terms and conditions" are after a succesful
 /// permission check.
@@ -9,7 +9,6 @@ use crate::system::time::Duration;
 /// The trait definitions can be part of some global crate in the future, if we support more
 /// than just the sudoers file.
 use std::collections::HashSet;
-use std::path::Path;
 
 pub trait Policy {
     fn authorization(&self) -> Authorization {
@@ -47,7 +46,7 @@ pub struct AuthorizationAllowed {
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[repr(u32)]
 pub enum DirChange<'a> {
-    Strict(Option<&'a Path>) = HARDENED_ENUM_VALUE_0,
+    Strict(Option<&'a SudoPath>) = HARDENED_ENUM_VALUE_0,
     Any = HARDENED_ENUM_VALUE_1,
 }
 
@@ -165,8 +164,8 @@ mod test {
         judge.mod_flag(|tag| tag.cwd = Some(ChDir::Any));
         assert_eq!(judge.chdir(), DirChange::Any);
         judge.mod_flag(|tag| tag.cwd = Some(ChDir::Path("/usr".into())));
-        assert_eq!(judge.chdir(), (DirChange::Strict(Some(Path::new("/usr")))));
+        assert_eq!(judge.chdir(), (DirChange::Strict(Some(&"/usr".into()))));
         judge.mod_flag(|tag| tag.cwd = Some(ChDir::Path("/bin".into())));
-        assert_eq!(judge.chdir(), (DirChange::Strict(Some(Path::new("/bin")))));
+        assert_eq!(judge.chdir(), (DirChange::Strict(Some(&"/bin".into()))));
     }
 }

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -1,3 +1,5 @@
+use std::ffi::CStr;
+
 use super::ast;
 use super::*;
 use basic_parser::{parse_eval, parse_lines, parse_string};
@@ -22,8 +24,8 @@ impl UnixUser for Named {
         dummy_cksum(self.0) == uid
     }
 
-    fn in_group_by_name(&self, name: &str) -> bool {
-        self.has_name(name)
+    fn in_group_by_name(&self, name: &CStr) -> bool {
+        self.has_name(name.to_str().unwrap())
     }
 
     fn in_group_by_gid(&self, gid: u32) -> bool {

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -1,15 +1,19 @@
 //! Various tokens
 
+use crate::common::{SudoPath, SudoString};
+
 use super::basic_parser::{Many, Token};
 use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2};
 
 #[cfg_attr(test, derive(Clone, PartialEq, Eq))]
-pub struct Username(pub String);
+pub struct Username(pub SudoString);
 
 /// A username consists of alphanumeric characters as well as "." and "-", but does not start with an underscore.
 impl Token for Username {
     fn construct(text: String) -> Result<Self, String> {
-        Ok(Username(text))
+        SudoString::new(text)
+            .map_err(|e| e.to_string())
+            .map(Username)
     }
 
     fn accept(c: char) -> bool {
@@ -318,7 +322,7 @@ impl Token for StringParameter {
 #[derive(Clone, PartialEq)]
 #[cfg_attr(test, derive(Debug, Eq))]
 pub enum ChDir {
-    Path(std::path::PathBuf),
+    Path(SudoPath),
     Any,
 }
 
@@ -331,7 +335,9 @@ impl Token for ChDir {
         } else if s.contains('*') {
             Err("path cannot contain '*'".to_string())
         } else {
-            Ok(ChDir::Path(s.into()))
+            Ok(ChDir::Path(
+                SudoPath::try_from(s).map_err(|e| e.to_string())?,
+            ))
         }
     }
 


### PR DESCRIPTION
these are versions of libstd's String and PathBuf that contain no null bytes and thus can be easily converted into CStr

SudoPath has the additional invariant that it is UTF-8 encoded. SudoPath is used to represent CWD which appears in the sudoers file. sudo-rs only accepts UTF-8 encoded sudoers files

closes #748