### PR TITLE
Fix clippy diagnostics

### DIFF
--- a/src/exec/use_pty/pipe/ring_buffer.rs
+++ b/src/exec/use_pty/pipe/ring_buffer.rs
@@ -25,6 +25,8 @@ impl RingBuffer {
         self.len == self.storage.len()
     }
 
+    // rustc 1.77.1 clippy gives false diagnostics, https://github.com/rust-lang/rust-clippy/issues/12519
+    #[allow(clippy::unused_io_amount)]
     pub(super) fn insert<R: Read>(&mut self, read: &mut R) -> io::Result<usize> {
         let inserted_len = if self.is_empty() {
             // Case 1.1. The buffer is empty, meaning that there are two unfilled slices in
@@ -61,6 +63,8 @@ impl RingBuffer {
         self.len == 0
     }
 
+    // rustc 1.77.1 clippy gives false diagnostics, https://github.com/rust-lang/rust-clippy/issues/12519
+    #[allow(clippy::unused_io_amount)]
     pub(super) fn remove<W: Write>(&mut self, write: &mut W) -> io::Result<usize> {
         let removed_len = if self.is_full() {
             // Case 2.1. The buffer is full, meaning that there are two filled slices in `storage`:

--- a/src/su/cli.rs
+++ b/src/su/cli.rs
@@ -22,6 +22,7 @@ impl SuAction {
     }
 
     #[cfg(test)]
+    #[allow(clippy::result_large_err)]
     pub fn try_into_run(self) -> Result<SuRunOptions, Self> {
         if let Self::Run(v) = self {
             Ok(v)

--- a/src/sudo/cli/mod.rs
+++ b/src/sudo/cli/mod.rs
@@ -80,6 +80,7 @@ impl SudoAction {
     }
 
     #[cfg(test)]
+    #[allow(clippy::result_large_err)]
     pub fn try_into_run(self) -> Result<SudoRunOptions, Self> {
         if let Self::Run(v) = self {
             Ok(v)

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -672,6 +672,13 @@ pub fn escape_os_str_lossy(s: &std::ffi::OsStr) -> String {
     s.to_string_lossy().escape_default().collect()
 }
 
+pub fn make_zeroed_sigaction() -> libc::sigaction {
+    // SAFETY: since sigaction is a C struct, all-zeroes is a valid representation
+    // We cannot use a "literal struct" initialization method since the exact representation
+    // of libc::sigaction is not fixed, see e.g. https://github.com/memorysafety/sudo-rs/issues/829
+    unsafe { std::mem::zeroed() }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -893,11 +900,4 @@ mod tests {
         let (_, status) = child_pid.wait(WaitOptions::new()).unwrap();
         assert_eq!(status.exit_status(), Some(0));
     }
-}
-
-pub fn make_zeroed_sigaction() -> libc::sigaction {
-    // SAFETY: since sigaction is a C struct, all-zeroes is a valid representation
-    // We cannot use a "literal struct" initialization method since the exact representation
-    // of libc::sigaction is not fixed, see e.g. https://github.com/memorysafety/sudo-rs/issues/829
-    unsafe { std::mem::zeroed() }
 }

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -172,6 +172,7 @@ fn run(file_arg: Option<&str>, perms: bool, owner: bool) -> io::Result<()> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(true)
         .open(&tmp_path)?;
 
     tmp_file.set_permissions(Permissions::from_mode(0o700))?;


### PR DESCRIPTION
This is best reviewed commit by commit: first commit handles `cargo clippy` warnings, the second fixes `cargo clippy --test` warning.

In the first commit, some of the clippy ignores are unavoidable; in the second, it's test code so we don't really care about the "large Error case" warning.

There were also some correct nitpicks by clippy (the ommission of `truncate` and the location of the the `make_zeroed_sigaction` function)