### PR TITLE
su CLI overhaul

### DIFF
--- a/src/su/cli.rs
+++ b/src/su/cli.rs
@@ -151,7 +151,7 @@ impl SuOptions {
                     let values: Vec<String> = list.split(',').map(str::to_string).collect();
                     sudo_options.whitelist_environment.extend(values);
                 } else {
-                    Err("no enivronment whitelist provided")?
+                    Err("no environment whitelist provided")?
                 }
 
                 Ok(())

--- a/src/su/cli.rs
+++ b/src/su/cli.rs
@@ -40,7 +40,7 @@ pub enum SuAction {
     Run,
 }
 
-type OptionSetter = &'static dyn Fn(&mut SuOptions, Option<String>) -> Result<(), String>;
+type OptionSetter = fn(&mut SuOptions, Option<String>) -> Result<(), String>;
 
 struct SuOption {
     short: char,
@@ -55,7 +55,7 @@ impl SuOptions {
             short: 'c',
             long: "command",
             takes_argument: true,
-            set: &|sudo_options, argument| {
+            set: |sudo_options, argument| {
                 if argument.is_some() {
                     sudo_options.command = argument;
                 } else {
@@ -69,7 +69,7 @@ impl SuOptions {
             short: 'g',
             long: "group",
             takes_argument: true,
-            set: &|sudo_options, argument| {
+            set: |sudo_options, argument| {
                 if let Some(value) = argument {
                     sudo_options.group.push(SudoString::from_cli_string(value));
                 } else {
@@ -83,7 +83,7 @@ impl SuOptions {
             short: 'G',
             long: "supp-group",
             takes_argument: true,
-            set: &|sudo_options, argument| {
+            set: |sudo_options, argument| {
                 if let Some(value) = argument {
                     sudo_options
                         .supp_group
@@ -99,7 +99,7 @@ impl SuOptions {
             short: 'l',
             long: "login",
             takes_argument: false,
-            set: &|sudo_options, _| {
+            set: |sudo_options, _| {
                 sudo_options.login = true;
                 Ok(())
             },
@@ -108,7 +108,7 @@ impl SuOptions {
             short: 'p',
             long: "preserve-environment",
             takes_argument: false,
-            set: &|sudo_options, _| {
+            set: |sudo_options, _| {
                 sudo_options.preserve_environment = true;
                 Ok(())
             },
@@ -117,7 +117,7 @@ impl SuOptions {
             short: 'm',
             long: "preserve-environment",
             takes_argument: false,
-            set: &|sudo_options, _| {
+            set: |sudo_options, _| {
                 sudo_options.preserve_environment = true;
                 Ok(())
             },
@@ -126,13 +126,13 @@ impl SuOptions {
             short: 'P',
             long: "pty",
             takes_argument: false,
-            set: &|_sudo_options, _| Ok(()),
+            set: |_sudo_options, _| Ok(()),
         },
         SuOption {
             short: 's',
             long: "shell",
             takes_argument: true,
-            set: &|sudo_options, argument| {
+            set: |sudo_options, argument| {
                 if let Some(path) = argument {
                     sudo_options.shell = Some(PathBuf::from(path));
                 } else {
@@ -146,7 +146,7 @@ impl SuOptions {
             short: 'w',
             long: "whitelist-environment",
             takes_argument: true,
-            set: &|sudo_options, argument| {
+            set: |sudo_options, argument| {
                 if let Some(list) = argument {
                     let values: Vec<String> = list.split(',').map(str::to_string).collect();
                     sudo_options.whitelist_environment.extend(values);
@@ -161,7 +161,7 @@ impl SuOptions {
             short: 'V',
             long: "version",
             takes_argument: false,
-            set: &|sudo_options, _| {
+            set: |sudo_options, _| {
                 sudo_options.action = SuAction::Version;
                 Ok(())
             },
@@ -170,7 +170,7 @@ impl SuOptions {
             short: 'h',
             long: "help",
             takes_argument: false,
-            set: &|sudo_options, _| {
+            set: |sudo_options, _| {
                 sudo_options.action = SuAction::Help;
                 Ok(())
             },

--- a/src/su/cli.rs
+++ b/src/su/cli.rs
@@ -1,5 +1,7 @@
 use std::{borrow::Cow, mem, path::PathBuf};
 
+use crate::common::SudoString;
+
 use super::DEFAULT_USER;
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
@@ -213,9 +215,7 @@ impl<T> IsAbsent for Vec<T> {
     }
 }
 
-use crate::common::SudoString;
-
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 struct SuOptions {
     // -c
     command: Option<String>,
@@ -239,24 +239,6 @@ struct SuOptions {
     whitelist_environment: Vec<String>,
 
     positional_args: Vec<String>,
-}
-
-impl Default for SuOptions {
-    fn default() -> Self {
-        Self {
-            command: None,
-            group: vec![],
-            help: false,
-            login: false,
-            positional_args: vec![],
-            preserve_environment: false,
-            pty: false,
-            shell: None,
-            supp_group: vec![],
-            version: false,
-            whitelist_environment: vec![],
-        }
-    }
 }
 
 type OptionSetter = fn(&mut SuOptions, Option<String>) -> Result<(), String>;

--- a/src/su/cli.rs
+++ b/src/su/cli.rs
@@ -230,7 +230,7 @@ impl SuOptions {
                         let rest = chars.as_str();
 
                         if option.takes_argument {
-                            let next_arg = if rest.trim().is_empty() {
+                            let next_arg = if rest.is_empty() {
                                 arg_iter.next()
                             } else {
                                 Some(rest.to_string())
@@ -470,5 +470,36 @@ mod tests {
         };
         assert_eq!(expected, parse(&["-V"]));
         assert_eq!(expected, parse(&["--version"]));
+    }
+
+    #[test]
+    fn short_flag_whitespace() {
+        let expected = SuOptions {
+            action: SuAction::Run,
+            group: vec![" ".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(expected, parse(&["-g "]));
+    }
+
+    #[test]
+    fn short_flag_whitespace_positional_argument() {
+        let expected = SuOptions {
+            action: SuAction::Run,
+            group: vec![" ".to_string()],
+            user: "ghost".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(expected, parse(&["-g ", "ghost"]));
+    }
+
+    #[test]
+    fn long_flag_equal_whitespace() {
+        let expected = SuOptions {
+            action: SuAction::Run,
+            group: vec![" ".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(expected, parse(&["--group= "]));
     }
 }

--- a/src/su/context.rs
+++ b/src/su/context.rs
@@ -14,7 +14,7 @@ use crate::exec::RunOptions;
 use crate::log::user_warn;
 use crate::system::{Group, Process, User};
 
-use super::cli::SuOptions;
+use super::cli::SuRunOptions;
 
 const VALID_LOGIN_SHELLS_LIST: &str = "/etc/shells";
 const FALLBACK_LOGIN_SHELL: &str = "/bin/sh";
@@ -27,7 +27,7 @@ const PATH_DEFAULT_ROOT: &str = env!("SU_PATH_DEFAULT_ROOT");
 pub(crate) struct SuContext {
     command: PathBuf,
     arguments: Vec<String>,
-    options: SuOptions,
+    options: SuRunOptions,
     pub(crate) environment: Environment,
     user: User,
     requesting_user: User,
@@ -49,7 +49,7 @@ fn is_restricted(shell: &Path) -> bool {
 }
 
 impl SuContext {
-    pub(crate) fn from_env(options: SuOptions) -> Result<SuContext, Error> {
+    pub(crate) fn from_env(options: SuRunOptions) -> Result<SuContext, Error> {
         let process = crate::system::Process::new();
 
         // resolve environment, reset if this is a login
@@ -253,14 +253,20 @@ impl RunOptions for SuContext {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{common::Error, su::cli::SuOptions};
+    use crate::{
+        common::Error,
+        su::cli::{SuAction, SuRunOptions},
+    };
 
     use super::SuContext;
 
-    fn get_options(args: &[&str]) -> SuOptions {
+    fn get_options(args: &[&str]) -> SuRunOptions {
         let mut args = args.iter().map(|s| s.to_string()).collect::<Vec<String>>();
         args.insert(0, "/bin/su".to_string());
-        SuOptions::parse_arguments(args).unwrap()
+        SuAction::parse_arguments(args)
+            .unwrap()
+            .try_into_run()
+            .unwrap()
     }
 
     #[test]

--- a/test-framework/sudo-compliance-tests/src/su/cli.rs
+++ b/test-framework/sudo-compliance-tests/src/su/cli.rs
@@ -53,3 +53,16 @@ echo "${@}""#;
 
     Ok(())
 }
+
+#[test]
+fn flag_after_positional_argument() -> Result<()> {
+    let expected = "-bash";
+    let env = Env("").build()?;
+    let stdout = Command::new("env")
+        .args(["su", "-c", "echo $0", "root", "-l"])
+        .output(&env)?
+        .stdout()?;
+
+    assert_eq!(expected, stdout);
+    Ok(())
+}

--- a/test-framework/sudo-compliance-tests/src/su/flag_command.rs
+++ b/test-framework/sudo-compliance-tests/src/su/flag_command.rs
@@ -54,3 +54,19 @@ fn when_specified_more_than_once_only_last_value_is_used() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn positional_arguments_are_not_passed_to_command() -> Result<()> {
+    let env = Env("").build()?;
+
+    let argss = [["-c", "echo", "root", "a"], ["root", "-c", "echo", "a"]];
+
+    for args in argss {
+        let output = Command::new("su").args(args).output(&env)?;
+        let stdout = output.stdout()?;
+
+        assert!(stdout.trim().is_empty());
+    }
+
+    Ok(())
+}

--- a/test-framework/sudo-compliance-tests/src/su/flag_login.rs
+++ b/test-framework/sudo-compliance-tests/src/su/flag_login.rs
@@ -136,7 +136,7 @@ fn term_var_in_invoking_users_env_is_preserved() -> Result<()> {
 }
 
 #[test]
-#[ignore = "intentionally non-compliant"]
+#[ignore = "wontfix"]
 fn may_be_specified_more_than_once_without_change_in_semantics() -> Result<()> {
     let env = Env("").build()?;
 

--- a/test-framework/sudo-compliance-tests/src/su/flag_login.rs
+++ b/test-framework/sudo-compliance-tests/src/su/flag_login.rs
@@ -136,6 +136,7 @@ fn term_var_in_invoking_users_env_is_preserved() -> Result<()> {
 }
 
 #[test]
+#[ignore = "intentionally non-compliant"]
 fn may_be_specified_more_than_once_without_change_in_semantics() -> Result<()> {
     let env = Env("").build()?;
 

--- a/test-framework/sudo-compliance-tests/src/su/flag_preserve_environment.rs
+++ b/test-framework/sudo-compliance-tests/src/su/flag_preserve_environment.rs
@@ -72,6 +72,7 @@ fn uses_shell_env_var_when_flag_preserve_environment_is_present() -> Result<()> 
 }
 
 #[test]
+#[ignore = "intentionally non-compliant"]
 fn may_be_specified_more_than_once_without_change_in_semantics() -> Result<()> {
     let env = Env("").build()?;
 

--- a/test-framework/sudo-compliance-tests/src/su/flag_preserve_environment.rs
+++ b/test-framework/sudo-compliance-tests/src/su/flag_preserve_environment.rs
@@ -72,7 +72,7 @@ fn uses_shell_env_var_when_flag_preserve_environment_is_present() -> Result<()> 
 }
 
 #[test]
-#[ignore = "intentionally non-compliant"]
+#[ignore = "wontfix"]
 fn may_be_specified_more_than_once_without_change_in_semantics() -> Result<()> {
     let env = Env("").build()?;
 

--- a/test-framework/sudo-compliance-tests/src/su/flag_shell.rs
+++ b/test-framework/sudo-compliance-tests/src/su/flag_shell.rs
@@ -355,3 +355,24 @@ echo $0";
 
     Ok(())
 }
+
+#[test]
+fn positional_arguments_are_passed_to_shell() -> Result<()> {
+    let shell_path = "/root/my-shell";
+    let args = ["a", "b"];
+    let shell = "#!/bin/sh
+echo ${@}";
+    let env = Env("")
+        .file(shell_path, TextFile(shell).chmod("100"))
+        .build()?;
+
+    let actual = Command::new("su")
+        .args(["-s", shell_path, "root"])
+        .args(args)
+        .output(&env)?
+        .stdout()?;
+
+    assert_eq!(args.join(" "), actual);
+
+    Ok(())
+}


### PR DESCRIPTION
this PR:

- refactors su's command line parsing to avoid panicky slicing operations
- fixes #790 
- fixes #791
- adds support for the `--` separator
- makes the CLI more strict, namely:
  - repeated boolean flags are rejected, e.g. `su -l -l` is rejected
  - flags unrelated to a working mode are rejected, e.g. `su --version root` is rejected

this PR is best reviewed commit by commit