### PR TITLE
Fix #824 syslog writer panic

### DIFF
--- a/src/log/syslog.rs
+++ b/src/log/syslog.rs
@@ -105,10 +105,10 @@ impl Log for Syslog {
 
 #[cfg(test)]
 mod tests {
+    use log::Log;
     use std::fmt::Write;
 
     use super::{SysLogWriter, Syslog, FACILITY};
-    use log::Log;
 
     #[test]
     fn can_write_to_syslog() {
@@ -120,7 +120,6 @@ mod tests {
 
         logger.log(&record);
     }
-
 
     #[test]
     fn can_handle_multiple_writes() {


### PR DESCRIPTION
See #824 

The `Write` trait implementation of  `SysLogWriter` did not correctly handle writing multiple messages. The buffer was incorrectly considered empty on each call. Fixed by subtracting the current buffer cursor of the message limit (line 53).