### PR TITLE
Fix visudo bugs; update the CI

### DIFF
--- a/src/defaults/settings_dsl.rs
+++ b/src/defaults/settings_dsl.rs
@@ -1,5 +1,6 @@
 macro_rules! add_from {
     ($ctor:ident, $type:ty) => {
+        #[allow(non_local_definitions)]
         impl From<$type> for $crate::defaults::SudoDefault {
             fn from(value: $type) -> Self {
                 $crate::defaults::SudoDefault::$ctor(value.into())
@@ -8,6 +9,7 @@ macro_rules! add_from {
     };
 
     ($ctor:ident, $type:ty, negatable$(, $vetting_function:expr)?) => {
+        #[allow(non_local_definitions)]
         impl From<$type> for $crate::defaults::SudoDefault {
             fn from(value: $type) -> Self {
                 $crate::defaults::SudoDefault::$ctor(OptTuple {
@@ -17,6 +19,7 @@ macro_rules! add_from {
             }
         }
 
+        #[allow(non_local_definitions)]
         impl From<($type, $type)> for $crate::defaults::SudoDefault {
             fn from((value, neg): ($type, $type)) -> Self {
                 $crate::defaults::SudoDefault::$ctor(OptTuple {

--- a/src/sudo/cli/mod.rs
+++ b/src/sudo/cli/mod.rs
@@ -10,6 +10,8 @@ pub mod help;
 #[cfg(test)]
 mod tests;
 
+// remove dead_code when sudoedit has been implemented
+#[allow(dead_code)]
 pub enum SudoAction {
     Edit(SudoEditOptions),
     Help(SudoHelpOptions),
@@ -205,6 +207,7 @@ impl TryFrom<SudoOptions> for SudoValidateOptions {
 }
 
 // sudo -e [-ABkNnS] [-r role] [-t type] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] [-u user] file ...
+#[allow(dead_code)]
 pub struct SudoEditOptions {
     // -k
     pub reset_timestamp: bool,

--- a/src/sudo/env/environment.rs
+++ b/src/sudo/env/environment.rs
@@ -133,6 +133,9 @@ fn is_safe_tz(value: &[u8]) -> bool {
     };
 
     if check_value.starts_with(&[b'/']) {
+        // clippy 1.79 wants to us to optimise this check away; but we don't know what this will always
+        // be possible; and the compiler is clever enough to do that for us anyway if it can be.
+        #[allow(clippy::const_is_empty)]
         if !PATH_ZONEINFO.is_empty() {
             if !check_value.starts_with(PATH_ZONEINFO.as_bytes())
                 || check_value.get(PATH_ZONEINFO.len()) != Some(&b'/')

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -96,8 +96,6 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
     let current_group = Group {
         gid: 1000,
         name: "test".to_string(),
-        passwd: String::new(),
-        members: Vec::new(),
     };
 
     let root_user = User {
@@ -114,8 +112,6 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
     let root_group = Group {
         gid: 0,
         name: "root".to_string(),
-        passwd: String::new(),
-        members: Vec::new(),
     };
 
     Context {

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -16,7 +16,7 @@ use pipeline::{Pipeline, PolicyPlugin};
 use std::path::Path;
 
 mod cli;
-mod diagnostic;
+pub mod diagnostic;
 mod env;
 mod pam;
 mod pipeline;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -420,8 +420,6 @@ impl User {
 pub struct Group {
     pub gid: GroupId,
     pub name: String,
-    pub passwd: String,
-    pub members: Vec<String>,
 }
 
 impl Group {
@@ -430,24 +428,9 @@ impl Group {
     /// In particular the grp.gr_mem pointer is assumed to be non-null, and pointing to a
     /// null-terminated list; the pointed-to strings are expected to be null-terminated.
     unsafe fn from_libc(grp: &libc::group) -> Group {
-        // find out how many members we have
-        let mut mem_count = 0;
-        while !(*grp.gr_mem.offset(mem_count)).is_null() {
-            mem_count += 1;
-        }
-
-        // convert the members to a slice and then put them into a vec of strings
-        let mut members = Vec::with_capacity(mem_count as usize);
-        let mem_slice = std::slice::from_raw_parts(grp.gr_mem, mem_count as usize);
-        for mem in mem_slice {
-            members.push(string_from_ptr(*mem));
-        }
-
         Group {
             gid: grp.gr_gid,
             name: string_from_ptr(grp.gr_name),
-            passwd: string_from_ptr(grp.gr_passwd),
-            members,
         }
     }
 
@@ -754,9 +737,7 @@ mod tests {
                 },
                 Group {
                     name: name.to_string(),
-                    passwd: passwd.to_string(),
                     gid,
-                    members: mem.iter().map(|s| s.to_string()).collect(),
                 }
             )
         }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -497,9 +497,7 @@ impl WithProcess {
 pub struct Process {
     pub pid: ProcessId,
     pub parent_pid: Option<ProcessId>,
-    pub group_id: ProcessId,
     pub session_id: ProcessId,
-    pub name: PathBuf,
 }
 
 impl Default for Process {
@@ -513,14 +511,8 @@ impl Process {
         Process {
             pid: Self::process_id(),
             parent_pid: Self::parent_id(),
-            group_id: Self::group_id(),
             session_id: Self::session_id(),
-            name: Self::process_name().unwrap_or_else(|| PathBuf::from("sudo")),
         }
-    }
-
-    pub fn process_name() -> Option<PathBuf> {
-        std::env::args().next().map(PathBuf::from)
     }
 
     /// Return the process identifier for the current process
@@ -540,11 +532,6 @@ impl Process {
         } else {
             Some(pid)
         }
-    }
-
-    /// Return the process group id for the current process
-    pub fn group_id() -> ProcessId {
-        unsafe { libc::getpgid(0) }
     }
 
     /// Get the session id for the current process

--- a/src/system/timestamp.rs
+++ b/src/system/timestamp.rs
@@ -315,6 +315,7 @@ pub enum TouchResult {
     NotFound,
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub enum CreateResult {
     /// The record was found and it was refreshed
     Updated {
@@ -736,9 +737,10 @@ mod tests {
 
         std::thread::sleep(std::time::Duration::from_millis(1));
         let res = srf.create(tty_scope, auth_user).unwrap();
-        let CreateResult::Updated { .. } = res else {
+        let CreateResult::Updated { old_time, new_time } = res else {
             panic!("Expected record to be updated");
         };
+        assert_ne!(old_time, new_time);
 
         // reset the file
         assert!(srf.reset().is_ok());

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use crate::{
+    sudo::diagnostic,
     sudoers::Sudoers,
     system::{
         can_execute,
@@ -106,9 +107,14 @@ fn check(file_arg: Option<&str>, perms: bool, owner: bool) -> io::Result<()> {
         return Ok(());
     }
 
-    let mut stderr = io::stderr();
-    for crate::sudoers::Error { message, .. } in errors {
-        writeln!(stderr, "syntax error: {message}")?;
+    for crate::sudoers::Error {
+        message,
+        source,
+        location,
+    } in errors
+    {
+        let path = source.as_deref().unwrap_or(sudoers_path);
+        diagnostic::diagnostic!("syntax error: {message}", path @ location);
     }
 
     Err(io::Error::new(io::ErrorKind::Other, "invalid sudoers file"))

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -283,6 +283,8 @@ fn edit_sudoers_file(
         writeln!(stderr, "visudo: {} unchanged", tmp_path.display())?;
     } else {
         sudoers_file.write_all(&tmp_contents)?;
+        let new_size = sudoers_file.stream_position()?;
+        sudoers_file.set_len(new_size)?;
     }
 
     lock.unlock()?;


### PR DESCRIPTION
CC #833

This also makes some changes which should be fix the CI for at least Rust 1.80 by removing some dead code and other cobwebs. Every change has been put in a seperate commit for easy review.

The penultimate commit ("fix indentation") consists of whitespace-only changes.

In more detail, this PR functionally ensures that:
- Truncates the sudoers file correctly after it has shrunk
- Prints file source and position information of errors instead of just saying "syntax error".

Thereby Closing #833 