### PR TITLE
To add a `SAFETY` comment to the now function

### DIFF
--- a/src/system/time.rs
+++ b/src/system/time.rs
@@ -23,6 +23,8 @@ impl SystemTime {
         crate::cutils::cerr(unsafe {
             libc::clock_gettime(libc::CLOCK_BOOTTIME, spec.as_mut_ptr())
         })?;
+        // SAFETY: The `libc::clock_gettime` will correctly initialize `spec`, 
+        // otherwise it will return early with the `?` operator.
         let spec = unsafe { spec.assume_init() };
         Ok(spec.into())
     }

--- a/src/system/time.rs
+++ b/src/system/time.rs
@@ -23,7 +23,7 @@ impl SystemTime {
         crate::cutils::cerr(unsafe {
             libc::clock_gettime(libc::CLOCK_BOOTTIME, spec.as_mut_ptr())
         })?;
-        // SAFETY: The `libc::clock_gettime` will correctly initialize `spec`, 
+        // SAFETY: The `libc::clock_gettime` will correctly initialize `spec`,
         // otherwise it will return early with the `?` operator.
         let spec = unsafe { spec.assume_init() };
         Ok(spec.into())


### PR DESCRIPTION
The `unsafe` block should include necessary comments to complete the safety abstraction.

In the implementation of the `now` function, necessary `SAFETY` comments should be added to explain its safety, with particular emphasis on the fact that `libc::clock_gettime` initializes the `spec`.