### PR TITLE
Make `sigaction` handling more portable

### DIFF
--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -894,3 +894,10 @@ mod tests {
         assert_eq!(status.exit_status(), Some(0));
     }
 }
+
+pub fn make_zeroed_sigaction() -> libc::sigaction {
+    // SAFETY: since sigaction is a C struct, all-zeroes is a valid representation
+    // We cannot use a "literal struct" initialization method since the exact representation
+    // of libc::sigaction is not fixed, see e.g. https://github.com/memorysafety/sudo-rs/issues/829
+    unsafe { std::mem::zeroed() }
+}

--- a/src/system/signal/set.rs
+++ b/src/system/signal/set.rs
@@ -1,4 +1,4 @@
-use crate::cutils::cerr;
+use crate::{cutils::cerr, system::make_zeroed_sigaction};
 
 use super::{handler::SignalHandlerBehavior, SignalNumber};
 
@@ -30,10 +30,7 @@ impl SignalAction {
             }
         };
 
-        // SAFETY: since sigaction is a C struct, all-zeroes is a valid representation
-        // We cannot use a "literal struct" initialization method since the exact representation
-        // of libc::sigaction is not fixed, see e.g. https://github.com/memorysafety/sudo-rs/issues/829
-        let mut raw: libc::sigaction = unsafe { std::mem::zeroed() };
+        let mut raw: libc::sigaction = make_zeroed_sigaction();
         raw.sa_sigaction = sa_sigaction;
         raw.sa_mask = sa_mask.raw;
         raw.sa_flags = sa_flags;

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -20,7 +20,10 @@ use libc::{
 };
 
 use super::{TermSize, Terminal};
-use crate::{cutils::cerr, system::interface::ProcessId};
+use crate::{
+    cutils::cerr,
+    system::{interface::ProcessId, make_zeroed_sigaction},
+};
 
 const INPUT_FLAGS: tcflag_t = IGNPAR
     | PARMRK
@@ -65,8 +68,7 @@ fn tcsetattr_nobg(fd: c_int, flags: c_int, tp: *const termios) -> io::Result<()>
     let mut original_action = MaybeUninit::<sigaction>::uninit();
 
     let action = {
-        // SAFETY: since sigaction is a C struct, all-zeroes is a valid representation
-        let mut raw: libc::sigaction = unsafe { std::mem::zeroed() };
+        let mut raw: libc::sigaction = make_zeroed_sigaction();
         // Call `on_sigttou` if `SIGTTOU` arrives.
         raw.sa_sigaction = on_sigttou as sighandler_t;
         // Exclude any other signals from the set
@@ -229,8 +231,7 @@ impl UserTerm {
         let mut original_action = MaybeUninit::<sigaction>::uninit();
 
         let action = {
-            // SAFETY: since sigaction is a C struct, all-zeroes is a valid representation
-            let mut raw: libc::sigaction = unsafe { std::mem::zeroed() };
+            let mut raw: libc::sigaction = make_zeroed_sigaction();
             // Call `on_sigttou` if `SIGTTOU` arrives.
             raw.sa_sigaction = on_sigttou as sighandler_t;
             // Exclude any other signals from the set


### PR DESCRIPTION
Closing #829.

Note that `system/signal/set.rs` has a light-weigth `SignalAction` wrapper, which it probably would be wise to use in `term/user_term.rs`, but that would be a bigger change and (given that that latter routine is more or less a straight port of original sudo code), this PR is a conservative update to avoid breaking things.