### PR TITLE
miscellaneous refactors

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -1,5 +1,5 @@
 use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2};
-use crate::system::{hostname, Group, Process, User};
+use crate::system::{Group, Hostname, Process, User};
 use std::path::PathBuf;
 
 use super::{
@@ -41,7 +41,7 @@ pub struct Context {
     pub non_interactive: bool,
     pub use_session_records: bool,
     // system
-    pub hostname: String,
+    pub hostname: Hostname,
     pub current_user: User,
     pub process: Process,
     // policy
@@ -61,7 +61,7 @@ impl Context {
         sudo_options: OptionsForContext,
         path: String,
     ) -> Result<Context, Error> {
-        let hostname = hostname();
+        let hostname = Hostname::resolve();
         let current_user = resolve_current_user()?;
         let (target_user, target_group) =
             resolve_target_user_and_group(&sudo_options.user, &sudo_options.group, &current_user)?;
@@ -95,7 +95,7 @@ impl Context {
 
 #[cfg(test)]
 mod tests {
-    use crate::{sudo::SudoAction, system::hostname};
+    use crate::{sudo::SudoAction, system::Hostname};
     use std::collections::HashMap;
 
     use super::Context;
@@ -115,7 +115,7 @@ mod tests {
 
         assert_eq!(context.command.command.to_str().unwrap(), "/usr/bin/echo");
         assert_eq!(context.command.arguments, ["hello"]);
-        assert_eq!(context.hostname, hostname());
+        assert_eq!(context.hostname, Hostname::resolve());
         assert_eq!(context.target_user.uid, 0);
     }
 }

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -2,9 +2,10 @@ use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_
 use crate::system::{Group, Hostname, Process, User};
 use std::path::PathBuf;
 
+use super::resolve::CurrentUser;
 use super::{
     command::CommandAndArguments,
-    resolve::{resolve_current_user, resolve_launch_and_shell, resolve_target_user_and_group},
+    resolve::{resolve_launch_and_shell, resolve_target_user_and_group},
     Error,
 };
 
@@ -42,7 +43,7 @@ pub struct Context {
     pub use_session_records: bool,
     // system
     pub hostname: Hostname,
-    pub current_user: User,
+    pub current_user: CurrentUser,
     pub process: Process,
     // policy
     pub use_pty: bool,
@@ -62,7 +63,7 @@ impl Context {
         path: String,
     ) -> Result<Context, Error> {
         let hostname = Hostname::resolve();
-        let current_user = resolve_current_user()?;
+        let current_user = CurrentUser::resolve()?;
         let (target_user, target_group) =
             resolve_target_user_and_group(&sudo_options.user, &sudo_options.group, &current_user)?;
         let (launch, shell) = resolve_launch_and_shell(&sudo_options, &current_user, &target_user);

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -2,6 +2,7 @@ use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_
 use crate::system::{Group, Hostname, Process, User};
 use std::path::PathBuf;
 
+use super::ne_string::NonEmptyString;
 use super::resolve::CurrentUser;
 use super::{
     command::CommandAndArguments,
@@ -19,14 +20,14 @@ pub enum ContextAction {
 // this is a bit of a hack to keep the existing `Context` API working
 pub struct OptionsForContext {
     pub chdir: Option<PathBuf>,
-    pub group: Option<String>,
+    pub group: Option<NonEmptyString>,
     pub login: bool,
     pub non_interactive: bool,
     pub positional_args: Vec<String>,
     pub reset_timestamp: bool,
     pub shell: bool,
     pub stdin: bool,
-    pub user: Option<String>,
+    pub user: Option<NonEmptyString>,
     pub action: ContextAction,
 }
 

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -1,4 +1,4 @@
-use crate::pam::PamError;
+use crate::{pam::PamError, system::Hostname};
 use std::{borrow::Cow, fmt, path::PathBuf};
 
 #[derive(Debug)]
@@ -7,7 +7,7 @@ pub enum Error {
     NotAllowed {
         username: String,
         command: Cow<'static, str>,
-        hostname: String,
+        hostname: Hostname,
         other_user: Option<String>,
     },
     SelfCheck,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -9,6 +9,7 @@ pub mod bin_serde;
 pub mod command;
 pub mod context;
 pub mod error;
+pub mod ne_string;
 pub mod resolve;
 
 pub type Environment = HashMap<OsString, OsString>;

--- a/src/common/ne_string.rs
+++ b/src/common/ne_string.rs
@@ -1,0 +1,45 @@
+use core::{fmt, ops};
+
+/// `String` but guaranteed to not be empty
+#[derive(PartialEq)]
+pub struct NonEmptyString {
+    inner: String,
+}
+
+#[cfg(test)]
+impl From<&'_ str> for NonEmptyString {
+    fn from(value: &str) -> Self {
+        Self::new(value.to_string()).unwrap()
+    }
+}
+
+#[cfg(test)]
+impl PartialEq<&'_ NonEmptyString> for str {
+    fn eq(&self, other: &&NonEmptyString) -> bool {
+        self == other.inner
+    }
+}
+
+impl fmt::Debug for NonEmptyString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+impl ops::Deref for NonEmptyString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl NonEmptyString {
+    pub fn new(string: String) -> Option<Self> {
+        if string.is_empty() {
+            None
+        } else {
+            Some(Self { inner: string })
+        }
+    }
+}

--- a/src/common/resolve.rs
+++ b/src/common/resolve.rs
@@ -1,6 +1,7 @@
 use crate::system::{Group, User};
+use core::fmt;
 use std::{
-    env, fs, io,
+    env, fs, io, ops,
     os::unix::prelude::MetadataExt,
     path::{Path, PathBuf},
     str::FromStr,
@@ -29,8 +30,42 @@ impl<'a, T: FromStr> NameOrId<'a, T> {
     }
 }
 
-pub fn resolve_current_user() -> Result<User, Error> {
-    User::real()?.ok_or(Error::UserNotFound("current user".to_string()))
+#[derive(Clone)]
+pub struct CurrentUser {
+    inner: User,
+}
+
+impl From<CurrentUser> for User {
+    fn from(value: CurrentUser) -> Self {
+        value.inner
+    }
+}
+
+impl fmt::Debug for CurrentUser {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CurrentUser").field(&self.inner).finish()
+    }
+}
+
+impl ops::Deref for CurrentUser {
+    type Target = User;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl CurrentUser {
+    #[cfg(test)]
+    pub fn fake(user: User) -> Self {
+        Self { inner: user }
+    }
+
+    pub fn resolve() -> Result<Self, Error> {
+        Ok(Self {
+            inner: User::real()?.ok_or(Error::UserNotFound("current user".to_string()))?,
+        })
+    }
 }
 
 type Shell = Option<PathBuf>;
@@ -56,7 +91,7 @@ pub(super) fn resolve_launch_and_shell(
 pub(crate) fn resolve_target_user_and_group(
     target_user_name_or_id: &Option<String>,
     target_group_name_or_id: &Option<String>,
-    current_user: &User,
+    current_user: &CurrentUser,
 ) -> Result<(User, Group), Error> {
     // resolve user name or #<id> to a user
     let mut target_user =
@@ -77,7 +112,7 @@ pub(crate) fn resolve_target_user_and_group(
     match (&target_user_name_or_id, &target_group_name_or_id) {
         // when -g is specified, but -u is not specified default -u to the current user
         (None, Some(_)) => {
-            target_user = Some(current_user.clone());
+            target_user = Some(current_user.clone().into());
         }
         // when -u is specified but -g is not specified, default -g to the primary group of the specified user
         (Some(_), None) => {
@@ -202,10 +237,9 @@ pub(crate) fn expand_tilde_in_path(
 mod tests {
     use std::path::PathBuf;
 
-    use super::{
-        is_valid_executable, resolve_current_user, resolve_path, resolve_target_user_and_group,
-        NameOrId,
-    };
+    use crate::common::resolve::CurrentUser;
+
+    use super::{is_valid_executable, resolve_path, resolve_target_user_and_group, NameOrId};
 
     #[test]
     fn test_resolve_path() {
@@ -241,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_resolve_target_user_and_group() {
-        let current_user = resolve_current_user().unwrap();
+        let current_user = CurrentUser::resolve().unwrap();
 
         // fallback to root
         let (user, group) = resolve_target_user_and_group(&None, &None, &current_user).unwrap();

--- a/src/su/context.rs
+++ b/src/su/context.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::common::resolve::{is_valid_executable, resolve_current_user};
+use crate::common::resolve::{is_valid_executable, CurrentUser};
 use crate::common::{error::Error, Environment};
 use crate::exec::RunOptions;
 use crate::log::user_warn;
@@ -27,7 +27,7 @@ pub(crate) struct SuContext {
     options: SuOptions,
     pub(crate) environment: Environment,
     user: User,
-    requesting_user: User,
+    requesting_user: CurrentUser,
     group: Group,
     pub(crate) process: Process,
 }
@@ -72,7 +72,7 @@ impl SuContext {
             }
         }
 
-        let requesting_user = resolve_current_user()?;
+        let requesting_user = CurrentUser::resolve()?;
 
         // resolve target user
         let mut user = User::from_name(&options.user)?

--- a/src/sudo/cli/mod.rs
+++ b/src/sudo/cli/mod.rs
@@ -2,7 +2,10 @@
 
 use std::{borrow::Cow, mem, path::PathBuf};
 
-use crate::common::context::{ContextAction, OptionsForContext};
+use crate::common::{
+    context::{ContextAction, OptionsForContext},
+    ne_string::NonEmptyString,
+};
 
 pub mod help;
 
@@ -171,9 +174,9 @@ pub struct SudoValidateOptions {
     // -S
     pub stdin: bool,
     // -g
-    pub group: Option<String>,
+    pub group: Option<NonEmptyString>,
     // -u
-    pub user: Option<String>,
+    pub user: Option<NonEmptyString>,
 }
 
 impl TryFrom<SudoOptions> for SudoValidateOptions {
@@ -213,9 +216,9 @@ pub struct SudoEditOptions {
     // -D
     pub chdir: Option<PathBuf>,
     // -g
-    pub group: Option<String>,
+    pub group: Option<NonEmptyString>,
     // -u
-    pub user: Option<String>,
+    pub user: Option<NonEmptyString>,
     pub positional_args: Vec<String>,
 }
 
@@ -265,11 +268,11 @@ pub struct SudoListOptions {
     // -S
     pub stdin: bool,
     // -g
-    pub group: Option<String>,
+    pub group: Option<NonEmptyString>,
     // -U
     pub other_user: Option<String>,
     // -u
-    pub user: Option<String>,
+    pub user: Option<NonEmptyString>,
 
     pub positional_args: Vec<String>,
 }
@@ -323,9 +326,9 @@ pub struct SudoRunOptions {
     // -D
     pub chdir: Option<PathBuf>,
     // -g
-    pub group: Option<String>,
+    pub group: Option<NonEmptyString>,
     // -u
-    pub user: Option<String>,
+    pub user: Option<NonEmptyString>,
     // VAR=value
     pub env_var_list: Vec<(String, String)>,
     // -i
@@ -393,7 +396,7 @@ struct SudoOptions {
     // -D
     chdir: Option<PathBuf>,
     // -g
-    group: Option<String>,
+    group: Option<NonEmptyString>,
     // -i
     login: bool,
     // -n
@@ -407,7 +410,7 @@ struct SudoOptions {
     // -S
     stdin: bool,
     // -u
-    user: Option<String>,
+    user: Option<NonEmptyString>,
 
     // additional environment
     env_var_list: Vec<(String, String)>,
@@ -661,13 +664,19 @@ impl SudoOptions {
                         // options.preserve_env = value.split(',').map(str::to_string).collect()
                     }
                     "-g" | "--group" => {
-                        options.group = Some(value);
+                        options.group = Some(
+                            NonEmptyString::new(value)
+                                .ok_or("group argument cannot be an empty string")?,
+                        );
                     }
                     "-U" | "--other-user" => {
                         options.other_user = Some(value);
                     }
                     "-u" | "--user" => {
-                        options.user = Some(value);
+                        options.user = Some(
+                            NonEmptyString::new(value)
+                                .ok_or("user argument cannot be an empty string")?,
+                        );
                     }
                     _option => {
                         Err("invalid option provided")?;

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -3,7 +3,7 @@ use crate::sudo::{
     cli::{SudoAction, SudoRunOptions},
     env::environment::get_target_environment,
 };
-use crate::system::{Group, Process, User};
+use crate::system::{Group, Hostname, Process, User};
 use std::collections::{HashMap, HashSet};
 
 const TESTS: &str = "
@@ -117,7 +117,7 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
     };
 
     Context {
-        hostname: "test-ubuntu".to_string(),
+        hostname: Hostname::fake("test-ubuntu"),
         command,
         current_user: current_user.clone(),
         target_user: if sudo_options.user.as_deref() == Some("test") {

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -1,3 +1,4 @@
+use crate::common::resolve::CurrentUser;
 use crate::common::{CommandAndArguments, Context, Environment};
 use crate::sudo::{
     cli::{SudoAction, SudoRunOptions},
@@ -80,7 +81,7 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
     let command =
         CommandAndArguments::build_from_args(None, sudo_options.positional_args.clone(), &path);
 
-    let current_user = User {
+    let current_user = CurrentUser::fake(User {
         uid: 1000,
         gid: 1000,
         name: "test".to_string(),
@@ -89,7 +90,7 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
         shell: "/bin/sh".into(),
         passwd: String::new(),
         groups: vec![],
-    };
+    });
 
     let current_group = Group {
         gid: 1000,
@@ -121,7 +122,7 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
         command,
         current_user: current_user.clone(),
         target_user: if sudo_options.user.as_deref() == Some("test") {
-            current_user
+            current_user.into()
         } else {
             root_user
         },

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
-use crate::common::{resolve::resolve_current_user, Context, Error};
+use crate::common::resolve::CurrentUser;
+use crate::common::{Context, Error};
 use crate::log::dev_info;
 use crate::system::timestamp::RecordScope;
 use crate::system::User;
@@ -59,7 +60,7 @@ impl PolicyPlugin for SudoersPolicy {
         context: &Context,
     ) -> Result<Self::Policy, Error> {
         Ok(pre.check(
-            &context.current_user,
+            &*context.current_user,
             &context.hostname,
             crate::sudoers::Request {
                 user: &context.target_user,
@@ -95,17 +96,17 @@ fn sudo_process() -> Result<(), Error> {
                 std::process::exit(0);
             }
             SudoAction::RemoveTimestamp(_) => {
-                let user = resolve_current_user()?;
+                let user = CurrentUser::resolve()?;
                 let mut record_file =
-                    SessionRecordFile::open_for_user(user.uid, Duration::seconds(0))?;
+                    SessionRecordFile::open_for_user(&user, Duration::seconds(0))?;
                 record_file.reset()?;
                 Ok(())
             }
             SudoAction::ResetTimestamp(_) => {
                 if let Some(scope) = RecordScope::for_process(&Process::new()) {
-                    let user = resolve_current_user()?;
+                    let user = CurrentUser::resolve()?;
                     let mut record_file =
-                        SessionRecordFile::open_for_user(user.uid, Duration::seconds(0))?;
+                        SessionRecordFile::open_for_user(&user, Duration::seconds(0))?;
                     record_file.disable(scope, None)?;
                 }
                 Ok(())

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -3,6 +3,7 @@ use std::process::exit;
 
 use super::cli::{SudoRunOptions, SudoValidateOptions};
 use crate::common::context::OptionsForContext;
+use crate::common::resolve::CurrentUser;
 use crate::common::{resolve::expand_tilde_in_path, Context, Environment, Error};
 use crate::exec::{ExecOutput, ExitReason};
 use crate::log::{auth_info, auth_warn};
@@ -145,7 +146,7 @@ impl<Policy: PolicyPlugin, Auth: AuthPlugin> Pipeline<Policy, Auth> {
             context.use_session_records,
             scope,
             context.current_user.uid,
-            context.current_user.uid,
+            &context.current_user,
             prior_validity,
         );
         self.authenticator.init(context)?;
@@ -216,7 +217,7 @@ fn determine_auth_status(
     use_session_records: bool,
     record_for: Option<RecordScope>,
     auth_uid: UserId,
-    current_user: UserId,
+    current_user: &CurrentUser,
     prior_validity: Duration,
 ) -> AuthStatus {
     if !must_policy_authenticate {

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -78,7 +78,7 @@ impl Pipeline<SudoersPolicy, PamAuthenticator<CLIConverser>> {
             target_group: &context.target_group,
         };
         let judgement =
-            sudoers.check_list_permission(&context.current_user, &context.hostname, list_request);
+            sudoers.check_list_permission(&*context.current_user, &context.hostname, list_request);
         match judgement.authorization() {
             Authorization::Allowed(auth) => {
                 self.auth_and_update_record_file(context, auth)?;

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -85,7 +85,7 @@ fn permission_test() {
             let (Sudoers { rules,aliases,settings }, _) = analyze(Path::new("/etc/fakesudoers"), sudoer![$($sudo),*]);
             let cmdvec = $command.split_whitespace().map(String::from).collect::<Vec<_>>();
             let req = Request { user: $req.0, group: $req.1, command: &realpath(cmdvec[0].as_ref()), arguments: &cmdvec[1..].to_vec() };
-            assert_eq!(Sudoers { rules, aliases, settings }.check(&Named($user), $server, req).flags, None);
+            assert_eq!(Sudoers { rules, aliases, settings }.check(&Named($user), &system::Hostname::fake($server), req).flags, None);
         }
     }
 
@@ -94,7 +94,7 @@ fn permission_test() {
             let (Sudoers { rules,aliases,settings }, _) = analyze(Path::new("/etc/fakesudoers"), sudoer![$($sudo),*]);
             let cmdvec = $command.split_whitespace().map(String::from).collect::<Vec<_>>();
             let req = Request { user: $req.0, group: $req.1, command: &realpath(cmdvec[0].as_ref()), arguments: &cmdvec[1..].to_vec() };
-            let result = Sudoers { rules, aliases, settings }.check(&Named($user), $server, req).flags;
+            let result = Sudoers { rules, aliases, settings }.check(&Named($user), &system::Hostname::fake($server), req).flags;
             assert!(!result.is_none());
             $(
                 let result = result.unwrap();

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1,9 +1,11 @@
+use core::fmt;
 // TODO: remove unused attribute when system is cleaned up
 use std::{
     collections::BTreeSet,
     ffi::{c_uint, CStr, CString},
     io,
     mem::MaybeUninit,
+    ops,
     os::{
         fd::AsRawFd,
         unix::{self, prelude::OsStrExt},
@@ -144,25 +146,63 @@ pub fn setsid() -> io::Result<ProcessId> {
     cerr(unsafe { libc::setsid() })
 }
 
-pub fn hostname() -> String {
-    // see `man 2 gethostname`
-    const MAX_HOST_NAME_SIZE_ACCORDING_TO_SUSV2: libc::c_long = 255;
+#[derive(Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct Hostname {
+    inner: String,
+}
 
-    // POSIX.1 systems limit hostnames to `HOST_NAME_MAX` bytes
-    // not including null-byte in the count
-    let max_hostname_size =
-        sysconf(libc::_SC_HOST_NAME_MAX).unwrap_or(MAX_HOST_NAME_SIZE_ACCORDING_TO_SUSV2) as usize;
+impl fmt::Debug for Hostname {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Hostname").field(&self.inner).finish()
+    }
+}
 
-    let buffer_size = max_hostname_size + 1 /* null byte delimiter */ ;
-    let mut buf = vec![0; buffer_size];
+impl fmt::Display for Hostname {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.inner)
+    }
+}
 
-    match cerr(unsafe { libc::gethostname(buf.as_mut_ptr(), buffer_size) }) {
-        Ok(_) => unsafe { string_from_ptr(buf.as_ptr()) },
+impl ops::Deref for Hostname {
+    type Target = str;
 
-        // ENAMETOOLONG is returned when hostname is greater than `buffer_size`
-        Err(_) => {
-            // but we have chosen a `buffer_size` larger than `max_hostname_size` so no truncation error is possible
-            panic!("Unexpected error while retrieving hostname, this should not happen");
+    fn deref(&self) -> &str {
+        &self.inner
+    }
+}
+
+impl Hostname {
+    #[cfg(test)]
+    pub fn fake(hostname: &str) -> Self {
+        Self {
+            inner: hostname.to_string(),
+        }
+    }
+
+    pub fn resolve() -> Self {
+        // see `man 2 gethostname`
+        const MAX_HOST_NAME_SIZE_ACCORDING_TO_SUSV2: libc::c_long = 255;
+
+        // POSIX.1 systems limit hostnames to `HOST_NAME_MAX` bytes
+        // not including null-byte in the count
+        let max_hostname_size = sysconf(libc::_SC_HOST_NAME_MAX)
+            .unwrap_or(MAX_HOST_NAME_SIZE_ACCORDING_TO_SUSV2)
+            as usize;
+
+        let buffer_size = max_hostname_size + 1 /* null byte delimiter */ ;
+        let mut buf = vec![0; buffer_size];
+
+        match cerr(unsafe { libc::gethostname(buf.as_mut_ptr(), buffer_size) }) {
+            Ok(_) => Self {
+                inner: unsafe { string_from_ptr(buf.as_ptr()) },
+            },
+
+            // ENAMETOOLONG is returned when hostname is greater than `buffer_size`
+            Err(_) => {
+                // but we have chosen a `buffer_size` larger than `max_hostname_size` so no truncation error is possible
+                panic!("Unexpected error while retrieving hostname, this should not happen");
+            }
         }
     }
 }

--- a/src/system/timestamp.rs
+++ b/src/system/timestamp.rs
@@ -4,7 +4,10 @@ use std::{
     path::PathBuf,
 };
 
-use crate::log::{auth_info, auth_warn};
+use crate::{
+    common::resolve::CurrentUser,
+    log::{auth_info, auth_warn},
+};
 
 use super::{
     audit::secure_open_cookie_file,
@@ -44,10 +47,11 @@ pub struct SessionRecordFile {
 impl SessionRecordFile {
     const BASE_PATH: &'static str = "/var/run/sudo-rs/ts";
 
-    pub fn open_for_user(user: UserId, timeout: Duration) -> io::Result<Self> {
+    pub fn open_for_user(user: &CurrentUser, timeout: Duration) -> io::Result<Self> {
+        let uid = user.uid;
         let mut path = PathBuf::from(Self::BASE_PATH);
-        path.push(user.to_string());
-        SessionRecordFile::new(user, secure_open_cookie_file(&path)?, timeout)
+        path.push(uid.to_string());
+        SessionRecordFile::new(uid, secure_open_cookie_file(&path)?, timeout)
     }
 
     const FILE_VERSION: u16 = 1;


### PR DESCRIPTION
mainly adds newtypes to prevent:
- creating an "invoking user" from thin air
- creating a "hostname" from thin air
- CLI arguments being empty strings

see individual commits for details

this PR depends on #789 so it has been opened against that PR branch to avoiding polluting the commit list shown in this PR. once PR789 has been merged this should be rebased against master.