### PR TITLE
fix clippy warnings

### DIFF
--- a/src/common/command.rs
+++ b/src/common/command.rs
@@ -63,10 +63,7 @@ impl CommandAndArguments {
                 arguments = vec!["-c".to_string(), escaped(arguments)]
             }
         } else {
-            command = arguments
-                .get(0)
-                .map(|s| s.into())
-                .unwrap_or_else(PathBuf::new);
+            command = arguments.get(0).map(|s| s.into()).unwrap_or_default();
             arguments.remove(0);
 
             // remember the original binary name before resolving symlinks; this is not


### PR DESCRIPTION
something changed recently on the stable channel that created this warning. this fixes CI and should prevent a bunch of PR from failing the CI clippy check