### PR TITLE
improve pty error

### DIFF
--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -266,7 +266,7 @@ fn get_pty() -> io::Result<Pty> {
 
     let pty = Pty::open().map_err(|err| {
         dev_error!("cannot allocate pty: {err}");
-        err
+        io::Error::new(io::ErrorKind::NotFound, "unable to open pty")
     })?;
 
     let euid = User::effective_uid();


### PR DESCRIPTION
This make it clear that the error that occurs when a PTY cannot be opened pertains to the PTY, and not to the command itself, i.e. it will produce:

```
sudo-rs: cannot execute '/usr/bin/ls': unable to open pty
```